### PR TITLE
feat: replace agent dropdown with inline logo selector

### DIFF
--- a/src/test/codeAgents/session-form-agent.test.ts
+++ b/src/test/codeAgents/session-form-agent.test.ts
@@ -81,7 +81,7 @@ suite('Session Form Agent Selection', () => {
 	});
 
 	suite('Agent Dropdown Rendering', () => {
-		test('Default agent is pre-selected with codex', () => {
+		test('Default agent codex is pre-selected', () => {
 			// Arrange
 			const availability = new Map([['claude', true], ['codex', true]]);
 			provider.setAgentAvailability(availability, 'codex');
@@ -89,10 +89,12 @@ suite('Session Form Agent Selection', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Codex option has selected attribute
-			const codexOptionMatch = html.match(/<option value="codex"[^>]*>/);
-			assert.ok(codexOptionMatch, 'Codex option should exist');
-			assert.ok(codexOptionMatch[0].includes('selected'), 'Codex option should have selected attribute when set as default');
+			// Assert: Codex menu item has active class, trigger shows codex SVG
+			const codexItemMatch = html.match(/<button[^>]*class="[^"]*"[^>]*data-agent="codex"/);
+			assert.ok(codexItemMatch, 'Codex menu item should exist');
+			assert.ok(codexItemMatch[0].includes('active'), 'Codex item should have active class when set as default');
+			// Trigger should show Codex title
+			assert.ok(html.includes('title="Codex CLI"'), 'Trigger should have Codex CLI tooltip when codex is default');
 		});
 
 		test('Default agent claude is pre-selected', () => {
@@ -103,13 +105,15 @@ suite('Session Form Agent Selection', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Claude option has selected attribute
-			const claudeOptionMatch = html.match(/<option value="claude"[^>]*>/);
-			assert.ok(claudeOptionMatch, 'Claude option should exist');
-			assert.ok(claudeOptionMatch[0].includes('selected'), 'Claude option should have selected attribute when set as default');
+			// Assert: Claude menu item has active class
+			const claudeItemMatch = html.match(/<button[^>]*class="[^"]*"[^>]*data-agent="claude"/);
+			assert.ok(claudeItemMatch, 'Claude menu item should exist');
+			assert.ok(claudeItemMatch[0].includes('active'), 'Claude item should have active class when set as default');
+			// Trigger should show Claude title
+			assert.ok(html.includes('title="Claude Code"'), 'Trigger should have Claude Code tooltip when claude is default');
 		});
 
-		test('Form includes Code Agent label when multiple agents available', () => {
+		test('Form includes agent dropdown with SVG logos when multiple agents available', () => {
 			// Arrange
 			const availability = new Map([['claude', true], ['codex', true]]);
 			provider.setAgentAvailability(availability, 'claude');
@@ -117,14 +121,18 @@ suite('Session Form Agent Selection', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Form includes "Code Agent" label
+			// Assert: Form includes agent dropdown with SVG icons
 			assert.ok(
-				html.includes('Code Agent'),
-				'Form should have "Code Agent" label when multiple agents available'
+				html.includes('id="agentDropdown"'),
+				'Form should have agent dropdown when multiple agents available'
+			);
+			assert.ok(
+				html.includes('<svg'),
+				'Agent dropdown should contain SVG logos'
 			);
 		});
 
-		test('Form includes agent selection hint text', () => {
+		test('Dropdown trigger has tooltip title', () => {
 			// Arrange
 			const availability = new Map([['claude', true], ['codex', true]]);
 			provider.setAgentAvailability(availability, 'claude');
@@ -132,10 +140,14 @@ suite('Session Form Agent Selection', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Form includes hint text
+			// Assert: Trigger button has title attribute
 			assert.ok(
-				html.includes('Select which AI assistant to use for this session'),
-				'Form should have hint text explaining agent selection'
+				html.includes('id="agentTrigger"'),
+				'Form should have dropdown trigger button'
+			);
+			assert.ok(
+				html.includes('title="Claude Code"'),
+				'Trigger should have tooltip showing current agent name'
 			);
 		});
 	});
@@ -303,12 +315,11 @@ suite('Session Form Agent Selection', () => {
 				'Form should handle clearForm message'
 			);
 
-			// The clearForm handler should reset agent to the default agent value
-			// Check that it includes the escaped default agent in the clearForm case
+			// The clearForm handler should reset agent selection via selectAgent function
 			const clearFormSection = html.substring(html.indexOf("case 'clearForm':"));
 			assert.ok(
-				clearFormSection.includes('agentInput.value ='),
-				'clearForm should reset agent input value'
+				clearFormSection.includes('selectAgent('),
+				'clearForm should reset agent selection via selectAgent'
 			);
 		});
 	});

--- a/src/test/session/session-form.test.ts
+++ b/src/test/session/session-form.test.ts
@@ -776,18 +776,18 @@ suite('Session Form', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Agent dropdown exists
+			// Assert: Agent dropdown exists with trigger and menu items
 			assert.ok(
-				html.includes('id="agent"'),
-				'Form should have agent dropdown with id="agent"'
+				html.includes('id="agentDropdown"'),
+				'Form should have agent dropdown with id="agentDropdown"'
 			);
 			assert.ok(
-				html.includes('Claude Code'),
-				'Form should have Claude Code option'
+				html.includes('data-agent="claude"'),
+				'Form should have Claude agent menu item'
 			);
 			assert.ok(
-				html.includes('Codex CLI'),
-				'Form should have Codex CLI option'
+				html.includes('data-agent="codex"'),
+				'Form should have Codex agent menu item'
 			);
 		});
 
@@ -799,14 +799,14 @@ suite('Session Form', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Agent dropdown does not exist
+			// Assert: Agent dropdown is hidden
 			assert.ok(
-				!html.includes('id="agent"'),
-				'Form should NOT have agent dropdown when only one agent available'
+				html.includes('style="display:none"'),
+				'Agent dropdown should be hidden when only one agent available'
 			);
 		});
 
-		test('Agent dropdown shows disabled option for unavailable agent', () => {
+		test('Agent dropdown items are enabled for available agents', () => {
 			// Arrange
 			const availability = new Map([['claude', true], ['codex', true]]);
 			provider.setAgentAvailability(availability, 'claude');
@@ -814,11 +814,11 @@ suite('Session Form', () => {
 			// Act
 			const html = getFormHtml(provider);
 
-			// Assert: Both options should be enabled (no disabled attribute)
-			const claudeMatch = html.match(/<option value="claude"[^>]*>/);
-			const codexMatch = html.match(/<option value="codex"[^>]*>/);
-			assert.ok(claudeMatch, 'Claude option should exist');
-			assert.ok(codexMatch, 'Codex option should exist');
+			// Assert: Both items should not have disabled attribute
+			const claudeMatch = html.match(/<button[^>]*data-agent="claude"[^>]*>/);
+			const codexMatch = html.match(/<button[^>]*data-agent="codex"[^>]*>/);
+			assert.ok(claudeMatch, 'Claude item should exist');
+			assert.ok(codexMatch, 'Codex item should exist');
 			assert.ok(!claudeMatch[0].includes('disabled'), 'Claude should not be disabled');
 			assert.ok(!codexMatch[0].includes('disabled'), 'Codex should not be disabled');
 		});


### PR DESCRIPTION
## Summary
- Replaces the separate agent dropdown row with a custom dropdown inline next to the session name input
- The trigger button displays the selected agent's SVG logo (Claude sunburst / OpenAI knot) and opens a dropdown menu with logo + label for each agent
- Default agent is driven by the `lanes.defaultAgent` global VS Code setting
- Dropdown is hidden when only one agent is installed

## Test plan
- [x] Verify the agent logo dropdown appears inline next to the session name when both Claude and Codex CLIs are installed
- [x] Verify clicking the trigger opens a menu with both agents showing their logos and labels
- [x] Verify selecting an agent updates the trigger icon and closes the menu
- [x] Verify clicking outside the dropdown closes it
- [x] Verify the dropdown is hidden when only one agent CLI is available
- [x] Verify the default agent from `lanes.defaultAgent` setting is pre-selected
- [x] Verify unavailable agents show "(not installed)" and are disabled in the menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)