### PR TITLE
fix: hide built-in workflows from sidebar tree view

### DIFF
--- a/src/WorkflowsProvider.ts
+++ b/src/WorkflowsProvider.ts
@@ -101,7 +101,7 @@ export class WorkflowsProvider implements vscode.TreeDataProvider<WorkflowItem>,
                 customWorkflowsFolder
             });
 
-            return this.workflows.map(wf => new WorkflowItem(wf));
+            return this.workflows.filter(wf => !wf.isBuiltIn).map(wf => new WorkflowItem(wf));
         } catch (err) {
             console.error('Lanes: Failed to discover workflows:', err);
             return [];


### PR DESCRIPTION
Built-in workflows are templates meant to be copied to the custom workflows folder, not used directly. Filter them out from the WorkflowsProvider so only custom workflows appear in the sidebar.