### PR TITLE
feat: add command to manually repair broken worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,11 @@
         "command": "lanes.validateWorkflow",
         "title": "Lanes: Validate Workflow Template",
         "icon": "$(check)"
+      },
+      {
+        "command": "lanes.repairBrokenWorktrees",
+        "title": "Lanes: Repair Broken Worktrees",
+        "icon": "$(wrench)"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1353,6 +1353,16 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(createWorkflowDisposable);
     context.subscriptions.push(validateWorkflowDisposable);
 
+    // 11. Register REPAIR BROKEN WORKTREES Command
+    const repairBrokenWorktreesDisposable = vscode.commands.registerCommand('lanes.repairBrokenWorktrees', async () => {
+        if (!baseRepoPath) {
+            vscode.window.showErrorMessage('No workspace folder open');
+            return;
+        }
+        await checkAndRepairBrokenWorktrees(baseRepoPath);
+    });
+    context.subscriptions.push(repairBrokenWorktreesDisposable);
+
     // Auto-resume Claude session when opened in a worktree with an existing session
     if (isInWorktree && workspaceRoot) {
         const sessionData = getSessionId(workspaceRoot);


### PR DESCRIPTION
Add "Lanes: Repair Broken Worktrees" command to the command palette, allowing users to manually trigger broken worktree detection and repair without needing to reload VS Code.