### PR TITLE
feat: add configurable base branch for Git diff comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,11 @@
           "type": "string",
           "default": "",
           "description": "Relative path within each worktree where .claude-status file should be stored. Leave empty to use the worktree root."
+        },
+        "claudeLanes.baseBranch": {
+          "type": "string",
+          "default": "",
+          "description": "The branch to compare against when viewing Git changes. Leave empty for auto-detection (checks origin/main, origin/master, main, master in order)."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -755,11 +755,21 @@ async function setupStatusHooks(worktreePath: string): Promise<void> {
 
 /**
  * Determines the base branch for comparing changes.
- * Checks in order: origin/main, origin/master, main, master.
+ * First checks the claudeLanes.baseBranch setting.
+ * If not set, checks in order: origin/main, origin/master, main, master.
  * @param cwd The working directory (git repo or worktree)
  * @returns The name of the base branch to use for comparisons
  */
 export async function getBaseBranch(cwd: string): Promise<string> {
+    // First check if user has configured a base branch
+    const config = vscode.workspace.getConfiguration('claudeLanes');
+    const configuredBranch = config.get<string>('baseBranch', '');
+
+    if (configuredBranch && configuredBranch.trim()) {
+        return configuredBranch.trim();
+    }
+
+    // Fallback to auto-detection
     // Check for origin/main
     try {
         await execGit(['show-ref', '--verify', '--quiet', 'refs/remotes/origin/main'], cwd);


### PR DESCRIPTION
 Body:
  ## Summary
  - Add `claudeLanes.baseBranch` setting to allow users to configure which branch to compare against when viewing Git changes
  - When the setting is empty (default), the extension continues using auto-detection (origin/main → origin/master → main → master)
  - Added 3 tests for the new configuration feature

  ## Test plan
  - [ ] Verify setting appears in VS Code settings under "Claude Lanes"
  - [ ] Set `claudeLanes.baseBranch` to a custom branch (e.g., `develop`) and verify Git Changes uses it
  - [ ] Clear the setting and verify auto-detection still works
  - [ ] Run `npm test` to confirm all 171 tests pass