### PR TITLE
fix: improve context menu and clear session functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,9 +123,14 @@
         "icon": "$(wrench)"
       },
       {
-        "command": "claudeWorktrees.toggleChime",
-        "title": "Toggle Chime",
+        "command": "claudeWorktrees.enableChime",
+        "title": "Enable Chime",
         "icon": "$(bell)"
+      },
+      {
+        "command": "claudeWorktrees.disableChime",
+        "title": "Disable Chime",
+        "icon": "$(bell-slash)"
       },
       {
         "command": "claudeWorktrees.testChime",
@@ -172,9 +177,14 @@
           "group": "inline"
         },
         {
-          "command": "claudeWorktrees.toggleChime",
-          "when": "view == claudeSessionsView && viewItem == sessionItem",
-          "group": "inline@2"
+          "command": "claudeWorktrees.enableChime",
+          "when": "view == claudeSessionsView && viewItem == sessionItem && !lanes.chimeEnabled",
+          "group": "navigation"
+        },
+        {
+          "command": "claudeWorktrees.disableChime",
+          "when": "view == claudeSessionsView && viewItem == sessionItem && lanes.chimeEnabled",
+          "group": "navigation"
         },
         {
           "command": "claudeWorktrees.clearSession",
@@ -183,7 +193,7 @@
         {
           "command": "claudeWorktrees.createTerminal",
           "when": "view == claudeSessionsView && viewItem == sessionItem",
-          "group": "inline@3"
+          "group": "navigation"
         }
       ]
     },

--- a/src/ClaudeSessionProvider.ts
+++ b/src/ClaudeSessionProvider.ts
@@ -537,6 +537,38 @@ export function getSessionId(worktreePath: string): ClaudeSessionData | null {
     }
 }
 
+/**
+ * Clear the Claude session ID from a worktree's .claude-session file.
+ * This preserves workflow and user preferences like isChimeEnabled, only removing the sessionId.
+ * @param worktreePath Path to the worktree directory
+ */
+export function clearSessionId(worktreePath: string): void {
+    const sessionPath = getClaudeSessionPath(worktreePath);
+
+    try {
+        if (!fs.existsSync(sessionPath)) {
+            return; // Nothing to clear
+        }
+
+        const content = fs.readFileSync(sessionPath, 'utf-8');
+        const data = JSON.parse(content);
+
+        // Remove only the sessionId field
+        delete data.sessionId;
+
+        // Preserve timestamp if it exists
+        if (!data.timestamp) {
+            data.timestamp = new Date().toISOString();
+        }
+
+        // Write back the modified data
+        fs.writeFileSync(sessionPath, JSON.stringify(data, null, 2), 'utf-8');
+    } catch (err) {
+        // Log but don't throw - this is a cleanup operation
+        console.warn(`Lanes: Failed to clear session ID from ${sessionPath}:`, err);
+    }
+}
+
 // Workflow status interface for display purposes
 export interface WorkflowStatus {
     active: boolean;


### PR DESCRIPTION
- Move Create Terminal and Chime from inline buttons to context menu
- Add dynamic Enable/Disable Chime menu items based on state
- Fix Create Terminal to use worktreePath instead of resourceUri
- Clear sessionId when clearing session (prevents --resume with old session)
- Add resume prompt for cleared workflow sessions
- Update chime context key immediately after enable/disable