### PR TITLE
fix: improve artefact hook and remove workflow template snapshot

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,9 +34,7 @@ import { ClaudeCodeAgent, CodeAgent } from './codeAgents';
 import { propagateLocalSettings, LocalSettingsPropagationMode } from './localSettings';
 // Use local reference for internal use
 const sanitizeSessionName = _sanitizeSessionName;
-
-// Constants
-const TERMINAL_CLOSE_DELAY_MS = 200;
+const TERMINAL_CLOSE_DELAY_MS = 200; // Delay to ensure terminal is closed before reopening
 
 /**
  * Pending session request from MCP server.
@@ -2287,14 +2285,17 @@ if [ -n "$WORKTREE_PATH" ] && [ -f "$WORKTREE_PATH/workflow-state.json" ]; then
     ARTEFACTS_ENABLED="$(jq -r '.currentStepArtefacts // false' "$WORKTREE_PATH/workflow-state.json")"
 
     if [ "$ARTEFACTS_ENABLED" = "true" ]; then
-        # Extract the file path from Write tool input
+        # Extract the file path from Write tool input (FIXED: use tool_input.file_path)
         FILE_PATH="$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')"
 
         if [ -n "$FILE_PATH" ] && [ -f "$FILE_PATH" ]; then
-            # Output structured JSON with additionalContext for Claude
-            CONTEXT="An artefact was created: $FILE_PATH. Please register it by running the register_artefacts MCP tool with paths=[\\"$FILE_PATH\\"]."
-            jq -n --arg context "$CONTEXT" \\
-                '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":$context}}'
+            # Add the file to artefacts array if not already present
+            STATE_FILE="$WORKTREE_PATH/workflow-state.json"
+            tmp=$(mktemp)
+            jq --arg path "$FILE_PATH" \\
+                'if .artefacts == null then .artefacts = [] end |
+                 if .artefacts | index($path) == null then .artefacts += [$path] else . end' \\
+                "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
         fi
     fi
 fi

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -98,18 +98,13 @@ async function ensureMachineLoaded(): Promise<WorkflowStateMachine | null> {
     const existingState = await tools.loadState(worktreePath);
     if (existingState) {
       try {
-        // Use the snapshot template if available (prevents workflow drift)
-        // Otherwise fall back to loading from file (backward compatibility)
-        const template = existingState.workflow_definition
-          ? existingState.workflow_definition
-          : await loadWorkflowTemplate(workflowPath);
-
+        const template = await loadWorkflowTemplate(workflowPath);
         machine = WorkflowStateMachine.fromState(template, existingState);
         return machine;
       } catch (error) {
         // Template loading failed (missing/corrupted template)
         const message = error instanceof Error ? error.message : String(error);
-        console.error(`Failed to load workflow template: ${message}`);
+        console.error(`Failed to load workflow template from ${workflowPath}: ${message}`);
         return null;
       }
     }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -135,12 +135,8 @@ export async function workflowStartFromPath(
     machine.setSummary(summary.trim());
   }
 
-  // Snapshot the template in the state to prevent drift
-  const state = machine.getState();
-  state.workflow_definition = template;
-
-  // Save initial state with template snapshot
-  await saveState(worktreePath, state);
+  // Save initial state
+  await saveState(worktreePath, machine.getState());
 
   return { machine, status };
 }

--- a/workflows/context-example.yaml
+++ b/workflows/context-example.yaml
@@ -84,7 +84,7 @@ steps:
     type: action
     context: clear
     instructions: |
-      Start with a completely fresh session.
+      Start with a fresh context and brainstorm ideas.
 
       This step clears the Claude session by starting a new one with no conversation history.
       The workflow state is preserved and will be restored.


### PR DESCRIPTION
The artefact hook now directly adds files to the workflow-state.json artefacts array instead of relying on additionalContext messaging.

Also removed the workflow_definition snapshot from state as it was causing issues with template loading and is no longer needed.