### PR TITLE
feat: add custom workflow template creation and validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,11 @@
           "id": "previousSessionsView",
           "name": "Previous Sessions",
           "icon": "$(history)"
+        },
+        {
+          "id": "workflowsView",
+          "name": "Workflows",
+          "icon": "$(symbol-event)"
         }
       ]
     },
@@ -101,9 +106,26 @@
         "command": "claudeWorktrees.openPreviousSessionPrompt",
         "title": "Open Session Prompt",
         "icon": "$(file)"
+      },
+      {
+        "command": "lanes.createWorkflow",
+        "title": "Lanes: Create Workflow Template",
+        "icon": "$(add)"
+      },
+      {
+        "command": "lanes.validateWorkflow",
+        "title": "Lanes: Validate Workflow Template",
+        "icon": "$(check)"
       }
     ],
     "menus": {
+      "view/title": [
+        {
+          "command": "lanes.createWorkflow",
+          "when": "view == workflowsView",
+          "group": "navigation"
+        }
+      ],
       "view/item/context": [
         {
           "command": "claudeWorktrees.openInNewWindow",
@@ -217,8 +239,14 @@
           "lanes.workflowsFolder": {
             "type": "string",
             "default": ".claude/workflows",
-            "description": "Workspace folder for custom workflow templates",
+            "description": "Workspace folder for built-in workflow templates",
             "order": 2
+          },
+          "lanes.customWorkflowsFolder": {
+            "type": "string",
+            "default": ".claude/lanes/workflows",
+            "description": "Workspace folder for custom workflow templates (relative to workspace root)",
+            "order": 3
           }
         }
       }

--- a/src/WorkflowsProvider.ts
+++ b/src/WorkflowsProvider.ts
@@ -1,0 +1,117 @@
+/**
+ * Tree data provider for the Workflows view in the sidebar.
+ * Displays discovered workflow templates from built-in and custom locations.
+ */
+
+import * as vscode from 'vscode';
+import { discoverWorkflows, WorkflowMetadata } from './workflow/discovery';
+
+/**
+ * Tree item representing a workflow template.
+ */
+export class WorkflowItem extends vscode.TreeItem {
+    constructor(
+        public readonly workflowMetadata: WorkflowMetadata
+    ) {
+        super(workflowMetadata.name, vscode.TreeItemCollapsibleState.None);
+
+        // Show description from YAML
+        this.description = workflowMetadata.isBuiltIn ? 'Built-in' : 'Custom';
+
+        // Tooltip with full description
+        this.tooltip = new vscode.MarkdownString();
+        this.tooltip.appendMarkdown(`**${workflowMetadata.name}**\n\n`);
+        this.tooltip.appendMarkdown(`${workflowMetadata.description}\n\n`);
+        this.tooltip.appendMarkdown(`*${workflowMetadata.isBuiltIn ? 'Built-in template' : 'Custom template'}*`);
+
+        // Icon based on type
+        this.iconPath = workflowMetadata.isBuiltIn
+            ? new vscode.ThemeIcon('symbol-event')
+            : new vscode.ThemeIcon('file-code');
+
+        // Open the file when clicked
+        this.command = {
+            command: 'vscode.open',
+            title: 'Open Workflow',
+            arguments: [vscode.Uri.file(workflowMetadata.path)]
+        };
+
+        this.contextValue = workflowMetadata.isBuiltIn ? 'builtInWorkflow' : 'customWorkflow';
+    }
+}
+
+/**
+ * Tree data provider for workflows.
+ */
+export class WorkflowsProvider implements vscode.TreeDataProvider<WorkflowItem>, vscode.Disposable {
+    private _onDidChangeTreeData: vscode.EventEmitter<WorkflowItem | undefined | null | void> =
+        new vscode.EventEmitter<WorkflowItem | undefined | null | void>();
+    readonly onDidChangeTreeData: vscode.Event<WorkflowItem | undefined | null | void> =
+        this._onDidChangeTreeData.event;
+
+    private workflows: WorkflowMetadata[] = [];
+
+    constructor(
+        private readonly extensionPath: string,
+        private readonly workspaceRoot: string | undefined
+    ) {}
+
+    /**
+     * Dispose of resources.
+     */
+    dispose(): void {
+        this._onDidChangeTreeData.dispose();
+    }
+
+    /**
+     * Refresh the workflows list.
+     */
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    /**
+     * Get a tree item for display.
+     */
+    getTreeItem(element: WorkflowItem): vscode.TreeItem {
+        return element;
+    }
+
+    /**
+     * Get children (workflow items).
+     */
+    async getChildren(element?: WorkflowItem): Promise<WorkflowItem[]> {
+        // We have a flat list - no children for items
+        if (element) {
+            return [];
+        }
+
+        if (!this.workspaceRoot) {
+            return [];
+        }
+
+        // Get custom workflows folder from config
+        const config = vscode.workspace.getConfiguration('lanes');
+        const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+
+        try {
+            this.workflows = await discoverWorkflows({
+                extensionPath: this.extensionPath,
+                workspaceRoot: this.workspaceRoot,
+                customWorkflowsFolder
+            });
+
+            return this.workflows.map(wf => new WorkflowItem(wf));
+        } catch (err) {
+            console.error('Lanes: Failed to discover workflows:', err);
+            return [];
+        }
+    }
+
+    /**
+     * Get the list of discovered workflows.
+     */
+    getWorkflows(): WorkflowMetadata[] {
+        return this.workflows;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,8 @@ import { SessionFormProvider, PermissionMode, isValidPermissionMode } from './Se
 import { initializeGitPath, execGit } from './gitService';
 import { GitChangesPanel, OnBranchChangeCallback } from './GitChangesPanel';
 import { PreviousSessionProvider, PreviousSessionItem, getPromptsDir } from './PreviousSessionProvider';
+import { WorkflowsProvider } from './WorkflowsProvider';
+import { discoverWorkflows, WorkflowMetadata, loadWorkflowTemplateFromString, WorkflowValidationError } from './workflow';
 import { addProject, removeProject, clearCache as clearProjectManagerCache, initialize as initializeProjectManagerService } from './ProjectManagerService';
 import { sanitizeSessionName as _sanitizeSessionName, getErrorMessage } from './utils';
 // Use local reference for internal use
@@ -625,6 +627,11 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.window.registerTreeDataProvider('previousSessionsView', previousSessionProvider);
     context.subscriptions.push(previousSessionProvider);
 
+    // Initialize Workflows Provider
+    const workflowsProvider = new WorkflowsProvider(context.extensionPath, workspaceRoot);
+    vscode.window.registerTreeDataProvider('workflowsView', workflowsProvider);
+    context.subscriptions.push(workflowsProvider);
+
     // Initialize Session Form Provider (webview in sidebar)
     const sessionFormProvider = new SessionFormProvider(context.extensionUri);
     context.subscriptions.push(
@@ -747,6 +754,20 @@ export async function activate(context: vscode.ExtensionContext) {
         });
 
         context.subscriptions.push(worktreeFolderWatcher);
+    }
+
+    // Watch for custom workflows folder changes
+    if (watchPath) {
+        const customWorkflowsFolder = vscode.workspace.getConfiguration('lanes').get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+        const customWorkflowsWatcher = vscode.workspace.createFileSystemWatcher(
+            new vscode.RelativePattern(watchPath, `${customWorkflowsFolder}/*.yaml`)
+        );
+
+        customWorkflowsWatcher.onDidChange(() => workflowsProvider.refresh());
+        customWorkflowsWatcher.onDidCreate(() => workflowsProvider.refresh());
+        customWorkflowsWatcher.onDidDelete(() => workflowsProvider.refresh());
+
+        context.subscriptions.push(customWorkflowsWatcher);
     }
 
     // Watch for pending session requests from MCP
@@ -1196,6 +1217,45 @@ export async function activate(context: vscode.ExtensionContext) {
         }
     });
 
+    // 9. Register CREATE WORKFLOW Command
+    let createWorkflowDisposable = vscode.commands.registerCommand('lanes.createWorkflow', async () => {
+        await createWorkflow(context.extensionPath, workspaceRoot, workflowsProvider);
+    });
+
+    // 10. Register VALIDATE WORKFLOW Command
+    let validateWorkflowDisposable = vscode.commands.registerCommand('lanes.validateWorkflow', async () => {
+        // 1. Get the active editor
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            vscode.window.showWarningMessage('No file is open');
+            return;
+        }
+
+        // 2. Check if it's a YAML file
+        const document = editor.document;
+        const fileName = document.fileName;
+        if (!fileName.endsWith('.yaml') && !fileName.endsWith('.yml')) {
+            vscode.window.showWarningMessage('Current file is not a YAML file');
+            return;
+        }
+
+        // 3. Get the file content
+        const content = document.getText();
+
+        // 4. Try to validate using loadWorkflowTemplateFromString
+        try {
+            const template = loadWorkflowTemplateFromString(content);
+            vscode.window.showInformationMessage(`Workflow "${template.name}" is valid!`);
+        } catch (error) {
+            if (error instanceof WorkflowValidationError) {
+                vscode.window.showErrorMessage(`Workflow validation failed: ${error.message}`);
+            } else {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                vscode.window.showErrorMessage(`Invalid YAML: ${errorMessage}`);
+            }
+        }
+    });
+
     context.subscriptions.push(createDisposable);
     context.subscriptions.push(openDisposable);
     context.subscriptions.push(deleteDisposable);
@@ -1203,6 +1263,8 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(showGitChangesDisposable);
     context.subscriptions.push(openWindowDisposable);
     context.subscriptions.push(openPreviousPromptDisposable);
+    context.subscriptions.push(createWorkflowDisposable);
+    context.subscriptions.push(validateWorkflowDisposable);
 
     // Auto-resume Claude session when opened in a worktree with an existing session
     if (isInWorktree && workspaceRoot) {
@@ -2018,6 +2080,241 @@ export async function getBaseBranch(cwd: string): Promise<string> {
 
     // Default fallback - this will likely fail but gives a sensible error
     return 'main';
+}
+
+/**
+ * Blank workflow template for "Start from scratch" option.
+ */
+const BLANK_WORKFLOW_TEMPLATE = `name: my-workflow
+description: Custom workflow description
+
+agents:
+  orchestrator:
+    description: Plans work and coordinates
+    tools:
+      - Read
+      - Glob
+      - Grep
+      - Task
+    cannot:
+      - Write
+      - Edit
+      - Bash
+      - commit
+
+loops: {}
+
+steps:
+  - id: plan
+    type: action
+    agent: orchestrator
+    instructions: |
+      Analyze the goal and create a plan.
+`;
+
+/**
+ * Creates a new workflow template by copying from an existing template or creating from scratch.
+ *
+ * Flow:
+ * 1. Show quick pick to select base template (built-in templates or start from scratch)
+ * 2. Prompt for new workflow name
+ * 3. Copy selected template to custom workflows folder
+ * 4. Open the new file for editing
+ *
+ * @param extensionPath Path to the extension directory (for built-in templates)
+ * @param workspaceRoot Path to the workspace root
+ * @param workflowsProvider The workflows provider to refresh after creation
+ */
+async function createWorkflow(
+    extensionPath: string,
+    workspaceRoot: string | undefined,
+    workflowsProvider: WorkflowsProvider
+): Promise<void> {
+    // 1. Check workspace root
+    if (!workspaceRoot) {
+        vscode.window.showErrorMessage('Please open a workspace folder first.');
+        return;
+    }
+
+    // 2. Discover available templates for selection
+    const config = vscode.workspace.getConfiguration('lanes');
+    const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+
+    let templates: WorkflowMetadata[] = [];
+    try {
+        templates = await discoverWorkflows({
+            extensionPath,
+            workspaceRoot,
+            customWorkflowsFolder
+        });
+    } catch (err) {
+        console.warn('Lanes: Failed to discover workflows:', err);
+        // Continue with empty list - user can still create from scratch
+    }
+
+    // 3. Build quick pick items
+    interface WorkflowQuickPickItem extends vscode.QuickPickItem {
+        action: 'scratch' | 'template';
+        template?: WorkflowMetadata;
+    }
+
+    const quickPickItems: WorkflowQuickPickItem[] = [
+        {
+            label: '$(file-add) Start from scratch',
+            description: 'Create a blank workflow template',
+            action: 'scratch'
+        }
+    ];
+
+    // Add built-in templates first
+    const builtInTemplates = templates.filter(t => t.isBuiltIn);
+    if (builtInTemplates.length > 0) {
+        quickPickItems.push({
+            label: 'Built-in Templates',
+            kind: vscode.QuickPickItemKind.Separator,
+            action: 'scratch' // Won't be selected
+        });
+        for (const template of builtInTemplates) {
+            quickPickItems.push({
+                label: `$(symbol-event) ${template.name}`,
+                description: template.description,
+                action: 'template',
+                template
+            });
+        }
+    }
+
+    // Add custom templates if any
+    const customTemplates = templates.filter(t => !t.isBuiltIn);
+    if (customTemplates.length > 0) {
+        quickPickItems.push({
+            label: 'Custom Templates',
+            kind: vscode.QuickPickItemKind.Separator,
+            action: 'scratch' // Won't be selected
+        });
+        for (const template of customTemplates) {
+            quickPickItems.push({
+                label: `$(file-code) ${template.name}`,
+                description: template.description,
+                action: 'template',
+                template
+            });
+        }
+    }
+
+    // 4. Show quick pick
+    const selected = await vscode.window.showQuickPick(quickPickItems, {
+        placeHolder: 'Select a base template or start from scratch',
+        title: 'Create Workflow Template'
+    });
+
+    if (!selected || selected.kind === vscode.QuickPickItemKind.Separator) {
+        return;
+    }
+
+    // 5. Prompt for new workflow name
+    const workflowName = await vscode.window.showInputBox({
+        prompt: 'Enter a name for your workflow',
+        placeHolder: 'my-custom-workflow',
+        validateInput: (value) => {
+            if (!value || !value.trim()) {
+                return 'Workflow name is required';
+            }
+            const trimmed = value.trim();
+            // Only allow alphanumeric, hyphens, and underscores
+            if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+                return 'Use only letters, numbers, hyphens, and underscores';
+            }
+            // Check for reserved names
+            if (trimmed === 'default' || trimmed === 'feature' || trimmed === 'bugfix' || trimmed === 'refactor') {
+                return `'${trimmed}' is a built-in workflow name. Please choose a different name.`;
+            }
+            return null;
+        }
+    });
+
+    if (!workflowName) {
+        return;
+    }
+
+    const trimmedName = workflowName.trim();
+
+    // 6. Validate custom workflows folder and create if needed
+    // Security: Reject path traversal
+    if (customWorkflowsFolder.includes('..')) {
+        vscode.window.showErrorMessage('Invalid custom workflows folder path (contains parent directory traversal).');
+        return;
+    }
+
+    const customPath = path.join(workspaceRoot, customWorkflowsFolder);
+
+    // Verify resolved path is within workspace
+    const normalizedWorkspace = path.normalize(workspaceRoot + path.sep);
+    const normalizedCustomPath = path.normalize(customPath + path.sep);
+    if (!normalizedCustomPath.startsWith(normalizedWorkspace)) {
+        vscode.window.showErrorMessage('Custom workflows folder resolves outside the workspace.');
+        return;
+    }
+
+    try {
+        await fsPromises.mkdir(customPath, { recursive: true });
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to create custom workflows folder: ${getErrorMessage(err)}`);
+        return;
+    }
+
+    // 7. Create the target file path
+    const targetPath = path.join(customPath, `${trimmedName}.yaml`);
+
+    // Check if file already exists
+    try {
+        await fsPromises.access(targetPath);
+        // File exists
+        const overwrite = await vscode.window.showWarningMessage(
+            `A workflow named '${trimmedName}' already exists. Overwrite?`,
+            { modal: true },
+            'Overwrite'
+        );
+        if (overwrite !== 'Overwrite') {
+            return;
+        }
+    } catch {
+        // File doesn't exist - good
+    }
+
+    // 8. Create the workflow file
+    try {
+        let content: string;
+        if (selected.action === 'scratch') {
+            // Create blank template with the user's name
+            content = BLANK_WORKFLOW_TEMPLATE.replace('name: my-workflow', `name: ${trimmedName}`);
+        } else if (selected.template) {
+            // Copy from existing template
+            const sourceContent = await fsPromises.readFile(selected.template.path, 'utf-8');
+            // Replace the name in the content
+            content = sourceContent.replace(/^name:\s*.+$/m, `name: ${trimmedName}`);
+        } else {
+            vscode.window.showErrorMessage('Invalid template selection.');
+            return;
+        }
+
+        await fsPromises.writeFile(targetPath, content, 'utf-8');
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to create workflow file: ${getErrorMessage(err)}`);
+        return;
+    }
+
+    // 9. Refresh the workflows view
+    workflowsProvider.refresh();
+
+    // 10. Open the file for editing
+    try {
+        const doc = await vscode.workspace.openTextDocument(targetPath);
+        await vscode.window.showTextDocument(doc, { preview: false });
+        vscode.window.showInformationMessage(`Created workflow template: ${trimmedName}`);
+    } catch (err) {
+        vscode.window.showErrorMessage(`Failed to open workflow file: ${getErrorMessage(err)}`);
+    }
 }
 
 /**

--- a/src/workflow/discovery.ts
+++ b/src/workflow/discovery.ts
@@ -1,0 +1,182 @@
+/**
+ * Workflow template discovery.
+ * Discovers workflow templates from both built-in and custom locations.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'yaml';
+
+/**
+ * Metadata for a discovered workflow template.
+ */
+export interface WorkflowMetadata {
+  /** Name of the workflow (from YAML) */
+  name: string;
+  /** Description of the workflow (from YAML) */
+  description: string;
+  /** Absolute path to the workflow file */
+  path: string;
+  /** Whether this is a built-in workflow (vs custom) */
+  isBuiltIn: boolean;
+}
+
+/**
+ * Extracts name and description from a YAML workflow file.
+ * Returns null if the file cannot be parsed or lacks required fields.
+ *
+ * @param filePath - Absolute path to the YAML file
+ * @returns Object with name and description, or null if invalid
+ */
+async function extractWorkflowMetadata(filePath: string): Promise<{ name: string; description: string } | null> {
+  try {
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+    const parsed = yaml.parse(content);
+
+    // Validate that we have the required fields
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof parsed.name === 'string' &&
+      typeof parsed.description === 'string'
+    ) {
+      return {
+        name: parsed.name,
+        description: parsed.description,
+      };
+    }
+
+    return null;
+  } catch {
+    // File read error, YAML parse error, etc. - skip this file
+    return null;
+  }
+}
+
+/**
+ * Lists YAML files in a directory.
+ * Returns an empty array if the directory doesn't exist or can't be read.
+ *
+ * @param dirPath - Absolute path to the directory
+ * @returns Array of absolute paths to .yaml files
+ */
+async function listYamlFiles(dirPath: string): Promise<string[]> {
+  try {
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+    return entries
+      .filter(entry => entry.isFile() && entry.name.endsWith('.yaml'))
+      .map(entry => path.join(dirPath, entry.name));
+  } catch {
+    // Directory doesn't exist or can't be read - return empty array
+    return [];
+  }
+}
+
+/**
+ * Discovers workflow templates from a directory.
+ *
+ * @param dirPath - Absolute path to the directory to scan
+ * @param isBuiltIn - Whether these are built-in workflows
+ * @returns Array of workflow metadata
+ */
+async function discoverFromDirectory(
+  dirPath: string,
+  isBuiltIn: boolean
+): Promise<WorkflowMetadata[]> {
+  const yamlFiles = await listYamlFiles(dirPath);
+  const results: WorkflowMetadata[] = [];
+
+  for (const filePath of yamlFiles) {
+    const metadata = await extractWorkflowMetadata(filePath);
+    if (metadata) {
+      results.push({
+        ...metadata,
+        path: filePath,
+        isBuiltIn,
+      });
+    } else {
+      // Log skipped files to help with debugging invalid workflow definitions
+      console.warn(`Lanes: Skipping invalid workflow file: ${filePath}`);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Options for workflow discovery.
+ */
+export interface DiscoverWorkflowsOptions {
+  /** Absolute path to the extension root (for built-in workflows) */
+  extensionPath: string;
+  /** Absolute path to the workspace root (for custom workflows) */
+  workspaceRoot: string;
+  /** Custom workflows folder relative to workspace root (default: '.claude/lanes/workflows') */
+  customWorkflowsFolder?: string;
+}
+
+/**
+ * Discovers all available workflow templates from built-in and custom locations.
+ *
+ * Built-in workflows are loaded from the extension's `workflows/` directory.
+ * Custom workflows are loaded from the workspace's configured folder.
+ *
+ * Invalid or malformed workflow files are silently skipped.
+ * If the custom workflows folder doesn't exist, no error is raised.
+ *
+ * @param options - Discovery options
+ * @returns Array of workflow metadata, with built-in workflows first
+ */
+export async function discoverWorkflows(options: DiscoverWorkflowsOptions): Promise<WorkflowMetadata[]> {
+  const { extensionPath, workspaceRoot, customWorkflowsFolder = '.claude/lanes/workflows' } = options;
+
+  // Discover built-in workflows
+  const builtIn = await discoverFromDirectory(path.join(extensionPath, 'workflows'), true);
+
+  // Validate customWorkflowsFolder against path traversal attacks
+  // Reject explicit parent directory traversal patterns
+  if (customWorkflowsFolder.includes('..')) {
+    console.warn('Lanes: Parent directory traversal (..) not allowed in customWorkflowsFolder');
+    return [...builtIn];
+  }
+
+  // Verify resolved path stays within workspace root
+  const normalizedWorkspace = path.normalize(workspaceRoot + path.sep);
+  const resolvedCustomPath = path.normalize(path.join(workspaceRoot, customWorkflowsFolder));
+  if (!resolvedCustomPath.startsWith(normalizedWorkspace)) {
+    console.warn('Lanes: Path traversal detected - customWorkflowsFolder resolves outside workspace');
+    return [...builtIn];
+  }
+
+  // Discover custom workflows from validated path
+  const custom = await discoverFromDirectory(resolvedCustomPath, false);
+
+  // Return built-in workflows first, then custom
+  return [...builtIn, ...custom];
+}
+
+/**
+ * Discovers workflows using VS Code configuration for the custom folder path.
+ * This is a convenience function for use within VS Code context.
+ *
+ * @param extensionPath - Absolute path to the extension root
+ * @param workspaceRoot - Absolute path to the workspace root
+ * @param getConfigValue - Function to get configuration value (for testing/DI)
+ * @returns Array of workflow metadata
+ */
+export async function discoverWorkflowsWithConfig(
+  extensionPath: string,
+  workspaceRoot: string,
+  getConfigValue?: <T>(section: string, key: string, defaultValue: T) => T
+): Promise<WorkflowMetadata[]> {
+  // Use default value if no config function provided
+  const customWorkflowsFolder = getConfigValue
+    ? getConfigValue<string>('lanes', 'customWorkflowsFolder', '.claude/lanes/workflows')
+    : '.claude/lanes/workflows';
+
+  return discoverWorkflows({
+    extensionPath,
+    workspaceRoot,
+    customWorkflowsFolder,
+  });
+}

--- a/src/workflow/index.ts
+++ b/src/workflow/index.ts
@@ -27,3 +27,11 @@ export {
 
 // Export state machine
 export { WorkflowStateMachine } from './state';
+
+// Export discovery functions
+export {
+  discoverWorkflows,
+  discoverWorkflowsWithConfig,
+  type WorkflowMetadata,
+  type DiscoverWorkflowsOptions,
+} from './discovery';


### PR DESCRIPTION
Add ability for users to create their own workflow templates:

- Add `lanes.customWorkflowsFolder` setting (default: .claude/lanes/workflows)
- Add Workflows sidebar view showing built-in and custom templates
- Add "Create Workflow" button with template selection UI
- Add `lanes.validateWorkflow` command to validate YAML templates
- Add workflow discovery module to find templates from multiple sources
- Include path traversal protection and input validation