### PR TITLE
fix: migrate from deprecated punycode to punycode.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,5 +277,12 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.2",
     "yaml": "^2.8.2"
-  }
+  },
+  "overrides": {
+    "uri-js": {
+      ".": "4.4.1",
+      "punycode": "npm:punycode.js@2.3.1"
+    }
+  },
+  "// Punycode override notes": "Use punycode.js instead of deprecated Node.js punycode module. Required by uri-js (transitive dependency via eslint->ajv)."
 }


### PR DESCRIPTION
Add npm override to force uri-js to use punycode.js@2.3.1 instead of the deprecated Node.js built-in punycode module.

Resolves deprecation warning:
"DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead."

Dependency chain affected: eslint → ajv → uri-js → punycode

All 528 tests passing with no regressions.