### PR TITLE
refactor: artefact hook now uses context message and workflow definition snapshot

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2150,17 +2150,14 @@ if [ -n "$WORKTREE_PATH" ] && [ -f "$WORKTREE_PATH/workflow-state.json" ]; then
     ARTEFACTS_ENABLED="$(jq -r '.currentStepArtefacts // false' "$WORKTREE_PATH/workflow-state.json")"
 
     if [ "$ARTEFACTS_ENABLED" = "true" ]; then
-        # Extract the file path from Write tool input (FIXED: use tool_input.file_path)
+        # Extract the file path from Write tool input
         FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')"
 
         if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
-            # Add the file to artefacts array if not already present
-            STATE_FILE="$WORKTREE_PATH/workflow-state.json"
-            tmp=$(mktemp)
-            jq --arg path "$FILE_PATH" \\
-                'if .artefacts == null then .artefacts = [] end |
-                 if .artefacts | index($path) == null then .artefacts += [$path] else . end' \\
-                "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+            # Output structured JSON with additionalContext for Claude
+            CONTEXT="An artefact was created: $FILE_PATH. Please register it by running the register_artefacts MCP tool with paths=[\\"$FILE_PATH\\"]."
+            jq -n --arg context "$CONTEXT" \\
+                '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$context}}'
         fi
     fi
 fi

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -98,13 +98,18 @@ async function ensureMachineLoaded(): Promise<WorkflowStateMachine | null> {
     const existingState = await tools.loadState(worktreePath);
     if (existingState) {
       try {
-        const template = await loadWorkflowTemplate(workflowPath);
+        // Use the snapshot template if available (prevents workflow drift)
+        // Otherwise fall back to loading from file (backward compatibility)
+        const template = existingState.workflow_definition
+          ? existingState.workflow_definition
+          : await loadWorkflowTemplate(workflowPath);
+
         machine = WorkflowStateMachine.fromState(template, existingState);
         return machine;
       } catch (error) {
         // Template loading failed (missing/corrupted template)
         const message = error instanceof Error ? error.message : String(error);
-        console.error(`Failed to load workflow template from ${workflowPath}: ${message}`);
+        console.error(`Failed to load workflow template: ${message}`);
         return null;
       }
     }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -135,8 +135,12 @@ export async function workflowStartFromPath(
     machine.setSummary(summary.trim());
   }
 
-  // Save initial state
-  await saveState(worktreePath, machine.getState());
+  // Snapshot the template in the state to prevent drift
+  const state = machine.getState();
+  state.workflow_definition = template;
+
+  // Save initial state with template snapshot
+  await saveState(worktreePath, state);
 
   return { machine, status };
 }

--- a/src/workflow/state.ts
+++ b/src/workflow/state.ts
@@ -576,6 +576,14 @@ export class WorkflowStateMachine {
   }
 
   /**
+   * Gets the workflow template.
+   * @returns The workflow template
+   */
+  getTemplate(): WorkflowTemplate {
+    return this.template;
+  }
+
+  /**
    * Registers artefact paths with validation.
    * @param paths - Array of file paths (absolute or relative)
    * @returns Object containing registered, duplicates, and invalid paths

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -126,6 +126,8 @@ export interface WorkflowState {
   currentStepArtefacts?: boolean;
   /** Whether the context action for the current step has been executed */
   contextActionExecuted: boolean;
+  /** Snapshot of the workflow definition (ensures workflow doesn't change during session) */
+  workflow_definition?: WorkflowTemplate;
 }
 
 /**


### PR DESCRIPTION

- Artefact registration hook outputs JSON context instead of directly modifying workflow-state.json
- Claude receives context message and calls register_artefacts MCP tool
- Added workflow_definition snapshot to WorkflowState to prevent workflow drift
- When resuming sessions, use snapshot template if available (backward compatible)
- Removed artefact merging logic from saveState (no longer needed)
- Updated README title from "AI Project Management" to "AI Session Management"