### PR TITLE
chore: add local install script for development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,16 @@ If you prefer to set up your development environment manually:
 
 To install and test your compiled extension in your regular VS Code installation (not the Extension Development Host):
 
+**Quick Method (Recommended):**
+
+```bash
+./scripts/install-local.sh
+```
+
+This compiles, packages, and installs the extension in one command.
+
+**Manual Method:**
+
 1. **Compile the extension**
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ npm run compile && npx vsce package
 # Then install the .vsix via "Extensions: Install from VSIX..."
 ```
 
+**Or use the local install script:**
+
+```bash
+./scripts/install-local.sh
+```
+
+This compiles, packages, and installs the extension in one command.
+
 ---
 
 ## Usage

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -e
+
+# Lanes Local Install Script
+# Usage: ./scripts/install-local.sh
+
+echo "🔨 Building extension..."
+npm run compile
+
+echo "📦 Packaging extension..."
+npx vsce package
+
+# Get the version from package.json to find the correct .vsix file
+VERSION=$(node -p "require('./package.json').version")
+VSIX_FILE="lanes-${VERSION}.vsix"
+
+echo "🔧 Installing extension locally..."
+code --install-extension "$VSIX_FILE"
+
+echo ""
+echo "✅ Extension installed locally!"
+echo "   Reload VS Code to use the updated version (Cmd+Shift+P → 'Developer: Reload Window')"


### PR DESCRIPTION
Add scripts/install-local.sh to compile, package, and install the extension locally in one command. Update README.md and CONTRIBUTING.md to document this workflow improvement.