### PR TITLE
feat: add workflow parameter to MCP session_create endpoint

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,7 @@ export interface PendingSessionConfig {
     name: string;
     sourceBranch: string;
     prompt?: string;
+    workflow?: string;
     requestedAt: string;
 }
 
@@ -42,6 +43,39 @@ export interface PendingSessionConfig {
  * Directory where MCP server writes pending session requests.
  */
 const PENDING_SESSIONS_DIR = path.join(os.homedir(), '.claude', 'lanes', 'pending-sessions');
+
+/**
+ * Directory containing bundled workflow templates.
+ * Located at extension root/workflows/ (from compiled code in out/, go up one level)
+ */
+const WORKFLOWS_DIR = path.join(__dirname, '..', 'workflows');
+
+/**
+ * Get available workflow template names from the workflows directory.
+ * @returns Array of workflow names (without .yaml extension)
+ */
+async function getAvailableWorkflows(): Promise<string[]> {
+    try {
+        const files = await fsPromises.readdir(WORKFLOWS_DIR);
+        return files
+            .filter(f => f.endsWith('.yaml'))
+            .map(f => f.replace('.yaml', ''));
+    } catch {
+        // If workflows directory doesn't exist, return empty array
+        return [];
+    }
+}
+
+/**
+ * Validate that a workflow template exists.
+ * @param workflow The workflow name to validate
+ * @returns Object with isValid flag and available workflows if invalid
+ */
+async function validateWorkflow(workflow: string): Promise<{ isValid: boolean; availableWorkflows: string[] }> {
+    const availableWorkflows = await getAvailableWorkflows();
+    const isValid = availableWorkflows.includes(workflow);
+    return { isValid, availableWorkflows };
+}
 
 /**
  * Represents a broken worktree that needs repair.
@@ -517,6 +551,23 @@ async function processPendingSession(
 
         console.log(`Processing pending session request: ${config.name}`);
 
+        // Validate workflow if provided
+        if (config.workflow) {
+            const { isValid, availableWorkflows } = await validateWorkflow(config.workflow);
+            if (!isValid) {
+                // Delete config file to prevent re-processing
+                await fsPromises.unlink(configPath);
+                const availableList = availableWorkflows.length > 0
+                    ? availableWorkflows.join(', ')
+                    : 'none found';
+                vscode.window.showErrorMessage(
+                    `Invalid workflow '${config.workflow}'. Available workflows: ${availableList}. ` +
+                    `Session '${config.name}' was not created.`
+                );
+                return;
+            }
+        }
+
         // Delete the config file first to prevent re-processing
         await fsPromises.unlink(configPath);
 
@@ -529,7 +580,7 @@ async function processPendingSession(
             '', // acceptanceCriteria
             'default' as PermissionMode, // permissionMode
             config.sourceBranch,
-            null, // workflow - not specified in pending session config
+            config.workflow || null, // workflow - optional workflow template from MCP request
             workspaceRoot,
             sessionProvider
         );

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -197,6 +197,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
             type: 'string',
             description: 'Optional starting prompt for Claude',
           },
+          workflow: {
+            type: 'string',
+            description:
+              'Workflow template to use for this session. Ask the user which workflow they want. ' +
+              'IMPORTANT: Must be an exact match of one of: feature, bugfix, refactor, default. ' +
+              'If the workflow name is incorrect, session creation will fail.',
+          },
         },
         required: ['name', 'sourceBranch'],
       },
@@ -312,17 +319,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'session_create': {
-        const { name: sessionName, sourceBranch, prompt } = toolArgs as {
+        const { name: sessionName, sourceBranch, prompt, workflow } = toolArgs as {
           name: string;
           sourceBranch: string;
           prompt?: string;
+          workflow?: string;
         };
 
         if (!sessionName || !sourceBranch) {
           throw new Error('name and sourceBranch are required');
         }
 
-        const result = await tools.createSession(sessionName, sourceBranch, prompt);
+        const result = await tools.createSession(sessionName, sourceBranch, prompt, workflow);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
         };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -299,6 +299,7 @@ export interface PendingSessionConfig {
   name: string;
   sourceBranch: string;
   prompt?: string;
+  workflow?: string;
   requestedAt: string;
 }
 
@@ -309,12 +310,14 @@ export interface PendingSessionConfig {
  * @param name Session name (will be sanitized for git branch)
  * @param sourceBranch Source branch to create worktree from
  * @param prompt Optional starting prompt for Claude
+ * @param workflow Optional workflow template name to use
  * @returns Result object with success status, config path, or error
  */
 export async function createSession(
   name: string,
   sourceBranch: string,
-  prompt?: string
+  prompt?: string,
+  workflow?: string
 ): Promise<CreateSessionResult> {
   try {
     // 1. Validate and sanitize the session name
@@ -345,6 +348,7 @@ export async function createSession(
       name: sanitizedName,
       sourceBranch,
       prompt: prompt?.trim() || undefined,
+      workflow: workflow?.trim() || undefined,
       requestedAt: new Date().toISOString()
     };
 


### PR DESCRIPTION
Add support for specifying a workflow template when creating sessions via the MCP session_create tool. The tool description guides Claude to ask users which workflow they want (feature, bugfix, refactor, default).

Changes:
- Add workflow parameter to session_create tool schema in server.ts
- Include workflow in PendingSessionConfig and createSession() in tools.ts
- Add workflow validation in extension.ts with error notification showing available workflows if the specified workflow doesn't exist
- Add 5 tests for workflow parameter handling