### PR TITLE
feat: add MCP workflow support for Codex CLI via config overrides

### DIFF
--- a/scripts/force-os-cpus.cjs
+++ b/scripts/force-os-cpus.cjs
@@ -1,0 +1,15 @@
+const os = require('os');
+
+const originalCpus = os.cpus;
+
+os.cpus = () => {
+    const cpus = originalCpus();
+    if (Array.isArray(cpus) && cpus.length > 0) {
+        return cpus;
+    }
+    return [{
+        model: 'unknown',
+        speed: 0,
+        times: { user: 0, nice: 0, sys: 0, idle: 0, irq: 0 }
+    }];
+};

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -8,7 +8,7 @@ echo "🔨 Building extension..."
 npm run compile
 
 echo "📦 Packaging extension..."
-npx vsce package
+NODE_OPTIONS="--require \"$(pwd)/scripts/force-os-cpus.cjs\" ${NODE_OPTIONS:-}" npx vsce package
 
 # Get the version from package.json to find the correct .vsix file
 VERSION=$(node -p "require('./package.json').version")

--- a/src/codeAgents/CodeAgent.ts
+++ b/src/codeAgents/CodeAgent.ts
@@ -121,6 +121,9 @@ export interface StartCommandOptions {
     /** Path to MCP config file */
     mcpConfigPath?: string;
 
+    /** MCP config overrides as -c key=value entries (Codex CLI) */
+    mcpConfigOverrides?: string[];
+
     /** Initial prompt for the agent */
     prompt?: string;
 }
@@ -134,6 +137,9 @@ export interface ResumeCommandOptions {
 
     /** Path to MCP config file */
     mcpConfigPath?: string;
+
+    /** MCP config overrides as -c key=value entries (Codex CLI) */
+    mcpConfigOverrides?: string[];
 }
 
 /**

--- a/src/test/codeAgents/codex-agent.test.ts
+++ b/src/test/codeAgents/codex-agent.test.ts
@@ -45,6 +45,17 @@ suite('CodexAgent Command Building', () => {
         assert.ok(command.includes("'Implement feature X'"), 'Should include escaped prompt');
     });
 
+    test('buildStartCommand includes mcp config overrides when provided', () => {
+        const command = agent.buildStartCommand({
+            mcpConfigOverrides: [
+                'mcp_servers.\"lanes-workflow\".command=\"node\"',
+                'mcp_servers.\"lanes-workflow\".args=[\"/path/to/server.js\"]'
+            ]
+        });
+        assert.ok(command.includes("-c 'mcp_servers.\"lanes-workflow\".command=\"node\"'"), 'Should include MCP command override');
+        assert.ok(command.includes("-c 'mcp_servers.\"lanes-workflow\".args=[\"/path/to/server.js\"]'"), 'Should include MCP args override');
+    });
+
     test('buildResumeCommand with valid UUID', () => {
         const uuid = 'a1b2c3d4-e5f6-7890-1234-567890abcdef';
         const command = agent.buildResumeCommand(uuid, {});
@@ -55,6 +66,21 @@ suite('CodexAgent Command Building', () => {
         const uuid = 'A1B2C3D4-E5F6-7890-1234-567890ABCDEF';
         const command = agent.buildResumeCommand(uuid, {});
         assert.strictEqual(command, `codex resume ${uuid}`, 'Should accept uppercase UUIDs');
+    });
+
+    test('buildResumeCommand includes mcp config overrides when provided', () => {
+        const uuid = 'a1b2c3d4-e5f6-7890-1234-567890abcdef';
+        const command = agent.buildResumeCommand(uuid, {
+            mcpConfigOverrides: [
+                'mcp_servers.\"lanes-workflow\".command=\"node\"',
+                'mcp_servers.\"lanes-workflow\".args=[\"/path/to/server.js\"]'
+            ]
+        });
+        assert.strictEqual(
+            command,
+            `codex -c 'mcp_servers.\"lanes-workflow\".command=\"node\"' -c 'mcp_servers.\"lanes-workflow\".args=[\"/path/to/server.js\"]' resume ${uuid}`,
+            'Should include MCP overrides before resume'
+        );
     });
 
     test('buildResumeCommand with invalid UUID throws error', () => {
@@ -172,8 +198,8 @@ suite('CodexAgent Configuration', () => {
         assert.strictEqual(events.length, 0, 'Should have no hook events');
     });
 
-    test('supportsMcp returns false', () => {
-        assert.strictEqual(agent.supportsMcp(), false, 'Codex should not support MCP');
+    test('supportsMcp returns true', () => {
+        assert.strictEqual(agent.supportsMcp(), true, 'Codex should support MCP');
     });
 
     test('generateHooksConfig returns empty array', () => {


### PR DESCRIPTION
Codex CLI doesn't support --mcp-config files, so MCP servers are passed as -c key=value overrides on the command line. This enables Codex sessions to use the lanes-workflow MCP server for structured workflows.

- Add mcpConfigOverrides to StartCommandOptions/ResumeCommandOptions
- Override supportsMcp() and getMcpConfig() in CodexAgent
- Route MCP config through overrides for Codex vs file-based for Claude
- Add buildCodexMcpOverrides helper with TOML-safe key quoting
- Fix duplicated/dead isCodexAgent block in openAgentTerminal fallback
- Fix indentation in tmux MCP config block
- Add os.cpus() workaround for vsce packaging