### PR TITLE
feat: add refresh button to workflow template dropdown

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -708,6 +708,11 @@ export async function activate(context: vscode.ExtensionContext) {
         sessionFormProvider.updateWorkflows(workflows);
     }
 
+    // Register callback for refresh workflows button in session form
+    sessionFormProvider.setOnRefreshWorkflows(async () => {
+        await refreshWorkflows();
+    });
+
     // Initial workflow load
     refreshWorkflows();
 


### PR DESCRIPTION
Add a refresh button (↻) to the right of the workflow dropdown in the session form. When clicked, it refreshes the list of available workflow templates by re-discovering workflows from the filesystem.

Implementation details:
- Added refresh button with loading state indicator (disables and shows '...' while refreshing)
- Button restores to normal state after workflows are updated
- Uses flex container to position button inline with dropdown
- Added accessibility support (aria-label) for screen readers
- Connected to existing refreshWorkflows() function via callback pattern