### PR TITLE
feat: move add comment button to left side of diff view

### DIFF
--- a/src/GitChangesPanel.ts
+++ b/src/GitChangesPanel.ts
@@ -646,6 +646,11 @@ export class GitChangesPanel {
             overflow: hidden;
         }
 
+        /* Allow comment button to extend outside the cell */
+        .diff-table td.line-content {
+            overflow: visible;
+        }
+
         .line-num {
             width: 50px;
             min-width: 50px;
@@ -776,7 +781,8 @@ export class GitChangesPanel {
 
         .comment-btn {
             position: absolute;
-            right: 8px;
+            /* Position button to the left, near the line number columns */
+            left: -52px;
             top: 50%;
             transform: translateY(-50%);
             width: 20px;


### PR DESCRIPTION
Move the comment button from the right side to the left side, positioning it near the line number columns. This prevents the button from being obscured by long lines of code.

- Change positioning from right: 8px to left: -52px
- Add overflow: visible to .line-content cell to allow button to extend outside cell boundaries