### PR TITLE
refactor: move clear session action to context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,6 @@
         },
         {
           "command": "claudeWorktrees.clearSession",
-          "group": "inline@4",
           "when": "view == claudeSessionsView && viewItem == sessionItem"
         },
         {


### PR DESCRIPTION
The "Clear Session" command now appears in the right-click context menu instead of as an inline button on the session item, reducing visual clutter in the sidebar.