### PR TITLE
fix: include hyphens in TOML bare key regex for Codex MCP server names

### DIFF
--- a/src/services/TerminalService.ts
+++ b/src/services/TerminalService.ts
@@ -45,7 +45,7 @@ function isCodexAgent(codeAgent?: CodeAgent): boolean {
 function buildCodexMcpOverrides(mcpConfig: { mcpServers: Record<string, { command: string; args: string[] }> }): string[] {
     const overrides: string[] = [];
     for (const [name, server] of Object.entries(mcpConfig.mcpServers)) {
-        const safeName = /^[A-Za-z0-9_]+$/.test(name) ? name : `"${name.replace(/"/g, '\\"')}"`;
+        const safeName = /^[A-Za-z0-9_-]+$/.test(name) ? name : `"${name.replace(/"/g, '\\"')}"`;
         overrides.push(`mcp_servers.${safeName}.command=${JSON.stringify(server.command)}`);
         overrides.push(`mcp_servers.${safeName}.args=${JSON.stringify(server.args)}`);
     }


### PR DESCRIPTION
  Summary

  - The buildCodexMcpOverrides regex (/^[A-Za-z0-9_]+$/) was missing hyphens, causing lanes-workflow to be wrapped in
  literal double quotes
  - Codex rejected "lanes-workflow" (with quote characters) since it doesn't match its required pattern ^[a-zA-Z0-9_-]+$
  - Added - to the regex so hyphenated names pass through as bare TOML keys

  Test plan

  - Verified Codex MCP client starts successfully with lanes-workflow server name
  - All 710 existing tests pass
  - Pre-commit hooks (compile, lint, test) pass