### PR TITLE
feat: use VS Code Git extension for git executable path

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "Other",
     "Machine Learning"
   ],
+  "extensionDependencies": [
+    "vscode.git"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "viewsContainers": {

--- a/src/gitService.ts
+++ b/src/gitService.ts
@@ -1,0 +1,86 @@
+/**
+ * Git Service for Claude Lanes
+ *
+ * Provides the git executable path from VS Code's Git Extension when available,
+ * with fallback to using 'git' directly from PATH.
+ */
+
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { GitExtension } from './types/git';
+
+// The git executable path - either from VS Code or 'git' as fallback
+let gitPath: string = 'git';
+
+/**
+ * Initialize the git service by attempting to get the git path from VS Code's Git Extension.
+ * Falls back to 'git' if the extension is not available.
+ * Should be called during extension activation.
+ */
+export async function initializeGitPath(): Promise<void> {
+    try {
+        const gitExtension = vscode.extensions.getExtension<GitExtension>('vscode.git');
+
+        if (!gitExtension) {
+            console.log('Claude Lanes: VS Code Git extension not found, using default git path');
+            return;
+        }
+
+        // Activate the extension if not already active
+        if (!gitExtension.isActive) {
+            await gitExtension.activate();
+        }
+
+        const api = gitExtension.exports.getAPI(1);
+        if (api?.git?.path) {
+            gitPath = api.git.path;
+            console.log(`Claude Lanes: Using git from VS Code: ${gitPath}`);
+        } else {
+            console.log('Claude Lanes: Could not get git path from VS Code, using default');
+        }
+    } catch (err) {
+        console.warn('Claude Lanes: Failed to get git path from VS Code, using default:', err);
+    }
+}
+
+/**
+ * Get the current git executable path.
+ */
+export function getGitPath(): string {
+    return gitPath;
+}
+
+/**
+ * Execute a git command using spawn (no shell).
+ * @param args The git command arguments
+ * @param cwd The working directory
+ * @returns The stdout output
+ * @throws Error if the command fails
+ */
+export function execGit(args: string[], cwd: string): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const process = spawn(gitPath, args, { cwd });
+        let stdout = '';
+        let stderr = '';
+
+        process.stdout.on('data', (data: Buffer) => {
+            stdout += data.toString();
+        });
+
+        process.stderr.on('data', (data: Buffer) => {
+            stderr += data.toString();
+        });
+
+        process.on('error', (err: Error) => {
+            reject(new Error(`Failed to spawn git process: ${err.message}`));
+        });
+
+        process.on('close', (code: number | null) => {
+            if (code === 0) {
+                resolve(stdout);
+            } else {
+                reject(new Error(stderr || `Git command failed with code ${code}`));
+            }
+        });
+    });
+}

--- a/src/types/git.d.ts
+++ b/src/types/git.d.ts
@@ -1,0 +1,31 @@
+/**
+ * Minimal type definitions for the VS Code Git Extension API.
+ * Only includes what Claude Lanes needs to get the git executable path.
+ */
+
+import { Event } from 'vscode';
+
+/**
+ * The main Git extension export.
+ * Use vscode.extensions.getExtension<GitExtension>('vscode.git') to get this.
+ */
+export interface GitExtension {
+    readonly enabled: boolean;
+    readonly onDidChangeEnablement: Event<boolean>;
+    getAPI(version: 1): API;
+}
+
+/**
+ * The Git API interface (version 1).
+ */
+export interface API {
+    readonly git: Git;
+}
+
+/**
+ * Git executable information.
+ */
+export interface Git {
+    readonly path: string;
+    readonly version: string;
+}


### PR DESCRIPTION
Get git executable path from VS Code's Git Extension when available, with fallback to using 'git' directly from PATH. This improves cross-platform compatibility by using the same git instance as VS Code.

- Add minimal git.d.ts type definitions for Git Extension API
- Add gitService.ts with initializeGitPath() and execGit() helpers
- Replace shell-based git commands with spawn-based execution
- Add extensionDependencies for vscode.git in package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)