### PR TITLE
fix: only set CLAUDE_CODE_TASK_LIST_ID for Claude session terminals

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2050,16 +2050,12 @@ async function createTerminalForSession(item: SessionItem): Promise<void> {
         const terminalCount = countTerminalsForSession(sessionName);
         const nextNumber = terminalCount + 1;
 
-        // Get or create a unique task list ID for this session
-        const taskListId = getOrCreateTaskListId(worktreePath, sessionName);
-
         // Create terminal with incremented name
         const terminalName = `${sessionName} [${nextNumber}]`;
         const terminal = vscode.window.createTerminal({
             name: terminalName,
             cwd: worktreePath,
-            iconPath: new vscode.ThemeIcon('terminal'),
-            env: { CLAUDE_CODE_TASK_LIST_ID: taskListId }
+            iconPath: new vscode.ThemeIcon('terminal')
         });
 
         terminal.show();


### PR DESCRIPTION
## Summary
- Remove `CLAUDE_CODE_TASK_LIST_ID` from plain shell terminals created via `createTerminalForSession()`
- Keep the env var only for actual Claude Code session terminals created via `openClaudeTerminal()`

## Context
The `CLAUDE_CODE_TASK_LIST_ID` environment variable should only be set for Claude Code sessions, not for normal terminals. Previously it was being set for both.

## Test plan
- [ ] Create a normal terminal via "Create Terminal" command - verify `CLAUDE_CODE_TASK_LIST_ID` is NOT set
- [ ] Create a Claude session terminal - verify `CLAUDE_CODE_TASK_LIST_ID` IS set

🤖 Generated with [Claude Code](https://claude.com/claude-code)