### PR TITLE
fix: resolve workflow path correctly for custom workflows

### DIFF
--- a/src/SessionFormProvider.ts
+++ b/src/SessionFormProvider.ts
@@ -54,6 +54,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
                 workflows: workflows.map(w => ({
                     name: w.name,
                     description: w.description,
+                    path: w.path,
                     isBuiltIn: w.isBuiltIn
                 }))
             });
@@ -70,6 +71,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
     /**
      * Generate HTML options for workflow dropdown
      * Only shows custom workflows (built-in workflows are filtered out)
+     * Uses the full path as the value so MCP server can find the workflow file
      */
     private _getWorkflowOptionsHtml(): string {
         // Filter to only include custom workflows
@@ -81,7 +83,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
 
         let html = '';
         for (const w of custom) {
-            html += `<option value="${this._escapeHtml(w.name)}">${this._escapeHtml(w.name)}</option>`;
+            html += `<option value="${this._escapeHtml(w.path)}">${this._escapeHtml(w.name)}</option>`;
         }
 
         return html;
@@ -139,6 +141,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
                 workflows: this._workflows.map(w => ({
                     name: w.name,
                     description: w.description,
+                    path: w.path,
                     isBuiltIn: w.isBuiltIn
                 }))
             });
@@ -416,6 +419,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
 
         // Helper function to update workflow dropdown options
         // Only shows custom workflows (built-in workflows are filtered out)
+        // Uses the full path as the value so MCP server can find the workflow file
         function updateWorkflowDropdown(workflows) {
             const currentValue = workflowInput.value;
 
@@ -440,9 +444,10 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
             }
 
             // Add custom workflow options directly (no optgroup needed)
+            // Use the path as value (for MCP server) and name as display text
             custom.forEach(w => {
                 const option = document.createElement('option');
-                option.value = w.name;
+                option.value = w.path;
                 option.textContent = w.name;
                 workflowInput.appendChild(option);
             });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -137,6 +137,7 @@ export async function loadState(worktreePath: string): Promise<WorkflowState | n
  * @param templatesDir - Directory containing workflow templates
  * @param summary - Optional brief summary of the user's request (max 10 words)
  * @returns The created state machine and initial status
+ * @deprecated Use workflowStartFromPath instead for explicit path handling
  */
 export async function workflowStart(
   worktreePath: string,
@@ -147,6 +148,40 @@ export async function workflowStart(
   // Load the workflow template
   const templatePath = path.join(templatesDir, `${workflowName}.yaml`);
   const template = await loadWorkflowTemplate(templatePath);
+
+  // Create new state machine
+  const machine = new WorkflowStateMachine(template);
+
+  // Start the workflow
+  const status = machine.start();
+
+  // Set summary if provided and non-empty
+  if (summary && summary.trim()) {
+    machine.setSummary(summary.trim());
+  }
+
+  // Save initial state
+  await saveState(worktreePath, machine.getState());
+
+  return { machine, status };
+}
+
+/**
+ * Initialize workflow from a direct file path.
+ * Creates a new WorkflowStateMachine from the specified template path.
+ *
+ * @param worktreePath - The worktree root path for state persistence
+ * @param workflowPath - Absolute path to the workflow YAML file
+ * @param summary - Optional brief summary of the user's request (max 10 words)
+ * @returns The created state machine and initial status
+ */
+export async function workflowStartFromPath(
+  worktreePath: string,
+  workflowPath: string,
+  summary?: string
+): Promise<WorkflowStartResult> {
+  // Load the workflow template directly from the path
+  const template = await loadWorkflowTemplate(workflowPath);
 
   // Create new state machine
   const machine = new WorkflowStateMachine(template);

--- a/src/test/sessionForm.test.ts
+++ b/src/test/sessionForm.test.ts
@@ -149,9 +149,10 @@ suite('Session Form', () => {
 				!html.includes('<optgroup label="Custom">'),
 				'Form should NOT have Custom optgroup (custom workflows added directly)'
 			);
+			// Option value is now the path, display text is the name
 			assert.ok(
-				html.includes('<option value="Custom">Custom</option>'),
-				'Form should have Custom workflow option'
+				html.includes('<option value="/path/custom.yaml">Custom</option>'),
+				'Form should have Custom workflow option with path as value'
 			);
 		});
 


### PR DESCRIPTION
The MCP server was looking for workflows only in the extension's bundled workflows/ directory, causing ENOENT errors when using custom workflows from .claude/lanes/workflows/. Fixed by passing the full absolute path to the workflow YAML file instead of just the name.

- SessionFormProvider: Use workflow path as dropdown value
- MCP server: Accept --workflow-path instead of --workflow
- MCP tools: Add workflowStartFromPath() for direct path loading
- extension.ts: Pass full path and validate as absolute .yaml path