### PR TITLE
fix: remove deprecated permission modes and fix acceptEdits flag

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -455,12 +455,8 @@
                                                         <span class="text-gray-600 dark:text-gray-400">Auto-accepts file edits (recommended for most workflows)</span>
                                                     </div>
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">plan</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Claude proposes changes but doesn't execute them</span>
-                                                    </div>
-                                                    <div class="flex gap-2">
                                                         <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">dontAsk</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Never prompts for permission (fully autonomous)</span>
+                                                        <span class="text-gray-600 dark:text-gray-400">Auto-deny tools unless explicitly allowed by an allow rule</span>
                                                     </div>
                                                     <div class="flex gap-2">
                                                         <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">bypassPermissions</code>
@@ -808,31 +804,25 @@
                                             <tr class="border-b border-gray-200 dark:border-gray-800">
                                                 <td class="p-3 font-medium text-gray-900 dark:text-white">default</td>
                                                 <td class="p-3">Ask first</td>
-                                                <td class="p-3">Ask first</td>
+                                                <td class="p-3">Ask first unless allowed by an allow rule</td>
                                                 <td class="p-3">Standard interactive workflow</td>
                                             </tr>
                                             <tr class="border-b border-gray-200 dark:border-gray-800">
                                                 <td class="p-3 font-medium text-gray-900 dark:text-white">acceptEdits</td>
                                                 <td class="p-3">Auto-approve</td>
-                                                <td class="p-3">Ask first</td>
+                                                <td class="p-3">Ask first unless allowed by an allow rule</td>
                                                 <td class="p-3">Fast coding, careful with commands</td>
-                                            </tr>
-                                            <tr class="border-b border-gray-200 dark:border-gray-800">
-                                                <td class="p-3 font-medium text-gray-900 dark:text-white">plan</td>
-                                                <td class="p-3">Propose only</td>
-                                                <td class="p-3">Propose only</td>
-                                                <td class="p-3">Learning, sensitive codebases</td>
                                             </tr>
                                             <tr class="border-b border-gray-200 dark:border-gray-800">
                                                 <td class="p-3 font-medium text-gray-900 dark:text-white">dontAsk</td>
                                                 <td class="p-3">Auto-approve</td>
-                                                <td class="p-3">Auto-approve all</td>
-                                                <td class="p-3">Fully automated workflows</td>
+                                                <td class="p-3">Auto-deny unless allowed by an allow rule</td>
+                                                <td class="p-3">Auto-deny tools unless explicitly allowed by an allow rule</td>
                                             </tr>
                                             <tr>
                                                 <td class="p-3 font-medium text-red-600 dark:text-red-400">bypassPermissions</td>
-                                                <td class="p-3">No checks</td>
-                                                <td class="p-3">No checks</td>
+                                                <td class="p-3">Auto-approve</td>
+                                                <td class="p-3">Auto-approve</td>
                                                 <td class="p-3">Testing/debugging only</td>
                                             </tr>
                                         </tbody>
@@ -860,41 +850,6 @@
                                     </div>
                                 </div>
 
-                                <!-- Security Recommendations -->
-                                <div class="mt-8 bg-blue-50 dark:bg-blue-950/30 rounded-lg p-6 border border-blue-200 dark:border-blue-900">
-                                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4 flex items-center gap-2">
-                                        <svg class="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
-                                        </svg>
-                                        Security Best Practices
-                                    </h3>
-                                    <ul class="space-y-3 text-gray-700 dark:text-gray-300">
-                                        <li class="flex items-start gap-2">
-                                            <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                            </svg>
-                                            <span><strong>Start conservative:</strong> Use <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">default</code> or <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">plan</code> when first learning or working with new code</span>
-                                        </li>
-                                        <li class="flex items-start gap-2">
-                                            <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                            </svg>
-                                            <span><strong>Leverage Lanes's isolation:</strong> More permissive modes like <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">dontAsk</code> are safer when each session has its own isolated worktree</span>
-                                        </li>
-                                        <li class="flex items-start gap-2">
-                                            <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                            </svg>
-                                            <span><strong>Match mode to task:</strong> Quick refactoring? Use <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">acceptEdits</code>. Complex workflow? Use <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">delegate</code>. Learning? Use <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">plan</code></span>
-                                        </li>
-                                        <li class="flex items-start gap-2">
-                                            <svg class="w-5 h-5 text-red-600 dark:text-red-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                                            </svg>
-                                            <span><strong>Use bypassPermissions with Caution:</strong> This mode disables all safety checks and should only be used when in a controlled environment.</span>
-                                        </li>
-                                    </ul>
-                                </div>
                             </div>
                         </section>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -207,7 +207,7 @@
                     </div>
                     <div class="flex items-start gap-3">
                         <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Permission mode selector (plan, auto-accept, etc.)</span>
+                        <span class="text-gray-600 dark:text-gray-400 text-sm">Permission mode selector (acceptEdits, DontAsk, etc.)</span>
                     </div>
                     <div class="flex items-start gap-3">
                         <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>

--- a/src/SessionFormProvider.ts
+++ b/src/SessionFormProvider.ts
@@ -4,7 +4,7 @@ import { WorkflowMetadata } from './workflow';
 /**
  * Valid permission modes for Claude CLI
  */
-export const PERMISSION_MODES = ['acceptEdits', 'bypassPermissions', 'default', 'delegate', 'dontAsk', 'plan'] as const;
+export const PERMISSION_MODES = ['acceptEdits', 'bypassPermissions', 'default', 'dontAsk'] as const;
 export type PermissionMode = typeof PERMISSION_MODES[number];
 
 /**
@@ -335,7 +335,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
                 placeholder="main"
                 autocomplete="off"
             />
-            <div class="hint">Leave empty to branch from current HEAD</div>
+            <div class="hint">Leave empty to branch from current HEAD. Use "origin/<branch_name>" to branch from a remote branch.</div>
         </div>
 
         <div class="form-group">
@@ -364,9 +364,7 @@ export class SessionFormProvider implements vscode.WebviewViewProvider {
                 <option value="default" selected>default</option>
                 <option value="acceptEdits">acceptEdits</option>
                 <option value="bypassPermissions">bypassPermissions</option>
-                <option value="delegate">delegate</option>
                 <option value="dontAsk">dontAsk</option>
-                <option value="plan">plan</option>
             </select>
             <div class="hint">Controls Claude's permission behavior</div>
         </div>

--- a/src/codeAgents/ClaudeCodeAgent.ts
+++ b/src/codeAgents/ClaudeCodeAgent.ts
@@ -23,7 +23,7 @@ import {
  * Claude Code implementation of the CodeAgent interface
  *
  * Provides all Claude-specific behavior including:
- * - Permission mode handling (acceptEdits, bypassPermissions, plan, etc.)
+ * - Permission mode handling (acceptEdits, bypassPermissions, dontAsk, etc.)
  * - Hook configuration for session tracking and status updates
  * - MCP server integration for workflow support
  */
@@ -211,11 +211,9 @@ export class ClaudeCodeAgent extends CodeAgent {
     getPermissionModes(): PermissionMode[] {
         return [
             { id: 'default', label: 'Default' },
-            { id: 'acceptEdits', label: 'Accept Edits', flag: '--allowedTools Edit,MultiEdit,Write,NotebookEdit' },
+            { id: 'acceptEdits', label: 'Accept Edits', flag: '--permission-mode acceptEdits' },
             { id: 'bypassPermissions', label: 'Bypass Permissions', flag: '--dangerously-skip-permissions' },
-            { id: 'delegate', label: 'Delegate', flag: '--permission-mode delegate' },
             { id: 'dontAsk', label: "Don't Ask", flag: '--permission-mode dontAsk' },
-            { id: 'plan', label: 'Plan', flag: '--permission-mode plan' }
         ];
     }
 

--- a/src/test/session.test.ts
+++ b/src/test/session.test.ts
@@ -1802,7 +1802,7 @@ suite('Session Tests', () => {
 				provider.resolveWebviewView(webviewView, mockContext, mockToken);
 
 				// Assert - verify all 6 options are present
-				const expectedOptions = ['acceptEdits', 'bypassPermissions', 'default', 'delegate', 'dontAsk', 'plan'];
+				const expectedOptions = ['acceptEdits', 'bypassPermissions', 'default', 'dontAsk'];
 				for (const option of expectedOptions) {
 					assert.ok(
 						capturedHtml.value.includes(`value="${option}"`),
@@ -1924,11 +1924,11 @@ suite('Session Tests', () => {
 					name: 'test-session',
 					prompt: 'Test prompt',
 					acceptanceCriteria: 'Test criteria',
-					permissionMode: 'plan'
+					permissionMode: 'acceptEdits'
 				});
 
 				// Assert
-				assert.strictEqual(capturedPermissionMode, 'plan', 'Callback should receive the permissionMode value');
+				assert.strictEqual(capturedPermissionMode, 'acceptEdits', 'Callback should receive the permissionMode value');
 			});
 
 			test('should default to "default" when permissionMode is not in message', async () => {
@@ -2014,7 +2014,7 @@ suite('Session Tests', () => {
 			test('should accept all valid PermissionMode values', async () => {
 				// This test verifies that the callback can receive all valid permission modes
 
-				const validModes = ['acceptEdits', 'bypassPermissions', 'default', 'delegate', 'dontAsk', 'plan'];
+				const validModes = ['acceptEdits', 'bypassPermissions', 'default', 'dontAsk'];
 
 				for (const mode of validModes) {
 					// Arrange
@@ -2089,9 +2089,9 @@ suite('Session Tests', () => {
 				assert.strictEqual(actualCommand, 'claude', 'Command should be just "claude" for default mode without prompt');
 			});
 
-			test('should include --permission-mode flag when mode is plan (with prompt)', () => {
+			test('should include --permission-mode flag when mode is acceptEdits (with prompt)', () => {
 				// Arrange
-				const permissionMode: string = 'plan';
+				const permissionMode: string = 'acceptEdits';
 				const prompt = 'Fix the bug';
 
 				// Act - simulate the permission flag building logic
@@ -2100,14 +2100,14 @@ suite('Session Tests', () => {
 					: '';
 
 				// Assert
-				assert.strictEqual(permissionFlag, '--permission-mode plan ', 'Permission flag should include plan mode');
+				assert.strictEqual(permissionFlag, '--permission-mode acceptEdits ', 'Permission flag should include acceptEdits mode');
 
 				// Verify the full command format
 				const actualCommand = `claude ${permissionFlag}"${prompt}"`;
 				assert.strictEqual(
 					actualCommand,
-					'claude --permission-mode plan "Fix the bug"',
-					'Command should include --permission-mode plan before the prompt'
+					'claude --permission-mode acceptEdits "Fix the bug"',
+					'Command should include --permission-mode acceptEdits before the prompt'
 				);
 			});
 
@@ -2134,7 +2134,7 @@ suite('Session Tests', () => {
 
 			test('should include --permission-mode flag for all non-default modes', () => {
 				// Test all non-default permission modes
-				const nonDefaultModes = ['acceptEdits', 'bypassPermissions', 'delegate', 'dontAsk', 'plan'];
+				const nonDefaultModes = ['bypassPermissions', 'dontAsk'];
 
 				for (const mode of nonDefaultModes) {
 					// Act - simulate the permission flag building logic
@@ -2181,7 +2181,7 @@ suite('Session Tests', () => {
 		suite('Permission Mode Validation', () => {
 
 			test('isValidPermissionMode should return true for all valid modes', () => {
-				const validModes = ['acceptEdits', 'bypassPermissions', 'default', 'delegate', 'dontAsk', 'plan'];
+				const validModes = ['acceptEdits', 'bypassPermissions', 'default', 'dontAsk'];
 
 				for (const mode of validModes) {
 					assert.strictEqual(
@@ -2225,14 +2225,12 @@ suite('Session Tests', () => {
 				}
 			});
 
-			test('PERMISSION_MODES should contain all 6 valid modes', () => {
-				assert.strictEqual(PERMISSION_MODES.length, 6, 'Should have exactly 6 permission modes');
+			test('PERMISSION_MODES should contain all 4 valid modes', () => {
+				assert.strictEqual(PERMISSION_MODES.length, 4, 'Should have exactly 4 permission modes');
 				assert.ok(PERMISSION_MODES.includes('acceptEdits'), 'Should include acceptEdits');
 				assert.ok(PERMISSION_MODES.includes('bypassPermissions'), 'Should include bypassPermissions');
 				assert.ok(PERMISSION_MODES.includes('default'), 'Should include default');
-				assert.ok(PERMISSION_MODES.includes('delegate'), 'Should include delegate');
 				assert.ok(PERMISSION_MODES.includes('dontAsk'), 'Should include dontAsk');
-				assert.ok(PERMISSION_MODES.includes('plan'), 'Should include plan');
 			});
 		});
 	});
@@ -2333,7 +2331,7 @@ suite('Session Tests', () => {
 				prompt: 'Fix the bug',
 				acceptanceCriteria: 'It should work',
 				sourceBranch: 'develop',
-				permissionMode: 'plan'
+				permissionMode: 'acceptEdits'
 			});
 
 			// Assert - clearForm should NOT be posted when an error occurs
@@ -2608,7 +2606,7 @@ suite('Session Tests', () => {
 				prompt: 'Test async success',
 				acceptanceCriteria: 'Should succeed',
 				sourceBranch: 'main',
-				permissionMode: 'plan'
+				permissionMode: 'acceptEdits'
 			});
 
 			// Assert - clearForm SHOULD be posted when async operation succeeds


### PR DESCRIPTION
- Remove 'plan' and 'delegate' permission modes (deprecated in Claude CLI)
- Fix acceptEdits to use --permission-mode acceptEdits instead of --allowedTools
- Update documentation and tests to reflect 4 remaining modes: default, acceptEdits, dontAsk, bypassPermissions
- Add hint for remote branch sourcing in session form