### PR TITLE
refactor: remove features.json integration from extension

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -15,31 +15,30 @@ You are the primary coding agent for the Lanes VS Code extension. Your job is to
 
 ### 2. Plan Tests First (MANDATORY)
 
-Before writing ANY code, create/update `tests.json` in the project root:
+Before writing ANY code, plan what tests are needed and document them in `tests.json`:
 
 ```json
 {
   "planned": [
     {
-      "id": "unique-test-id",
-      "description": "What the test should verify",
+      "id": "test-id",
+      "description": "What the test verifies",
       "file": "src/test/extension.test.ts",
       "suite": "Suite name",
-      "type": "unit|integration",
       "priority": "critical|high|medium|low",
-      "acceptance_criteria": [
-        "Given X, when Y, then Z"
-      ],
+      "acceptance_criteria": ["Given X, when Y, then Z"],
       "implemented": false
     }
   ]
 }
 ```
 
-Define:
-- What tests are needed for this change
-- Acceptance criteria for each test
-- Priority of each test
+**Rules for tests.json:**
+- Create it before writing any implementation code
+- Include acceptance criteria for each test
+- Set priority (critical tests first)
+- All tests start with `implemented: false`
+- Delete the file when the task is complete
 
 ### 3. Implement Changes
 
@@ -61,7 +60,7 @@ After planning tests:
 
 After implementation:
 - Use the Task tool to invoke `test-engineer` agent
-- The test-engineer will implement tests based on your `tests.json`
+- The test-engineer will read `tests.json` and implement the planned tests
 
 ## Key Files in This Project
 
@@ -69,11 +68,10 @@ After implementation:
 - `src/ClaudeSessionProvider.ts` - Tree data provider for sidebar
 - `package.json` - Extension manifest (commands, views, menus)
 - `src/test/extension.test.ts` - Test suite
-- `tests.json` - Your test plan (create/update before coding)
 
 ## Constraints
 
-1. **Always plan tests first** - Create tests.json before writing any code
+1. **Always plan tests first** - Plan tests before writing any code
 2. Always read files before editing them
 3. Never skip the verification step with specialist agents for non-trivial changes
 4. Ensure all changes maintain backward compatibility

--- a/.claude/agents/initializer.md
+++ b/.claude/agents/initializer.md
@@ -39,69 +39,23 @@ Create the progress tracking file:
 - None
 ```
 
-### 2. Create features.json
-
-Create the feature tracking file based on current implementation:
-
-```json
-{
-  "features": [
-    {
-      "id": "create-session",
-      "description": "Create new worktree session with dedicated terminal",
-      "passes": true
-    },
-    {
-      "id": "open-session",
-      "description": "Open/resume existing session terminal",
-      "passes": true
-    },
-    {
-      "id": "delete-session",
-      "description": "Delete session worktree and cleanup terminal",
-      "passes": true
-    },
-    {
-      "id": "session-sidebar",
-      "description": "Display active sessions in sidebar tree view",
-      "passes": true
-    },
-    {
-      "id": "session-persistence",
-      "description": "Sessions persist across VS Code restarts",
-      "passes": true
-    }
-  ]
-}
-```
-
-### 3. Create tests.json
-
-Create an empty test plan file:
-
-```json
-{
-  "planned": []
-}
-```
-
-### 4. Verify Project State
+### 2. Verify Project State
 
 Run these checks:
 - `npm install` - Ensure dependencies are installed
 - `npm run compile` - Verify TypeScript compiles
 - `npm test` - Verify tests pass
 
-### 5. Create Initial Commit (if needed)
+### 3. Create Initial Commit (if needed)
 
-If these files are new, stage and commit them:
+If progress file is new, stage and commit it:
 ```bash
-git add claude-progress.txt features.json tests.json
-git commit -m "chore: initialize progress tracking files"
+git add claude-progress.txt
+git commit -m "chore: initialize progress tracking file"
 ```
 
 ## Constraints
 
 - Only create files that don't already exist
-- Never overwrite existing progress or feature data
+- Never overwrite existing progress data
 - Verify npm test passes before completing

--- a/.claude/agents/test-engineer.md
+++ b/.claude/agents/test-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: test-engineer
-description: QA/Test expert. Implements tests from tests.json created by the coder agent.
+description: QA/Test expert. Implements tests based on task requirements.
 tools: Bash, Read, Edit, Write, Glob
 model: sonnet
 ---
@@ -11,17 +11,16 @@ You are a QA Automation Engineer specializing in the VS Code Test Adapter.
 
 ### 1. Read the Test Plan
 
-First, read `tests.json` from the project root to understand what tests need to be implemented:
+Read `tests.json` to understand what tests need to be implemented. The coder agent will have created this file with planned tests:
 
 ```json
 {
   "planned": [
     {
       "id": "test-id",
-      "description": "What to test",
+      "description": "What the test verifies",
       "file": "src/test/extension.test.ts",
       "suite": "Suite name",
-      "type": "unit|integration",
       "priority": "critical|high|medium|low",
       "acceptance_criteria": ["Given X, when Y, then Z"],
       "implemented": false
@@ -32,12 +31,13 @@ First, read `tests.json` from the project root to understand what tests need to 
 
 ### 2. Implement Tests
 
-For each test where `implemented: false`:
+For each test in `tests.json` (ordered by priority: critical → high → medium → low):
 
-1. Read the target test file
-2. Implement the test according to the acceptance criteria
+1. Read the target test file specified in `file`
+2. Implement the test according to the `acceptance_criteria`
 3. Follow existing test patterns in the file
 4. Ensure proper setup/teardown
+5. Mark the test as `"implemented": true` in `tests.json`
 
 ### 3. Run Tests
 
@@ -48,15 +48,10 @@ npm test
 
 Verify all tests pass.
 
-### 4. Update tests.json
+### 4. Clean Up
 
-Mark implemented tests as complete:
-```json
-{
-  "id": "test-id",
-  "implemented": true
-}
-```
+When all tests are implemented and passing:
+- Delete `tests.json`
 
 ## Test Implementation Constraints
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,14 +5,11 @@ node_modules
 .vscode/settings.json
 *.vsix
 
-# Ephemeral task tracking files (created per Claude session, deleted when done)
-features.json
-tests.json
-
 # Claude Code session files
 .claude-session
 .claude-status
 workflow-state.json
+tests.json
 
 # Git worktrees directory
 .worktrees/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -12,8 +12,6 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 .husky/**
 node_modules/**
-features.json
-tests.json
 claude-progress.txt
 CLAUDE.md
 .claude/**

--- a/docs/CLAUDE-HARNESS.md
+++ b/docs/CLAUDE-HARNESS.md
@@ -12,79 +12,13 @@ Each new Claude session begins with no memory of what came before. A harness sol
 - **Tracking progress** - Clear pass/fail status for each feature
 - **Enabling handoffs** - Fresh sessions can quickly assess the current state
 
-Lanes supports two harness approaches: a simple **features.json** approach for straightforward tasks, and a more sophisticated **MCP Workflow System** for complex, multi-phase development work.
-
----
-
-## Simple Approach: features.json
-
-For straightforward tasks where you want to track a list of features without complex orchestration, use the features.json approach.
-
-### Setting Up
-
-Add the following instructions to your project's `CLAUDE.md` file (or create one in your repository root):
-
-```markdown
-## Task Planning
-
-When starting a new task, create a `features.json` file to track all features:
-
-\`\`\`json
-{
-  "features": [
-    {
-      "id": "unique-feature-id",
-      "description": "What needs to be implemented",
-      "passes": false
-    }
-  ]
-}
-\`\`\`
-
-### Rules:
-- Break down the user's request into discrete, testable features
-- All features start with `passes: false`
-- Work on one feature at a time
-- Only set `passes: true` after the feature is fully implemented and tested
-- Commit changes after completing each feature
-- Delete `features.json` when the task is complete
-```
-
-### Required Fields
-
-Lanes expects the following structure in `features.json`:
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `features` | array | Yes | Array of feature objects |
-| `features[].id` | string | Yes | Unique identifier for the feature |
-| `features[].description` | string | Yes | What needs to be implemented |
-| `features[].passes` | boolean | Yes | Whether the feature is complete |
-
-> **Note:** Your harness can include additional fields (e.g., `priority`, `dependencies`, `assignee`) - Lanes only requires the fields listed above. Feel free to extend the schema to suit your workflow.
-
-### Example Workflow
-
-1. **User requests**: "Add user authentication with login and logout"
-2. **Claude creates** `features.json`:
-   ```json
-   {
-     "features": [
-       { "id": "login-form", "description": "Create login form UI", "passes": false },
-       { "id": "auth-api", "description": "Implement authentication API endpoint", "passes": false },
-       { "id": "logout", "description": "Add logout functionality", "passes": false },
-       { "id": "session-persistence", "description": "Persist user session across page reloads", "passes": false }
-     ]
-   }
-   ```
-3. **Claude works** on each feature incrementally, marking `passes: true` as each is completed
-4. **On completion**, Claude deletes the file and updates progress notes
+Lanes provides an **MCP Workflow System** - a structured approach using workflow templates, specialized agents, and MCP tools to guide Claude through complex development work.
 
 ---
 
 ## MCP Workflow System
 
-For more complex development work that requires structured phases (planning, implementation, testing, review), Lanes provides an MCP (Model Context Protocol) based workflow system.
+The MCP (Model Context Protocol) based workflow system provides structured phases for planning, implementation, testing, and review.
 
 ### What is the Workflow System?
 
@@ -94,8 +28,6 @@ The MCP Workflow System guides Claude through structured development phases usin
 - **Specialized Agents** - Sub-agents with specific roles and tool restrictions
 - **Reusable Loops** - Sub-workflows that iterate over tasks
 - **MCP Tools** - Functions Claude uses to navigate the workflow
-
-The system automatically syncs workflow progress with `features.json` so you get the benefits of both approaches.
 
 ### Key Concepts
 
@@ -371,16 +303,6 @@ The workflow system automatically persists state to `workflow-state.json` in you
 
 The state file is automatically updated after each step and should not be manually edited.
 
-### Integration with features.json
-
-The workflow system automatically syncs with `features.json`:
-
-- When you call `workflow_set_tasks`, tasks are written to `features.json` with `passes: false`
-- When a task completes (all loop sub-steps done), the corresponding feature is marked `passes: true`
-- The Lanes sidebar shows progress for both features.json and workflow state
-
-This means you get the benefits of both systems: structured workflow guidance AND simple progress tracking.
-
 ---
 
 ## Progress Tracking with claude-progress.txt
@@ -421,29 +343,25 @@ This gives new sessions immediate context about what's been accomplished.
 
 ---
 
-## Choosing the Right Approach
+## Choosing the Right Workflow
 
-| Use Case | Recommended Approach |
+| Use Case | Recommended Workflow |
 |----------|---------------------|
-| Simple feature list | features.json |
-| Quick bug fixes | features.json |
-| Proof of concepts | features.json |
-| Complex multi-phase development | MCP Workflow System |
-| Large refactors requiring multiple steps | MCP Workflow System |
-| Work requiring specialized agents | MCP Workflow System |
-| Standardized team workflow | MCP Workflow System (custom template) |
-
-You can also use both: start with features.json for quick work, then graduate to workflows for more complex tasks.
+| New features | feature.yaml |
+| Bug fixes | bugfix.yaml |
+| Code quality improvements | refactor.yaml |
+| General development | default.yaml |
+| Standardized team process | Custom workflow template |
 
 ---
 
 ## Best Practices
 
-1. **Always use a harness** - Even simple tasks benefit from structured tracking
-2. **Break down work into discrete units** - Smaller features/tasks are easier to complete and verify
+1. **Always use a workflow** - Even simple tasks benefit from structured tracking
+2. **Break down work into discrete units** - Smaller tasks are easier to complete and verify
 3. **Update claude-progress.txt at the end of each session** - Future sessions will thank you
-4. **Delete ephemeral files when done** - Clean up features.json, tests.json, workflow-state.json
-5. **Commit frequently** - Commit after each feature/task completion
+4. **Clean up when done** - Delete workflow-state.json when the task is complete
+5. **Commit frequently** - Commit after each task completion
 6. **Use workflows for consistency** - Create custom workflows for your team's standard processes
 
 ---

--- a/docs/index.html
+++ b/docs/index.html
@@ -313,7 +313,6 @@
 
             <div class="mt-8 text-center">
                 <p class="text-sm text-gray-500 dark:text-gray-400">
-                    For simpler use cases, Lanes also supports a lightweight features.json approach.
                     <a href="https://github.com/FilipeJesus/lanes/blob/main/docs/CLAUDE-HARNESS.md" class="text-vscode-accent hover:underline">Learn more in the docs</a>.
                 </p>
             </div>

--- a/package.json
+++ b/package.json
@@ -212,18 +212,6 @@
             "default": "",
             "description": "Relative path for .claude-status file within each worktree. Only used when Use Global Storage is disabled. Leave empty for worktree root",
             "order": 3
-          },
-          "lanes.featuresJsonPath": {
-            "type": "string",
-            "default": "",
-            "description": "Relative path for features.json within each worktree. Leave empty for worktree root",
-            "order": 4
-          },
-          "lanes.testsJsonPath": {
-            "type": "string",
-            "default": "",
-            "description": "Relative path for tests.json within each worktree. Leave empty for worktree root",
-            "order": 5
           }
         }
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -470,8 +470,8 @@ export async function getBaseRepoPath(workspacePath: string): Promise<string> {
 /**
  * Get the glob pattern for watching a file based on configuration.
  * Security: Validates path to prevent directory traversal in glob patterns.
- * @param configKey The configuration key to read (e.g., 'featuresJsonPath')
- * @param filename The filename to watch (e.g., 'features.json')
+ * @param configKey The configuration key to read
+ * @param filename The filename to watch (e.g., 'workflow-state.json')
  * @returns Glob pattern for watching the file in worktrees
  */
 function getWatchPattern(configKey: string, filename: string): string {
@@ -500,15 +500,6 @@ function getWatchPattern(configKey: string, filename: string): string {
         return `${worktreesFolder}/**/${normalizedPath}/${filename}`;
     }
     return `${worktreesFolder}/**/${filename}`;
-}
-
-/**
- * Get the glob pattern for watching features.json based on configuration.
- * Security: Validates path to prevent directory traversal in glob patterns.
- * @returns Glob pattern for watching features.json in worktrees
- */
-function getFeaturesWatchPattern(): string {
-    return getWatchPattern('featuresJsonPath', 'features.json');
 }
 
 /**
@@ -740,17 +731,6 @@ export async function activate(context: vscode.ExtensionContext) {
 
         context.subscriptions.push(statusWatcher);
 
-        // Also watch for features.json changes to refresh the sidebar
-        const featuresWatcher = vscode.workspace.createFileSystemWatcher(
-            new vscode.RelativePattern(watchPath, getFeaturesWatchPattern())
-        );
-
-        featuresWatcher.onDidChange(() => sessionProvider.refresh());
-        featuresWatcher.onDidCreate(() => sessionProvider.refresh());
-        featuresWatcher.onDidDelete(() => sessionProvider.refresh());
-
-        context.subscriptions.push(featuresWatcher);
-
         // Also watch for .claude-session file changes to refresh the sidebar
         const sessionWatcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern(watchPath, getSessionWatchPattern())
@@ -793,8 +773,6 @@ export async function activate(context: vscode.ExtensionContext) {
         globalSessionWatcher.onDidDelete(() => sessionProvider.refresh());
 
         context.subscriptions.push(globalSessionWatcher);
-        // Note: features.json and tests.json are NOT stored in global storage
-        // as they are development workflow files, not extension-managed session files
     }
 
     // Watch for changes to the prompts folder to refresh previous sessions

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -116,7 +116,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       name: 'workflow_set_tasks',
       description:
         'Associate tasks with a loop step. Each task will be iterated through ' +
-        'the loop sub-steps. Also syncs tasks to features.json for tracking.',
+        'the loop sub-steps.',
       inputSchema: {
         type: 'object' as const,
         properties: {
@@ -156,8 +156,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       name: 'workflow_advance',
       description:
         'Complete the current step/sub-step and advance to the next. ' +
-        'Provide output summarizing what was accomplished. ' +
-        'When a task completes (all sub-steps done), updates features.json.',
+        'Provide output summarizing what was accomplished.',
       inputSchema: {
         type: 'object' as const,
         properties: {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -822,7 +822,6 @@ suite('Session Provider', () => {
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);
@@ -859,7 +858,6 @@ suite('Session Provider', () => {
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);
@@ -877,13 +875,8 @@ suite('Session Provider', () => {
 			);
 		});
 
-		test('SessionItem shows Working status when feature ID present but no workflow', () => {
+		test('SessionItem shows Working status when no workflow', () => {
 			// Arrange
-			const featureStatus = {
-				currentFeature: { id: 'feat-123', description: 'Test feature', passes: false },
-				allComplete: false
-			};
-
 			const claudeStatus = { status: 'working' as const };
 
 			// Act
@@ -891,12 +884,11 @@ suite('Session Provider', () => {
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				featureStatus,
 				claudeStatus,
 				null
 			);
 
-			// Assert - when working, shows "Working" regardless of feature ID
+			// Assert - when working, shows "Working"
 			const description = String(sessionItem.description || '');
 			assert.ok(
 				description.includes('Working'),
@@ -1262,7 +1254,6 @@ steps:
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);
@@ -1302,7 +1293,6 @@ steps:
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);
@@ -1330,7 +1320,6 @@ steps:
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);
@@ -1369,7 +1358,6 @@ steps:
 				'test-session',
 				'/path/to/worktree',
 				vscode.TreeItemCollapsibleState.None,
-				undefined,
 				claudeStatus,
 				workflowStatus
 			);

--- a/src/workflow/loader.ts
+++ b/src/workflow/loader.ts
@@ -52,23 +52,29 @@ function validateAgentConfig(key: string, value: unknown): asserts value is Agen
     throw new WorkflowValidationError(`Agent '${key}' must have a 'description' string`);
   }
 
-  if (!isArray(value.tools)) {
-    throw new WorkflowValidationError(`Agent '${key}' must have a 'tools' array`);
-  }
+  // tools is optional - if omitted, agent has access to all tools
+  if (value.tools !== undefined) {
+    if (!isArray(value.tools)) {
+      throw new WorkflowValidationError(`Agent '${key}' tools must be an array if provided`);
+    }
 
-  for (const tool of value.tools) {
-    if (!isString(tool)) {
-      throw new WorkflowValidationError(`Agent '${key}' tools must be strings`);
+    for (const tool of value.tools) {
+      if (!isString(tool)) {
+        throw new WorkflowValidationError(`Agent '${key}' tools must be strings`);
+      }
     }
   }
 
-  if (!isArray(value.cannot)) {
-    throw new WorkflowValidationError(`Agent '${key}' must have a 'cannot' array`);
-  }
+  // cannot is optional - if omitted, no special restrictions
+  if (value.cannot !== undefined) {
+    if (!isArray(value.cannot)) {
+      throw new WorkflowValidationError(`Agent '${key}' cannot must be an array if provided`);
+    }
 
-  for (const restriction of value.cannot) {
-    if (!isString(restriction)) {
-      throw new WorkflowValidationError(`Agent '${key}' cannot restrictions must be strings`);
+    for (const restriction of value.cannot) {
+      if (!isString(restriction)) {
+        throw new WorkflowValidationError(`Agent '${key}' cannot restrictions must be strings`);
+      }
     }
   }
 }

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -9,10 +9,10 @@
 export interface AgentConfig {
   /** Human-readable description of the agent's role */
   description: string;
-  /** List of tools this agent is allowed to use */
-  tools: string[];
-  /** List of actions this agent cannot perform */
-  cannot: string[];
+  /** List of tools this agent is allowed to use. If omitted, agent has access to all tools. */
+  tools?: string[];
+  /** List of actions this agent cannot perform. If omitted, no special restrictions. */
+  cannot?: string[];
 }
 
 /**

--- a/workflows/bugfix.yaml
+++ b/workflows/bugfix.yaml
@@ -56,18 +56,12 @@ name: bugfix
 description: Investigate and fix a bug
 
 agents:
+  # The orchestrator has access to ALL tools by default.
+  # It needs full access to coordinate work, spawn sub-agents, and handle
+  # situations where sub-agents cannot complete tasks.
   orchestrator:
     description: Coordinates investigation and fix
-    tools:
-      - Read
-      - Glob
-      - Grep
-      - Task
-    cannot:
-      - Write
-      - Edit
-      - Bash
-      - commit
+    # No tool restrictions - orchestrator needs full access
 
   investigator:
     description: Investigates bug root cause

--- a/workflows/default.yaml
+++ b/workflows/default.yaml
@@ -145,5 +145,5 @@ steps:
 
       1. Run all tests one final time
       2. Update any documentation
-      3. Clean up temporary files (features.json, tests.json)
+      3. Clean up any temporary files
       4. Summarize what was accomplished

--- a/workflows/feature.yaml
+++ b/workflows/feature.yaml
@@ -55,18 +55,12 @@ name: feature
 description: Plan and implement a new feature
 
 agents:
+  # The orchestrator has access to ALL tools by default.
+  # It needs full access to coordinate work, spawn sub-agents, and handle
+  # situations where sub-agents cannot complete tasks.
   orchestrator:
     description: Plans work and coordinates sub-agents
-    tools:
-      - Read
-      - Glob
-      - Grep
-      - Task
-    cannot:
-      - Write
-      - Edit
-      - Bash
-      - commit
+    # No tool restrictions - orchestrator needs full access
 
   implementer:
     description: Writes code to implement features

--- a/workflows/refactor.yaml
+++ b/workflows/refactor.yaml
@@ -56,18 +56,12 @@ name: refactor
 description: Refactor code for improved quality
 
 agents:
+  # The orchestrator has access to ALL tools by default.
+  # It needs full access to coordinate work, spawn sub-agents, and handle
+  # situations where sub-agents cannot complete tasks.
   orchestrator:
     description: Coordinates refactoring effort
-    tools:
-      - Read
-      - Glob
-      - Grep
-      - Task
-    cannot:
-      - Write
-      - Edit
-      - Bash
-      - commit
+    # No tool restrictions - orchestrator needs full access
 
   analyzer:
     description: Analyzes code for refactoring opportunities


### PR DESCRIPTION
Remove all features.json and tests.json integration from the Lanes extension. The workflow-state.json managed by MCP tools is the preferred approach for tracking workflow progress.

Changes:
- Remove features.json/tests.json configuration settings from package.json
- Remove file watchers and path helpers for features.json
- Remove FeatureStatus tracking from ClaudeSessionProvider
- Remove features.json syncing from MCP workflow tools
- Make agent tools/cannot arrays optional in workflow templates
- Update orchestrator agents to have no tool restrictions
- Update all test files to remove features.json test coverage
- Update documentation (CLAUDE.md, CLAUDE-HARNESS.md, agents)

The tests.json file is retained as an agent-managed ephemeral file for test planning between coder and test-engineer agents, but has no integration with the extension itself.