### PR TITLE
feat: add configurable option to include uncommitted changes in Git diff

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,56 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r --arg ts \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\" '{sessionId: .session_id, timestamp: $ts}' > .claude-session"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"status\":\"waiting_for_user\"}' > .claude-status"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"status\":\"working\"}' > .claude-status"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"status\":\"waiting_for_user\"}' > .claude-status"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo '{\"status\":\"working\"}' > .claude-status"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,8 @@ node_modules
 # Ephemeral task tracking files (created per Claude session, deleted when done)
 features.json
 tests.json
+
+# Claude Code session files
 .claude/lanes
+.claude-session
+.claude-status

--- a/package.json
+++ b/package.json
@@ -139,6 +139,11 @@
           "type": "string",
           "default": "",
           "description": "The branch to compare against when viewing Git changes. Leave empty for auto-detection (checks origin/main, origin/master, main, master in order)."
+        },
+        "claudeLanes.includeUncommittedChanges": {
+          "type": "boolean",
+          "default": true,
+          "description": "When viewing Git changes, include uncommitted local changes (staged and unstaged). If false, only shows committed changes."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -240,8 +240,15 @@ export async function activate(context: vscode.ExtensionContext) {
             // Determine the base branch (main or master)
             const baseBranch = await getBaseBranch(item.worktreePath);
 
-            // Get the diff from the base branch to HEAD
-            const diffContent = await execGit(['diff', `${baseBranch}...HEAD`], item.worktreePath);
+            // Check if we should include uncommitted changes
+            const config = vscode.workspace.getConfiguration('claudeLanes');
+            const includeUncommitted = config.get<boolean>('includeUncommittedChanges', true);
+
+            // Get the diff - either including working directory changes or only committed changes
+            const diffArgs = includeUncommitted
+                ? ['diff', baseBranch]  // Compare base branch to working directory
+                : ['diff', `${baseBranch}...HEAD`];  // Compare base branch to HEAD (committed only)
+            const diffContent = await execGit(diffArgs, item.worktreePath);
 
             // Check if there are any changes
             if (!diffContent || diffContent.trim() === '') {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -3674,6 +3674,9 @@ index 7654321..gfedcba 100644
 				assert.ok(codeBlockMatches, 'Should have code block markers');
 				assert.strictEqual(codeBlockMatches.length, 2, 'Should have opening and closing code block markers');
 			});
+		});
+	});
+
 	suite('Base Branch Configuration', () => {
 		// These tests verify that getBaseBranch correctly uses the claudeLanes.baseBranch
 		// configuration setting, and falls back to auto-detection when not set.


### PR DESCRIPTION
Add claudeLanes.includeUncommittedChanges setting (default: true) that controls whether the Git Changes viewer shows uncommitted local changes or only committed changes. Also fix missing closing braces in test file and update gitignore for Claude session files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)