### PR TITLE
feat: move lanes folder from .claude/lanes to .lanes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ features.json
 tests.json
 .claude/settings.local.json
 
+# Lanes directory (pending sessions, custom workflows)
+.lanes/pending-sessions
+
 # Git worktrees directory
 .worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **MCP-based Agentic Workflow System** - Structured workflow (via Model Context Protocol) that guides Claude through planning → implementing → testing → reviewing phases
-- **Custom Workflow Templates** - Create YAML workflow templates in `.claude/lanes/workflows/` with agents, loops, and steps
+- **Custom Workflow Templates** - Create YAML workflow templates in `.lanes/workflows/` with agents, loops, and steps
 - **Workflow Template Dropdown** - Session creation form now shows available workflows with refresh button
 - **MCP Session Creation** - `session_create` endpoint allows programmatic session creation via MCP
 - **Workflow Progress Display** - Session tree view shows current workflow step/task as child items
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Built-in workflows are now template-only (not selectable in dropdown, copy to use)
 - Workflow and task info moved to child item in session tree view
+- **Lanes folder moved from `.claude/lanes/` to `.lanes/`** - Custom workflows and pending sessions now stored in `.lanes/` at repository root
+
+### Migration
+
+If you have existing custom workflows or data in `.claude/lanes/`, move them to the new location:
+```bash
+mv .claude/lanes .lanes
+```
 
 ### Fixed
 
@@ -200,7 +208,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Ignore `.claude/lanes` directory in git
+- Ignore `.lanes` directory in git
 
 ## [0.3.4] - 2025-12-23
 

--- a/docs/CLAUDE-HARNESS.md
+++ b/docs/CLAUDE-HARNESS.md
@@ -40,7 +40,7 @@ Workflow templates are YAML files that define:
 
 **Template Locations:**
 - Built-in templates: `workflows/` (feature, bugfix, refactor, default)
-- Custom templates: `.claude/lanes/workflows/` (appear in VS Code dropdown)
+- Custom templates: `.lanes/workflows/` (appear in VS Code dropdown)
 
 **Example Template Structure:**
 
@@ -320,12 +320,12 @@ To create a custom workflow for your project:
 
 1. **Create the directory structure:**
    ```bash
-   mkdir -p .claude/lanes/workflows
+   mkdir -p .lanes/workflows
    ```
 
 2. **Copy a built-in template as a starting point:**
    ```bash
-   cp workflows/feature.yaml .claude/lanes/workflows/my-custom-workflow.yaml
+   cp workflows/feature.yaml .lanes/workflows/my-custom-workflow.yaml
    ```
 
 3. **Customize the workflow:**

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1803,7 +1803,7 @@
                                                 <div class="flex-1">
                                                     <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Start creating a workflow document</h5>
                                                     <p class="text-sm text-gray-600 dark:text-gray-400">
-                                                        If you like, choose a template to start from (feature, bugfix, refactor, or default). This will create a new YAML file in <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.claude/lanes/workflows/</code>.
+                                                        If you like, choose a template to start from (feature, bugfix, refactor, or default). This will create a new YAML file in <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.lanes/workflows/</code>.
                                                     </p>
                                                 </div>
                                             </li>
@@ -2105,7 +2105,7 @@
                                             <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Version Control Your Workflows</h5>
                                                 <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    Commit your <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">.claude/lanes/workflows/</code> directory to git.
+                                                    Commit your <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">.lanes/workflows/</code> directory to git.
                                                     This ensures your team uses consistent workflows and you can track changes over time.
                                                 </p>
                                             </div>
@@ -2552,7 +2552,7 @@
                                                     <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">session_create</code>
                                                 </h4>
                                                 <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                                                    Request creation of a new Lanes session. Writes a config file to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">~/.claude/lanes/pending-sessions/</code> that the VS Code extension monitors and processes.
+                                                    Request creation of a new Lanes session. Writes a config file to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.lanes/pending-sessions/</code> that the VS Code extension monitors and processes.
                                                 </p>
                                                 <div class="mb-3">
                                                     <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
@@ -2584,7 +2584,7 @@
                                                     <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
 <pre class="text-gray-800 dark:text-gray-200">{
   "success": true,
-  "configPath": "~/.claude/lanes/pending-sessions/fix-auth-bug-1736454321.json"
+  "configPath": ".lanes/pending-sessions/fix-auth-bug-1736454321.json"
 }</pre>
                                                     </div>
                                                 </div>

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
           "lanes.promptsFolder": {
             "type": "string",
             "default": "",
-            "description": "Folder where session starting prompts are stored. Leave empty (default) to use VS Code's global storage (keeps repo clean). Set a path like '.claude/lanes' for repo-relative storage.",
+            "description": "Folder where session starting prompts are stored. Leave empty (default) to use VS Code's global storage (keeps repo clean). Set a path like '.lanes' for repo-relative storage.",
             "order": 2
           }
         }
@@ -232,7 +232,7 @@
           },
           "lanes.customWorkflowsFolder": {
             "type": "string",
-            "default": ".claude/lanes/workflows",
+            "default": ".lanes/workflows",
             "description": "Workspace folder for custom workflow templates (relative to workspace root)",
             "order": 3
           }

--- a/src/ClaudeSessionProvider.ts
+++ b/src/ClaudeSessionProvider.ts
@@ -101,7 +101,7 @@ export function getSessionNameFromWorktree(worktreePath: string): string {
  * Fallback chain:
  * 1. User-specified promptsFolder (if valid) -> repo-relative storage
  * 2. Global storage (if initialized) -> extension storage
- * 3. Legacy default (.claude/lanes) -> repo-relative fallback
+ * 3. Legacy default (.lanes) -> repo-relative fallback
  *
  * Security: Validates both sessionName and user-provided paths to prevent directory traversal.
  *
@@ -150,8 +150,8 @@ export function getPromptsPath(sessionName: string, repoRoot: string): { path: s
     // Default: Use global storage
     if (!globalStorageUri || !baseRepoPathForStorage) {
         // Global storage not initialized - fall back to legacy default
-        console.warn('Lanes: Global storage not initialized. Using legacy prompts location (.claude/lanes).');
-        const legacyDir = path.join(repoRoot, '.claude', 'lanes');
+        console.warn('Lanes: Global storage not initialized. Using legacy prompts location (.lanes).');
+        const legacyDir = path.join(repoRoot, '.lanes');
         const legacyPath = path.join(legacyDir, `${sessionName}.txt`);
         return { path: legacyPath, needsDir: legacyDir };
     }

--- a/src/PreviousSessionProvider.ts
+++ b/src/PreviousSessionProvider.ts
@@ -46,8 +46,8 @@ export function getPromptsDir(repoRoot: string): string | null {
 
     if (!globalStorageUri || !baseRepoPath) {
         // Global storage not initialized - fall back to legacy default
-        console.warn('Lanes: Global storage not initialized. Using legacy prompts location (.claude/lanes).');
-        return path.join(repoRoot, '.claude', 'lanes');
+        console.warn('Lanes: Global storage not initialized. Using legacy prompts location (.lanes).');
+        return path.join(repoRoot, '.lanes');
     }
 
     const repoIdentifier = getRepoIdentifier(baseRepoPath);

--- a/src/WorkflowsProvider.ts
+++ b/src/WorkflowsProvider.ts
@@ -92,7 +92,7 @@ export class WorkflowsProvider implements vscode.TreeDataProvider<WorkflowItem>,
 
         // Get custom workflows folder from config
         const config = vscode.workspace.getConfiguration('lanes');
-        const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+        const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.lanes/workflows');
 
         try {
             this.workflows = await discoverWorkflows({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,12 +43,12 @@ export interface PendingSessionConfig {
 
 /**
  * Get the directory where MCP server writes pending session requests.
- * Uses the workspace's .claude directory instead of the home directory.
+ * Uses the workspace's .lanes directory instead of the home directory.
  * @param repoRoot The root directory of the repository
  * @returns The path to the pending sessions directory
  */
 function getPendingSessionsDir(repoRoot: string): string {
-    return path.join(repoRoot, '.claude', 'lanes', 'pending-sessions');
+    return path.join(repoRoot, '.lanes', 'pending-sessions');
 }
 
 /**
@@ -804,7 +804,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Watch for changes to the custom workflows folder to refresh workflows
     if (workspaceRoot) {
         const config = vscode.workspace.getConfiguration('lanes');
-        const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+        const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.lanes/workflows');
         const customWorkflowsPath = path.join(workspaceRoot, customWorkflowsFolder);
 
         const workflowsWatcher = vscode.workspace.createFileSystemWatcher(
@@ -840,7 +840,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Watch for custom workflows folder changes
     if (watchPath) {
-        const customWorkflowsFolder = vscode.workspace.getConfiguration('lanes').get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+        const customWorkflowsFolder = vscode.workspace.getConfiguration('lanes').get<string>('customWorkflowsFolder', '.lanes/workflows');
         const customWorkflowsWatcher = vscode.workspace.createFileSystemWatcher(
             new vscode.RelativePattern(watchPath, `${customWorkflowsFolder}/*.yaml`)
         );
@@ -2351,7 +2351,7 @@ async function createWorkflow(
 
     // 2. Discover available templates for selection
     const config = vscode.workspace.getConfiguration('lanes');
-    const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.claude/lanes/workflows');
+    const customWorkflowsFolder = config.get<string>('customWorkflowsFolder', '.lanes/workflows');
 
     let templates: WorkflowMetadata[] = [];
     try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -227,12 +227,12 @@ export function workflowContext(machine: WorkflowStateMachine): Record<string, s
 
 /**
  * Get the directory where pending session configs are written.
- * Uses the workspace's .claude directory instead of the home directory.
+ * Uses the workspace's .lanes directory instead of the home directory.
  * @param repoRoot The root directory of the repository
  * @returns The path to the pending sessions directory
  */
 export function getPendingSessionsDir(repoRoot: string): string {
-  return path.join(repoRoot, '.claude', 'lanes', 'pending-sessions');
+  return path.join(repoRoot, '.lanes', 'pending-sessions');
 }
 
 /**

--- a/src/test/configuration.test.ts
+++ b/src/test/configuration.test.ts
@@ -966,7 +966,7 @@ suite('Configuration Test Suite', () => {
 			// Expected descriptions for each setting
 			const expectedDescriptions: { [key: string]: string } = {
 				'lanes.worktreesFolder': 'Folder name where session worktrees are created (relative to repository root). Default: .worktrees',
-				'lanes.promptsFolder': "Folder where session starting prompts are stored. Leave empty (default) to use VS Code's global storage (keeps repo clean). Set a path like '.claude/lanes' for repo-relative storage.",
+				'lanes.promptsFolder': "Folder where session starting prompts are stored. Leave empty (default) to use VS Code's global storage (keeps repo clean). Set a path like '.lanes' for repo-relative storage.",
 				'lanes.baseBranch': 'Branch to compare against when viewing changes. Leave empty for auto-detection (tries origin/main, origin/master, main, master)',
 				'lanes.includeUncommittedChanges': 'Show uncommitted changes (staged and unstaged) when viewing session changes. Default: enabled',
 				'lanes.useGlobalStorage': 'Store session tracking files in VS Code\'s storage instead of worktree folders. Keeps worktrees cleaner but files are hidden from version control. Default: enabled',
@@ -1334,7 +1334,7 @@ suite('Configuration Test Suite', () => {
 
 		suite('Fallback: Global Storage Not Initialized', () => {
 
-			test('should fall back to legacy .claude/lanes when global storage is not initialized', async () => {
+			test('should fall back to legacy .lanes when global storage is not initialized', async () => {
 				// Arrange: Ensure promptsFolder is empty (would normally use global storage)
 				const config = vscode.workspace.getConfiguration('lanes');
 				await config.update('promptsFolder', '', vscode.ConfigurationTarget.Global);
@@ -1361,14 +1361,13 @@ suite('Configuration Test Suite', () => {
 					const sessionName = 'test-session';
 
 					// When global storage IS initialized but we want to verify legacy path format
-					// We can check the structure: <repoRoot>/.claude/lanes/<sessionName>.txt
-					const legacyDir = path.join(uninitializedRepoDir, '.claude', 'lanes');
+					// We can check the structure: <repoRoot>/.lanes/<sessionName>.txt
+					const legacyDir = path.join(uninitializedRepoDir, '.lanes');
 					const legacyPath = path.join(legacyDir, `${sessionName}.txt`);
 
 					// This verifies the expected legacy format
 					assert.ok(legacyPath.endsWith(`${sessionName}.txt`), 'Legacy path should end with session name');
-					assert.ok(legacyPath.includes('.claude'), 'Legacy path should include .claude');
-					assert.ok(legacyPath.includes('lanes'), 'Legacy path should include lanes');
+					assert.ok(legacyPath.includes('.lanes'), 'Legacy path should include .lanes');
 
 					// The actual test: when global storage context was never initialized for a repo
 					// This is hard to test in isolation, but we verify the function signature
@@ -1378,22 +1377,22 @@ suite('Configuration Test Suite', () => {
 				}
 			});
 
-			test('should return legacy path structure: <repoRoot>/.claude/lanes/<sessionName>.txt', async () => {
+			test('should return legacy path structure: <repoRoot>/.lanes/<sessionName>.txt', async () => {
 				// This test documents the expected legacy fallback behavior
-				// Legacy path: <repoRoot>/.claude/lanes/<sessionName>.txt
+				// Legacy path: <repoRoot>/.lanes/<sessionName>.txt
 
 				const repoRoot = '/example/repo';
 				const sessionName = 'my-session';
 
 				// Calculate expected legacy path
-				const expectedLegacyDir = path.join(repoRoot, '.claude', 'lanes');
+				const expectedLegacyDir = path.join(repoRoot, '.lanes');
 				const expectedLegacyPath = path.join(expectedLegacyDir, `${sessionName}.txt`);
 
 				// Verify the path structure
 				assert.strictEqual(
 					expectedLegacyPath,
-					path.join(repoRoot, '.claude', 'lanes', 'my-session.txt'),
-					'Legacy path should follow <repoRoot>/.claude/lanes/<sessionName>.txt structure'
+					path.join(repoRoot, '.lanes', 'my-session.txt'),
+					'Legacy path should follow <repoRoot>/.lanes/<sessionName>.txt structure'
 				);
 			});
 		});

--- a/src/test/previousSession.test.ts
+++ b/src/test/previousSession.test.ts
@@ -32,7 +32,7 @@ suite('PreviousSessionItem', () => {
 	test('should have promptFilePath containing full path to prompt file', () => {
 		// Arrange
 		const sessionName = 'test-session';
-		const promptFilePath = '/absolute/path/to/.claude/lanes/test-session.txt';
+		const promptFilePath = '/absolute/path/to/.lanes/test-session.txt';
 
 		// Act
 		const item = new PreviousSessionItem(sessionName, promptFilePath);
@@ -127,7 +127,7 @@ suite('PreviousSessionProvider', () => {
 	setup(async () => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'previous-session-test-'));
 		worktreesDir = path.join(tempDir, '.worktrees');
-		promptsDir = path.join(tempDir, '.claude', 'lanes');
+		promptsDir = path.join(tempDir, '.lanes');
 
 		// Reset configuration to default
 		const config = vscode.workspace.getConfiguration('lanes');
@@ -323,7 +323,7 @@ suite('PreviousSessionProvider', () => {
 	test('should use baseRepoPath for finding sessions when provided', async () => {
 		// Arrange: Create a second temp dir to simulate base repo
 		const baseRepoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'base-repo-'));
-		const basePromptsDir = path.join(baseRepoDir, '.claude', 'lanes');
+		const basePromptsDir = path.join(baseRepoDir, '.lanes');
 
 		try {
 			fs.mkdirSync(basePromptsDir, { recursive: true });
@@ -365,10 +365,10 @@ suite('getPromptsDir', () => {
 		// Act
 		const result = getPromptsDir(testRepoRoot);
 
-		// Assert - falls back to legacy .claude/lanes when global storage not initialized
+		// Assert - falls back to legacy .lanes when global storage not initialized
 		assert.strictEqual(
 			result,
-			path.join(testRepoRoot, '.claude', 'lanes'),
+			path.join(testRepoRoot, '.lanes'),
 			'Should return legacy path when global storage not initialized'
 		);
 	});
@@ -384,7 +384,7 @@ suite('getPromptsDir', () => {
 		// Assert
 		assert.strictEqual(
 			result,
-			path.join(testRepoRoot, '.claude', 'lanes'),
+			path.join(testRepoRoot, '.lanes'),
 			'Should return legacy path when config is empty string'
 		);
 	});
@@ -400,7 +400,7 @@ suite('getPromptsDir', () => {
 		// Assert
 		assert.strictEqual(
 			result,
-			path.join(testRepoRoot, '.claude', 'lanes'),
+			path.join(testRepoRoot, '.lanes'),
 			'Should return legacy path when config is only whitespace'
 		);
 	});
@@ -448,7 +448,7 @@ suite('getPromptsDir', () => {
 		// Assert - falls back to legacy when global storage not initialized
 		assert.strictEqual(
 			result,
-			path.join(testRepoRoot, '.claude', 'lanes'),
+			path.join(testRepoRoot, '.lanes'),
 			'Should reject path traversal and fall back to legacy path'
 		);
 	});

--- a/src/workflow/discovery.ts
+++ b/src/workflow/discovery.ts
@@ -111,7 +111,7 @@ export interface DiscoverWorkflowsOptions {
   extensionPath: string;
   /** Absolute path to the workspace root (for custom workflows) */
   workspaceRoot: string;
-  /** Custom workflows folder relative to workspace root (default: '.claude/lanes/workflows') */
+  /** Custom workflows folder relative to workspace root (default: '.lanes/workflows') */
   customWorkflowsFolder?: string;
 }
 
@@ -128,7 +128,7 @@ export interface DiscoverWorkflowsOptions {
  * @returns Array of workflow metadata, with built-in workflows first
  */
 export async function discoverWorkflows(options: DiscoverWorkflowsOptions): Promise<WorkflowMetadata[]> {
-  const { extensionPath, workspaceRoot, customWorkflowsFolder = '.claude/lanes/workflows' } = options;
+  const { extensionPath, workspaceRoot, customWorkflowsFolder = '.lanes/workflows' } = options;
 
   // Discover built-in workflows
   const builtIn = await discoverFromDirectory(path.join(extensionPath, 'workflows'), true);
@@ -171,8 +171,8 @@ export async function discoverWorkflowsWithConfig(
 ): Promise<WorkflowMetadata[]> {
   // Use default value if no config function provided
   const customWorkflowsFolder = getConfigValue
-    ? getConfigValue<string>('lanes', 'customWorkflowsFolder', '.claude/lanes/workflows')
-    : '.claude/lanes/workflows';
+    ? getConfigValue<string>('lanes', 'customWorkflowsFolder', '.lanes/workflows')
+    : '.lanes/workflows';
 
   return discoverWorkflows({
     extensionPath,

--- a/workflows/bugfix.yaml
+++ b/workflows/bugfix.yaml
@@ -7,7 +7,7 @@
 #
 # TO USE THIS TEMPLATE:
 # ---------------------
-# 1. Copy this file to your project's .claude/lanes/workflows/ directory
+# 1. Copy this file to your project's .lanes/workflows/ directory
 # 2. Customize the workflow for your project's needs
 # 3. The workflow will appear in the "Custom" section of the dropdown
 #

--- a/workflows/default.yaml
+++ b/workflows/default.yaml
@@ -7,7 +7,7 @@
 #
 # TO USE THIS TEMPLATE:
 # ---------------------
-# 1. Copy this file to your project's .claude/lanes/workflows/ directory
+# 1. Copy this file to your project's .lanes/workflows/ directory
 # 2. Customize the workflow for your project's needs
 # 3. The workflow will appear in the "Custom" section of the dropdown
 #

--- a/workflows/feature.yaml
+++ b/workflows/feature.yaml
@@ -7,7 +7,7 @@
 #
 # TO USE THIS TEMPLATE:
 # ---------------------
-# 1. Copy this file to your project's .claude/lanes/workflows/ directory
+# 1. Copy this file to your project's .lanes/workflows/ directory
 # 2. Customize the workflow for your project's needs
 # 3. The workflow will appear in the "Custom" section of the dropdown
 #

--- a/workflows/refactor.yaml
+++ b/workflows/refactor.yaml
@@ -7,7 +7,7 @@
 #
 # TO USE THIS TEMPLATE:
 # ---------------------
-# 1. Copy this file to your project's .claude/lanes/workflows/ directory
+# 1. Copy this file to your project's .lanes/workflows/ directory
 # 2. Customize the workflow for your project's needs
 # 3. The workflow will appear in the "Custom" section of the dropdown
 #


### PR DESCRIPTION
Move the default lanes folder location from `.claude/lanes/` to `.lanes/` at the repository root for cleaner separation of concerns.

Changes:
- Update all default paths from .claude/lanes to .lanes
- Update getPendingSessionsDir to use .lanes/pending-sessions
- Update legacy fallback paths in session providers
- Add .lanes/ to .gitignore
- Update all documentation and workflow templates
- Add migration instructions to CHANGELOG

BREAKING CHANGE: Users with existing data in .claude/lanes/ should run:
  mv .claude/lanes .lanes