### PR TITLE
fix: read session ID from stdin JSON instead of environment variable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -302,10 +302,10 @@ async function setupStatusHooks(worktreePath: string): Promise<void> {
     };
 
     // Define our session ID capture hook
-    // $CLAUDE_SESSION_ID is an environment variable provided by Claude to hooks
+    // Session ID is provided via stdin as JSON: {"session_id": "...", ...}
     const sessionIdCapture = {
         type: 'command',
-        command: "echo '{\"sessionId\":\"'$CLAUDE_SESSION_ID'\",\"timestamp\":\"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'\"}' > .claude-session"
+        command: "jq -r --arg ts \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" '{sessionId: .session_id, timestamp: $ts}' > .claude-session"
     };
 
     // Helper to check if our status hook already exists

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -628,7 +628,7 @@ suite('Claude Lanes Extension Test Suite', () => {
 							hooks: [
 								{
 									type: 'command',
-									command: "echo '{\"sessionId\":\"'$CLAUDE_SESSION_ID'\",\"timestamp\":\"'$(date -u +%Y-%m-%dT%H:%M:%SZ)'\"}' > .claude-session"
+									command: "jq -r --arg ts \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" '{sessionId: .session_id, timestamp: $ts}' > .claude-session"
 								}
 							]
 						}
@@ -652,7 +652,7 @@ suite('Claude Lanes Extension Test Suite', () => {
 			assert.ok(sessionStartHook.hooks, 'SessionStart entry should have hooks array');
 			const hookCommand = sessionStartHook.hooks[0].command;
 			assert.ok(hookCommand.includes('.claude-session'), 'Hook command should write to .claude-session');
-			assert.ok(hookCommand.includes('CLAUDE_SESSION_ID'), 'Hook command should use CLAUDE_SESSION_ID env var');
+			assert.ok(hookCommand.includes('.session_id'), 'Hook command should extract session_id from stdin JSON');
 		});
 
 		test('should read session ID correctly from .claude-session file', () => {
@@ -796,7 +796,7 @@ suite('Claude Lanes Extension Test Suite', () => {
 				hooks: [
 					{
 						type: 'command',
-						command: "echo '{\"sessionId\":\"'$CLAUDE_SESSION_ID'\"}' > .claude-session"
+						command: "jq -r '{sessionId: .session_id}' > .claude-session"
 					}
 				]
 			});


### PR DESCRIPTION
The SessionStart hook receives session_id via stdin as JSON, not as an environment variable. Updated the hook command to use jq to parse the input and extract the session_id field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)