### PR TITLE
feat: make agents and loops optional in workflow templates

### DIFF
--- a/docs/CLAUDE-HARNESS.md
+++ b/docs/CLAUDE-HARNESS.md
@@ -33,20 +33,53 @@ The MCP Workflow System guides Claude through structured development phases usin
 
 #### 1. Workflow Templates
 
-Workflow templates are YAML files that define:
-- **Agents** - Specialized roles with allowed/disallowed tools
-- **Loops** - Reusable sub-workflows that iterate over tasks
-- **Steps** - The main workflow sequence
+Workflow templates are YAML files that define the sequence of steps in a development workflow.
+
+**Required Fields:**
+- **name** - Unique identifier for the workflow
+- **description** - Brief description of the workflow's purpose
+- **steps** - The main workflow sequence
+
+**Optional Fields:**
+- **agents** - Specialized roles with allowed/disallowed tools (for complex workflows)
+- **loops** - Reusable sub-workflows that iterate over tasks (for multi-task workflows)
+
+Simple workflows can be defined with just `name`, `description`, and `steps`. The `agents` and `loops` fields are only needed for more complex workflows that require specialized sub-agents or iteration over multiple tasks.
 
 **Template Locations:**
 - Built-in templates: `workflows/` (feature, bugfix, refactor, default)
 - Custom templates: `.lanes/workflows/` (appear in VS Code dropdown)
 
-**Example Template Structure:**
+**Example: Simple Workflow (no agents or loops):**
+
+```yaml
+name: simple-task
+description: Execute a straightforward task without specialized agents
+
+steps:
+  - id: analyze
+    type: action
+    instructions: |
+      Analyze the codebase and identify what needs to be done.
+
+  - id: implement
+    type: action
+    instructions: |
+      Implement the required changes.
+      Ensure all tests pass.
+
+  - id: verify
+    type: action
+    instructions: |
+      Run tests and verify the implementation.
+      Update documentation if needed.
+```
+
+**Example: Complex Workflow (with agents and loops):**
 
 ```yaml
 name: feature
-description: Plan and implement a new feature
+description: Plan and implement a new feature with specialized agents
 
 agents:
   orchestrator:

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -1419,7 +1419,7 @@
                                     <div>
                                         <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">YAML Structure Overview</h3>
                                         <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            Workflow templates are YAML files with four top-level sections:
+                                            Workflow templates are YAML files. Simple workflows only need <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">name</code>, <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">description</code>, and <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">steps</code>. The <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">agents</code> and <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">loops</code> sections are optional for more complex workflows:
                                         </p>
 
                                         <div class="space-y-4">
@@ -1445,8 +1445,8 @@
                                                 <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">agents</h4>
                                                 <p class="text-sm text-gray-600 dark:text-gray-400">
                                                     <strong>Type:</strong> object<br>
-                                                    <strong>Required:</strong> Yes<br>
-                                                    <strong>Purpose:</strong> Defines specialized agents with tool permissions and restrictions.
+                                                    <strong>Required:</strong> No (optional)<br>
+                                                    <strong>Purpose:</strong> Defines specialized agents with tool permissions and restrictions. Only needed for complex workflows requiring sub-agents.
                                                 </p>
                                             </div>
 
@@ -1454,8 +1454,8 @@
                                                 <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">loops</h4>
                                                 <p class="text-sm text-gray-600 dark:text-gray-400">
                                                     <strong>Type:</strong> object<br>
-                                                    <strong>Required:</strong> Yes<br>
-                                                    <strong>Purpose:</strong> Reusable sub-workflows that iterate over tasks.
+                                                    <strong>Required:</strong> No (optional)<br>
+                                                    <strong>Purpose:</strong> Reusable sub-workflows that iterate over tasks. Only needed for workflows that process multiple items.
                                                 </p>
                                             </div>
 
@@ -1841,11 +1841,52 @@
 
                                     </div>
 
+                                    <!-- Simple Workflow Example -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Simple Workflow Example</h3>
+                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                            For straightforward tasks, you can create a workflow with just steps—no agents or loops required. The main Claude agent handles all steps directly:
+                                        </p>
+
+                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
+                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">simple-workflow.yaml</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-gray-500"># A minimal workflow - just name, description, and steps</span>
+<span class="text-purple-400">name:</span> simple-task
+<span class="text-purple-400">description:</span> Execute a straightforward task
+
+<span class="text-purple-400">steps:</span>
+  - <span class="text-green-400">id:</span> analyze
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Analyze the codebase and identify what needs to be done.
+
+  - <span class="text-green-400">id:</span> implement
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Implement the required changes.
+      Ensure all tests pass.
+
+  - <span class="text-green-400">id:</span> verify
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Run tests and verify the implementation.
+      Update documentation if needed.</code></pre>
+                                        </div>
+
+                                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 mb-4">
+                                            <p class="text-sm text-blue-800 dark:text-blue-200">
+                                                <strong>Tip:</strong> Simple workflows are great for quick prototypes, single-developer tasks, or when you don't need tool restrictions between phases.
+                                            </p>
+                                        </div>
+                                    </div>
+
                                     <!-- Complete Annotated Example -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Complete Annotated Example</h3>
+                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Complete Annotated Example (with Agents and Loops)</h3>
                                         <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            Here's a complete workflow template with detailed annotations explaining each section:
+                                            For complex workflows that need specialized agents and iteration over tasks, here's a complete template with detailed annotations:
                                         </p>
 
                                         <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden">

--- a/src/workflow/state.ts
+++ b/src/workflow/state.ts
@@ -73,6 +73,9 @@ export class WorkflowStateMachine {
    * Gets the loop definition for a loop step.
    */
   private getLoopSteps(stepId: string): LoopStep[] {
+    if (!this.template.loops) {
+      throw new Error(`No loops defined in template`);
+    }
     const loopSteps = this.template.loops[stepId];
     if (!loopSteps) {
       throw new Error(`Loop '${stepId}' not found in template`);
@@ -115,7 +118,7 @@ export class WorkflowStateMachine {
    * Gets the agent configuration for a given agent ID.
    */
   private getAgentConfig(agentId: string | undefined): AgentConfig | undefined {
-    if (!agentId) {
+    if (!agentId || !this.template.agents) {
       return undefined;
     }
     return this.template.agents[agentId];
@@ -298,7 +301,7 @@ export class WorkflowStateMachine {
    */
   setTasks(loopId: string, tasks: Task[]): void {
     // Validate the loop exists
-    if (!this.template.loops[loopId]) {
+    if (!this.template.loops || !this.template.loops[loopId]) {
       throw new Error(`Loop '${loopId}' not found in template`);
     }
 

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -55,9 +55,9 @@ export interface WorkflowTemplate {
   /** Human-readable description of what this workflow accomplishes */
   description: string;
   /** Available agents and their configurations */
-  agents: Record<string, AgentConfig>;
+  agents?: Record<string, AgentConfig>;
   /** Reusable sub-workflows (loops) */
-  loops: Record<string, LoopStep[]>;
+  loops?: Record<string, LoopStep[]>;
   /** Main workflow steps */
   steps: WorkflowStep[];
 }

--- a/workflows/bugfix.yaml
+++ b/workflows/bugfix.yaml
@@ -50,6 +50,20 @@
 # 4. Final verify - run full test suite
 # 5. Cleanup - prepare for commit
 #
+# REQUIRED vs OPTIONAL FIELDS
+# ---------------------------
+# Required:
+#   - name: Unique identifier for the workflow
+#   - description: Brief description of purpose
+#   - steps: The main workflow sequence
+#
+# Optional:
+#   - agents: Only needed for complex workflows with specialized sub-agents
+#   - loops: Only needed for workflows that iterate over multiple tasks
+#
+# Simple workflows can omit agents and loops. When omitted, the main Claude
+# agent handles all steps directly.
+#
 # =============================================================================
 
 name: bugfix

--- a/workflows/default.yaml
+++ b/workflows/default.yaml
@@ -48,6 +48,20 @@
 # 2. Implement - code and test each feature in a loop
 # 3. Cleanup - finalize, run tests, and clean up
 #
+# REQUIRED vs OPTIONAL FIELDS
+# ---------------------------
+# Required:
+#   - name: Unique identifier for the workflow
+#   - description: Brief description of purpose
+#   - steps: The main workflow sequence
+#
+# Optional:
+#   - agents: Only needed for complex workflows with specialized sub-agents
+#   - loops: Only needed for workflows that iterate over multiple tasks
+#
+# Simple workflows can omit agents and loops. When omitted, the main Claude
+# agent handles all steps directly.
+#
 # =============================================================================
 
 name: default

--- a/workflows/feature.yaml
+++ b/workflows/feature.yaml
@@ -49,6 +49,20 @@
 # 4. Final review - review the implementation as a whole
 # 5. Final resolution - address any issues from the final review
 #
+# REQUIRED vs OPTIONAL FIELDS
+# ---------------------------
+# Required:
+#   - name: Unique identifier for the workflow
+#   - description: Brief description of purpose
+#   - steps: The main workflow sequence
+#
+# Optional:
+#   - agents: Only needed for complex workflows with specialized sub-agents
+#   - loops: Only needed for workflows that iterate over multiple tasks
+#
+# Simple workflows can omit agents and loops. When omitted, the main Claude
+# agent handles all steps directly.
+#
 # =============================================================================
 
 name: feature

--- a/workflows/refactor.yaml
+++ b/workflows/refactor.yaml
@@ -50,6 +50,20 @@
 # 4. Final test - ensure all tests pass
 # 5. Cleanup - prepare for commit
 #
+# REQUIRED vs OPTIONAL FIELDS
+# ---------------------------
+# Required:
+#   - name: Unique identifier for the workflow
+#   - description: Brief description of purpose
+#   - steps: The main workflow sequence
+#
+# Optional:
+#   - agents: Only needed for complex workflows with specialized sub-agents
+#   - loops: Only needed for workflows that iterate over multiple tasks
+#
+# Simple workflows can omit agents and loops. When omitted, the main Claude
+# agent handles all steps directly.
+#
 # =============================================================================
 
 name: refactor


### PR DESCRIPTION
Simple workflows can now be defined with just name, description, and steps. The agents and loops fields are only required for complex workflows that need specialized sub-agents or iteration over multiple tasks.

- Updated WorkflowTemplate interface to make agents/loops optional
- Updated loader validation to allow missing agents/loops
- Added null checks in state machine for optional fields
- Added tests for workflows without agents/loops
- Updated documentation with simple workflow examples