### PR TITLE
feat: handle session clear across multiple VS Code windows

### DIFF
--- a/src/watchers.ts
+++ b/src/watchers.ts
@@ -223,7 +223,7 @@ export function registerWatchers(
 
         clearRequestWatcher.onDidCreate(async (uri) => {
             console.log(`Clear request file detected: ${uri.fsPath}`);
-            await checkClearRequests(uri.fsPath, codeAgent, baseRepoPath, sessionProvider);
+            await checkClearRequests(uri.fsPath, codeAgent, baseRepoPath, sessionProvider, undefined, workspaceRoot);
         });
 
         context.subscriptions.push(clearRequestWatcher);


### PR DESCRIPTION
## Summary
- When clearing a session from a window that doesn't own the terminal, writes a file-based request to `.lanes/clear-requests/` for the owning window's file watcher to pick up
- Uses atomic file claiming (`unlink` as claim) to prevent race conditions when multiple windows detect the same clear request
- Implements a fallback priority chain: terminal owner → primary window → last resort, ensuring the request is always handled

## Test plan
- [x] Clear a session from the window that owns its terminal — should clear directly
- [x] Clear a session from a different window — should write a clear request file and the owning window should pick it up
- [x] Open 3+ windows for the same project and clear a session — only one window should process the request
- [x] Clear a session whose terminal was manually closed — primary window should claim as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)