### PR TITLE
feat: upload attachments via webview with progress

### DIFF
--- a/src/test/session/session-form.test.ts
+++ b/src/test/session/session-form.test.ts
@@ -562,14 +562,37 @@ suite('Session Form', () => {
 			);
 		});
 
-		test('Form JavaScript handles showFilePicker message', () => {
+		test('Form has attachment upload progress UI', () => {
 			// Arrange & Act
 			const html = getFormHtml(provider);
 
-			// Assert: showFilePicker command is in JavaScript
+			// Assert: Progress UI exists
 			assert.ok(
-				html.includes("command: 'showFilePicker'"),
-				'JavaScript should send showFilePicker message to extension'
+				html.includes('id="attachmentProgress"'),
+				'Form should have attachment progress container'
+			);
+			assert.ok(
+				html.includes('id="attachmentProgressBar"'),
+				'Form should have attachment progress bar'
+			);
+			assert.ok(
+				html.includes('id="attachmentProgressText"'),
+				'Form should have attachment progress text'
+			);
+		});
+
+		test('Form has hidden file input for attachments', () => {
+			// Arrange & Act
+			const html = getFormHtml(provider);
+
+			// Assert: file input exists
+			assert.ok(
+				html.includes('id="fileInput"'),
+				'Form should include hidden file input'
+			);
+			assert.ok(
+				html.includes('type="file"'),
+				'File input should be of type file'
 			);
 		});
 
@@ -590,8 +613,8 @@ suite('Session Form', () => {
 
 			// Assert: Duplicate detection logic exists
 			assert.ok(
-				html.includes('.toLowerCase()'),
-				'JavaScript should have case-insensitive duplicate detection'
+				html.includes('sourceKey'),
+				'JavaScript should use sourceKey for duplicate detection'
 			);
 		});
 


### PR DESCRIPTION
## Summary
- Replaces the VS Code native file picker (`showOpenDialog`) with an HTML file input inside the webview, enabling direct file uploads with base64 encoding
- Adds a progress bar UI showing upload status as files are processed
- Files are written to a temp directory (`lanes-attachments/`) with sanitized filenames and UUID prefixes for uniqueness
- Improves duplicate detection using a composite `sourceKey` (name + size + lastModified) instead of path comparison

## Test plan
- [x] Attach files via the paperclip button and verify the hidden file input opens
- [x] Confirm progress bar appears and fills during upload
- [x] Verify files are written to the temp directory and attachment chips render correctly
- [x] Attach the same file twice and confirm duplicate warning appears
- [x] Reach the max file limit and confirm the warning message
- [x] Run `npm test` and verify all session form tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)