### PR TITLE
feat: store prompts in VS Code global storage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,8 +137,8 @@
           },
           "claudeLanes.promptsFolder": {
             "type": "string",
-            "default": ".claude/lanes",
-            "description": "Folder where session starting prompts are stored (relative to repository root). Default: .claude/lanes",
+            "default": "",
+            "description": "Folder where session starting prompts are stored. Leave empty (default) to use VS Code's global storage (keeps repo clean). Set a path like '.claude/lanes' for repo-relative storage.",
             "order": 2
           }
         }


### PR DESCRIPTION
Changes the default storage location for session prompts from repo-relative `.claude/lanes` to VS Code's global storage directory. This keeps the user's repository clean by default.

Key changes:
- Prompts now stored at: globalStorageUri/<repoIdentifier>/prompts/<session>.txt
- Uses same repo identifier pattern as sessions to prevent project clobbering
- User can override via claudeLanes.promptsFolder setting for repo-relative storage
- Added sessionName validation to prevent path traversal attacks
- Added fallback to legacy .claude/lanes when global storage not initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)