### PR TITLE
fix: add explicit step boundaries to prevent skipping workflow steps

### DIFF
--- a/.claude/lanes/workflows/feature-dev.yaml
+++ b/.claude/lanes/workflows/feature-dev.yaml
@@ -150,6 +150,9 @@ steps:
 
       Document your analysis before proceeding.
 
+      IMPORTANT: Do NOT call workflow_set_tasks in this step - that happens in the next step.
+      When done analyzing, call workflow_advance with your analysis summary.
+
   - id: define_tasks
     type: action
     instructions: |
@@ -159,6 +162,8 @@ steps:
       - description: Detailed description of what needs to be done
 
       Call workflow_set_tasks('feature_development', tasks) when done.
+
+      IMPORTANT: The loop is named 'feature_development' - use exactly this name.
 
   - id: feature_development
     type: loop

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1641,6 +1641,7 @@ function getWorkflowOrchestratorInstructions(): string {
 3. **For implementation/test/review steps**, spawn sub-agents using the Task tool
 4. **Call workflow_advance** after completing each step
 5. **Never skip steps** - complete each one before advancing
+6. **Only perform actions for the CURRENT step** - do NOT call workflow tools that belong to future steps. If you are unsure about a parameter value (like a loop name), read the workflow file or wait for the step that provides that information instead of guessing.
 
 ## Workflow
 


### PR DESCRIPTION
- Add rule #6 to orchestrator instructions: only perform actions for the CURRENT step, don't call workflow tools from future steps
- Add IMPORTANT notes to plan step: don't call workflow_set_tasks yet
- Add IMPORTANT note to define_tasks step: specify exact loop name 'feature_development' to prevent guessing