### PR TITLE
refactor: rename 'restart' to 'clear' for context action

### DIFF
--- a/docs/plans/2026-01-19-session-restart-design.md
+++ b/docs/plans/2026-01-19-session-restart-design.md
@@ -1,21 +1,21 @@
-# Session Restart Feature Design
+# Session Clear Feature Design
 
 **Date:** 2026-01-19
 **Status:** Implemented
 
 ## Overview
 
-The session restart feature provides a reliable way to clear conversation context without relying on automatic slash commands. When a workflow step specifies `context: restart`, a fresh Claude session is created with no conversation history while workflow state is preserved.
+The session clear feature provides a reliable way to clear conversation context by creating a fresh Claude session. When a workflow step specifies `context: clear`, a new Claude session is created with no conversation history while workflow state is preserved.
 
 ## Problem Solved
 
-The original `context: clear` feature was broken because Claude cannot automatically execute slash commands like `/clear`. The restart feature achieves the same goal by creating a new session.
+The original `context: clear` feature was broken because Claude cannot automatically execute slash commands like `/clear`. The new clear feature achieves the same goal by creating a new session.
 
 ## How It Works
 
-1. Workflow step specifies `context: restart`
-2. MCP server's `workflow_status` detects the pending restart action
-3. MCP server calls `restartSession()` which writes a config file
+1. Workflow step specifies `context: clear`
+2. MCP server's `workflow_status` detects the pending clear action
+3. MCP server calls `clearSession()` which writes a config file
 4. VS Code extension's file watcher detects the config file
 5. Extension closes the existing terminal and opens a new one
 6. New session has no conversation history
@@ -30,19 +30,19 @@ The original `context: clear` feature was broken because Claude cannot automatic
 steps:
   - id: brainstorm
     type: action
-    context: restart
+    context: clear
     instructions: |
       Start with a completely fresh perspective.
 ```
 
 ### From Context Menu
 
-Right-click on a session in the sidebar and select "Restart Session".
+Right-click on a session in the sidebar and select "Clear Session".
 
 ## Files Modified
 
-- `src/extension.ts` - Added restartSession command and file watcher
-- `src/mcp/server.ts` - Added session_restart tool
-- `src/mcp/tools.ts` - Added restartSession handler
-- `src/workflow/types.ts` - Added 'restart' to StepContextAction
+- `src/extension.ts` - Added clearSession command and file watcher
+- `src/mcp/server.ts` - Added session_clear tool
+- `src/mcp/tools.ts` - Added clearSession handler
+- `src/workflow/types.ts` - 'clear' is the primary context action
 - `package.json` - Added context menu item

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
         "title": "Lanes: Test Chime"
       },
       {
-        "command": "claudeWorktrees.restartSession",
-        "title": "Restart Session",
+        "command": "claudeWorktrees.clearSession",
+        "title": "Clear Session",
         "icon": "$(refresh)"
       }
     ],
@@ -172,7 +172,7 @@
           "group": "inline@2"
         },
         {
-          "command": "claudeWorktrees.restartSession",
+          "command": "claudeWorktrees.clearSession",
           "group": "inline@4",
           "when": "view == claudeSessionsView && viewItem == sessionItem"
         }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -268,9 +268,9 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
       },
     },
     {
-      name: 'session_restart',
+      name: 'session_clear',
       description:
-        'Restart the current Claude session with a fresh context. ' +
+        'Clear the current Claude session by starting a fresh one. ' +
         'The existing terminal will be closed and a new one created with no conversation history. ' +
         'Workflow state is preserved and will be restored via the SessionStart hook.',
       inputSchema: {
@@ -315,28 +315,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           machine.markContextActionExecuted();
           await tools.saveState(worktreePath, machine.getState());
 
-          if (contextAction === 'restart') {
-            // Call session_restart tool
-            const result = await tools.restartSession(worktreePath);
+          if (contextAction === 'clear') {
+            // Call session_clear tool to start fresh session
+            const result = await tools.clearSession(worktreePath);
             return {
               content: [{
                 type: 'text' as const,
                 text: JSON.stringify({
-                  sessionRestart: true,
-                  message: result.message || 'Session restart requested. Please wait for the new session to start.',
+                  sessionCleared: true,
+                  message: result.message || 'Session cleared. A fresh session will start.',
                   result
                 }, null, 2)
               }]
             };
           }
 
-          const command = contextAction === 'compact' ? '/compact' : '/clear';
+          // contextAction === 'compact' - use /compact slash command
           return {
             content: [{
               type: 'text' as const,
               text: JSON.stringify({
-                contextAction: command,
-                message: `Please run \`${command}\` first, then call workflow_status again.`
+                contextAction: '/compact',
+                message: `Please run \`/compact\` first, then call workflow_status again.`
               }, null, 2)
             }]
           };
@@ -450,28 +450,28 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           machine.markContextActionExecuted();
           await tools.saveState(worktreePath, machine.getState());
 
-          if (contextAction === 'restart') {
-            // Call session_restart tool
-            const result = await tools.restartSession(worktreePath);
+          if (contextAction === 'clear') {
+            // Call session_clear tool to start fresh session
+            const result = await tools.clearSession(worktreePath);
             return {
               content: [{
                 type: 'text' as const,
                 text: JSON.stringify({
-                  sessionRestart: true,
-                  message: result.message || 'Session restart requested. Please wait for the new session to start.',
+                  sessionCleared: true,
+                  message: result.message || 'Session cleared. A fresh session will start.',
                   result
                 }, null, 2)
               }]
             };
           }
 
-          const command = contextAction === 'compact' ? '/compact' : '/clear';
+          // contextAction === 'compact' - use /compact slash command
           return {
             content: [{
               type: 'text' as const,
               text: JSON.stringify({
-                contextAction: command,
-                message: `Please run \`${command}\` first, then call workflow_status again.`
+                contextAction: '/compact',
+                message: `Please run \`/compact\` first, then call workflow_status again.`
               }, null, 2)
             }]
           };
@@ -538,9 +538,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
-      case 'session_restart': {
-        // Write a restart request file that the VS Code extension will process
-        const result = await tools.restartSession(worktreePath);
+      case 'session_clear': {
+        // Write a clear request file that the VS Code extension will process
+        const result = await tools.clearSession(worktreePath);
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
         };

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -362,10 +362,10 @@ export async function createSession(
 }
 
 /**
- * Restart request configuration.
+ * Clear session request configuration.
  * Written to a JSON file for the VS Code extension to process.
  */
-export interface RestartSessionConfig {
+export interface ClearSessionConfig {
   worktreePath: string;
   requestedAt: string;
 }
@@ -401,13 +401,13 @@ function isValidWorktreePath(worktreePath: string): boolean {
 }
 
 /**
- * Request a session restart with fresh context.
+ * Clear the current session by starting a fresh one.
  * Writes a config file that the VS Code extension will process.
  *
  * @param worktreePath The worktree root path
  * @returns Result object with success status
  */
-export async function restartSession(
+export async function clearSession(
   worktreePath: string
 ): Promise<{ success: boolean; message?: string; error?: string }> {
   try {
@@ -427,35 +427,35 @@ export async function restartSession(
       };
     }
 
-    // 3. Ensure restart requests directory exists
+    // 3. Ensure clear requests directory exists
     const repoRoot = path.dirname(path.dirname(worktreePath)); // Go up from .worktrees/session-name
-    const restartDir = path.join(repoRoot, '.lanes', 'restart-requests');
-    if (!fs.existsSync(restartDir)) {
-      fs.mkdirSync(restartDir, { recursive: true });
+    const clearDir = path.join(repoRoot, '.lanes', 'clear-requests');
+    if (!fs.existsSync(clearDir)) {
+      fs.mkdirSync(clearDir, { recursive: true });
     }
 
     // 4. Create config object
     const sessionName = path.basename(worktreePath);
-    const config: RestartSessionConfig = {
+    const config: ClearSessionConfig = {
       worktreePath,
       requestedAt: new Date().toISOString()
     };
 
     // 5. Write config file with unique name
     const configId = `${sessionName}-${Date.now()}`;
-    const configPath = path.join(restartDir, `${configId}.json`);
+    const configPath = path.join(clearDir, `${configId}.json`);
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
 
     // 6. Return success
     return {
       success: true,
-      message: `Session restart requested for '${sessionName}'. The terminal will be closed and a new session started.`
+      message: `Session cleared for '${sessionName}'. A fresh session will start.`
     };
 
   } catch (err) {
     return {
       success: false,
-      error: `Failed to request session restart: ${err instanceof Error ? err.message : String(err)}`
+      error: `Failed to request session clear: ${err instanceof Error ? err.message : String(err)}`
     };
   }
 }

--- a/src/test/session-clear.test.ts
+++ b/src/test/session-clear.test.ts
@@ -2,9 +2,9 @@ import assert from 'assert';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { restartSession } from '../mcp/tools';
+import { clearSession } from '../mcp/tools';
 
-suite('Session Restart Tool', () => {
+suite('Session Clear Tool', () => {
   let tempDir: string;
   let worktreePath: string;
 
@@ -20,9 +20,9 @@ suite('Session Restart Tool', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test('restartSession creates restart request file', async () => {
+  test('clearSession creates clear request file', async () => {
     // Act
-    const result = await restartSession(worktreePath);
+    const result = await clearSession(worktreePath);
 
     // Assert
     assert.strictEqual(result.success, true);
@@ -30,25 +30,25 @@ suite('Session Restart Tool', () => {
 
     // Verify the request file was created
     const repoRoot = path.dirname(path.dirname(worktreePath));
-    const restartDir = path.join(repoRoot, '.lanes', 'restart-requests');
-    assert.ok(fs.existsSync(restartDir));
+    const clearDir = path.join(repoRoot, '.lanes', 'clear-requests');
+    assert.ok(fs.existsSync(clearDir));
 
-    const files = fs.readdirSync(restartDir);
+    const files = fs.readdirSync(clearDir);
     assert.ok(files.length > 0);
 
     // Verify file contents
-    const configPath = path.join(restartDir, files[0]);
+    const configPath = path.join(clearDir, files[0]);
     const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     assert.strictEqual(config.worktreePath, worktreePath);
     assert.ok(config.requestedAt);
   });
 
-  test('restartSession fails for non-existent worktree', async () => {
+  test('clearSession fails for non-existent worktree', async () => {
     // Arrange - use a path with .worktrees structure that doesn't exist
     const nonExistentPath = path.join(tempDir, '.worktrees', 'non-existent-session');
 
     // Act
-    const result = await restartSession(nonExistentPath);
+    const result = await clearSession(nonExistentPath);
 
     // Assert
     assert.strictEqual(result.success, false);
@@ -56,12 +56,12 @@ suite('Session Restart Tool', () => {
     assert.ok(result.error?.includes('does not exist'));
   });
 
-  test('restartSession fails for invalid path structure', async () => {
+  test('clearSession fails for invalid path structure', async () => {
     // Arrange - use a path without .worktrees structure (path traversal protection)
     const invalidPath = path.join(tempDir, 'does-not-exist');
 
     // Act
-    const result = await restartSession(invalidPath);
+    const result = await clearSession(invalidPath);
 
     // Assert
     assert.strictEqual(result.success, false);
@@ -69,12 +69,12 @@ suite('Session Restart Tool', () => {
     assert.ok(result.error?.includes('Invalid worktree path structure'));
   });
 
-  test('restartSession fails for path traversal attempts', async () => {
+  test('clearSession fails for path traversal attempts', async () => {
     // Arrange - use a path with .. (path traversal attempt)
     const invalidPath = path.join(tempDir, '.worktrees', '..');
 
     // Act
-    const result = await restartSession(invalidPath);
+    const result = await clearSession(invalidPath);
 
     // Assert
     assert.strictEqual(result.success, false);

--- a/src/test/workflow.test.ts
+++ b/src/test/workflow.test.ts
@@ -236,22 +236,22 @@ steps:
 			assert.strictEqual(action, 'compact');
 		});
 
-		test('Returns restart action when step has context: restart', () => {
+		test('Returns clear action when step has context: clear', () => {
 			const template = loadWorkflowTemplateFromString(`
 name: test
 description: Test
 steps:
   - id: step1
     type: action
-    context: restart
-    instructions: Restart first
+    context: clear
+    instructions: Clear context first
 `);
 			const machine = new WorkflowStateMachine(template);
 			machine.start();
 
 			const action = machine.getContextActionIfNeeded();
 
-			assert.strictEqual(action, 'restart');
+			assert.strictEqual(action, 'clear');
 		});
 
 		test('Returns null after action is marked executed', () => {

--- a/src/workflow/loader.ts
+++ b/src/workflow/loader.ts
@@ -117,9 +117,9 @@ function validateLoopStep(loopId: string, index: number, value: unknown): assert
     if (!isString(value.context)) {
       throw new WorkflowValidationError(`Loop '${loopId}' step '${value.id}' context must be a string`);
     }
-    if (value.context !== 'compact' && value.context !== 'clear' && value.context !== 'restart') {
+    if (value.context !== 'compact' && value.context !== 'clear') {
       throw new WorkflowValidationError(
-        `Loop '${loopId}' step '${value.id}' context must be either 'compact', 'clear', or 'restart', got: ${value.context}`
+        `Loop '${loopId}' step '${value.id}' context must be either 'compact' or 'clear', got: ${value.context}`
       );
     }
   }
@@ -170,9 +170,9 @@ function validateWorkflowStep(index: number, value: unknown): asserts value is W
     if (!isString(value.context)) {
       throw new WorkflowValidationError(`Step '${stepId}' context must be a string`);
     }
-    if (value.context !== 'compact' && value.context !== 'clear' && value.context !== 'restart') {
+    if (value.context !== 'compact' && value.context !== 'clear') {
       throw new WorkflowValidationError(
-        `Step '${stepId}' context must be either 'compact', 'clear', or 'restart', got: ${value.context}`
+        `Step '${stepId}' context must be either 'compact' or 'clear', got: ${value.context}`
       );
     }
   }

--- a/src/workflow/types.ts
+++ b/src/workflow/types.ts
@@ -13,8 +13,9 @@ export interface AgentConfig {
 
 /**
  * Context action to perform before executing a step.
+ * 'clear' creates a fresh session with no conversation history.
  */
-export type StepContextAction = 'compact' | 'clear' | 'restart';
+export type StepContextAction = 'compact' | 'clear';
 
 /**
  * A step within a reusable loop (sub-workflow).

--- a/workflows/context-example.yaml
+++ b/workflows/context-example.yaml
@@ -15,20 +15,14 @@
 # ------------------
 # This workflow demonstrates how to use the context management feature.
 # The context field can be set to:
-#   - restart: Restarts the session with fresh context (no conversation history)
-#   - clear: Clears the conversation history before the step
+#   - clear: Clears the session by starting a fresh one (no conversation history)
 #   - compact: Compacts the conversation history before the step
 #   - omitted: No context action (default behavior)
 #
-# Use context: restart for steps that benefit from a completely fresh session:
+# Use context: clear for steps that benefit from a completely fresh session:
 #   - Starting a new phase of work with no conversation history
 #   - Brainstorming new ideas with maximum context refresh
 #   - Analyzing problems from first principles
-#
-# Use context: clear for steps that benefit from a fresh start:
-#   - Brainstorming new ideas
-#   - Analyzing problems from first principles
-#   - Starting a new phase of work
 #
 # Use context: compact for steps that need focused context, like:
 #   - Writing code (reduces token usage while keeping relevant info)
@@ -88,11 +82,11 @@ loops:
 steps:
   - id: brainstorm
     type: action
-    context: restart
+    context: clear
     instructions: |
       Start with a completely fresh session.
 
-      This step restarts the Claude session with no conversation history.
+      This step clears the Claude session by starting a new one with no conversation history.
       The workflow state is preserved and will be restored.
 
       1. Consider the problem from first principles


### PR DESCRIPTION
## Summary

Renames the session restart feature to "session clear" to simplify the naming. The `'restart'` context action has been renamed to `'clear'`, and all related functions, interfaces, and commands have been updated accordingly.

## Context

The original implementation used `'restart'` as the context action name, but `'clear'` is more intuitive since it directly describes what happens - the conversation context is cleared by starting a fresh session.

## Changes

### Renamed
- `context: restart` → `context: clear`
- `session_restart` tool → `session_clear` tool  
- `restartSession()` function → `clearSession()` function
- `RestartSessionConfig` → `ClearSessionConfig`
- `restart-requests/` directory → `clear-requests/`
- `claudeWorktrees.restartSession` command → `claudeWorktrees.clearSession`
- Context menu: "Restart Session" → "Clear Session"

### Type Changes
- `StepContextAction` is now `'compact' | 'clear'` (removed `'restart'`)

## Test Plan

- [x] All 616 tests passing
- [x] Compilation successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)