### PR TITLE
feat: Terminal Noir design system for docs and blog

### DIFF
--- a/docs/blog/2026-01-17-lanes-x-superpower.html
+++ b/docs/blog/2026-01-17-lanes-x-superpower.html
@@ -6,6 +6,12 @@
     <title>Lanes X Superpower - Lanes</title>
     <meta name="description" content="Manage multiple, isolated Claude Code sessions directly inside VS Code.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -13,19 +19,31 @@
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
-                    }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
+                    },
+                    fontFamily: {
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -33,67 +51,156 @@
         }
     </script>
     <style>
-        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
-        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; }
-        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; }
-        .prose p { margin: 1em 0; line-height: 1.7; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Mobile nav --- */
+        .mobile-nav {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        /* --- Prose styles --- */
+        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; color: var(--ink); }
+        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; color: var(--ink); }
+        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; color: var(--ink); }
+        .prose p { margin: 1em 0; line-height: 1.7; color: var(--ink-muted); }
         .prose ul, .prose ol { margin: 1em 0; padding-left: 1.5em; }
         .prose ul { list-style-type: disc; }
         .prose ul ul { list-style-type: circle; }
         .prose ul ul ul { list-style-type: square; }
         .prose ol { list-style-type: decimal; }
-        .prose li { margin: 0.5em 0; }
-        .prose a { color: #007acc; text-decoration: underline; }
-        .prose a:hover { color: #005a9e; }
-        .prose code { background: rgba(0,0,0,0.08); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace; }
-        .prose pre { background: #1e1e1e; color: #d4d4d4; padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid rgba(255,255,255,0.1); }
+        .prose li { margin: 0.5em 0; color: var(--ink-muted); }
+        .prose a { color: var(--accent); text-decoration: underline; }
+        .prose a:hover { opacity: 0.8; }
+        .prose code { background: var(--surface-2); color: var(--ink-muted); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, monospace; }
+        .prose pre { background: var(--surface-2); color: var(--ink-muted); padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid var(--border); }
         .prose pre code { background: transparent; padding: 0; color: inherit; }
-        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; }
-        .prose blockquote { border-left: 4px solid #007acc; padding-left: 1em; margin: 1em 0; color: #666; }
-        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid #e5e7eb; border-radius: 6px; overflow: hidden; }
-        .prose table thead { background: #f3f4f6; border-bottom: 2px solid #e5e7eb; }
-        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: #1f2937; border-right: 1px solid #e5e7eb; }
+        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; border: 1px solid var(--border); }
+        .prose blockquote { border-left: 4px solid var(--accent); padding-left: 1em; margin: 1em 0; color: var(--ink-muted); }
+        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+        .prose table thead { background: var(--surface-2); border-bottom: 2px solid var(--border); }
+        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: var(--ink); border-right: 1px solid var(--border); }
         .prose table th:last-child { border-right: none; }
-        .prose table td { padding: 0.75em 1em; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb; }
+        .prose table td { padding: 0.75em 1em; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); }
         .prose table td:last-child { border-right: none; }
         .prose table tbody tr:last-child td { border-bottom: none; }
-        .prose table tbody tr:nth-child(even) { background: #f9fafb; }
-        .prose table tbody tr:hover { background: #f3f4f6; }
-        .dark .prose table { border: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table thead { background: #2d2d2d; border-bottom: 2px solid rgba(255,255,255,0.1); }
-        .dark .prose table th { color: #f9fafb; border-right: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table td { border-right: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table tbody tr:last-child td { border-bottom: none; }
-        .dark .prose table tbody tr:nth-child(even) { background: rgba(255,255,255,0.05); }
-        .dark .prose table tbody tr:hover { background: rgba(255,255,255,0.1); }
-        .dark .prose code { background: rgba(255,255,255,0.1); }
+        .prose table tbody tr:nth-child(even) { background: var(--surface-1); }
+        .prose table tbody tr:hover { background: var(--surface-2); }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav" class="mobile-nav fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="../index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="../index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="../index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Blog</a>
+            <a href="../docs.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
+
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                    <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                    <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="../index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                        <a href="../index.html#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="../index.html#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="index.html" class="text-vscode-accent font-medium transition-colors">Blog</a>
-                        <a href="../docs.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="../index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="../index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="../index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Blog</a>
+                    <a href="../docs.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-mobile" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
                 </div>
             </div>
@@ -103,24 +210,24 @@
 
     <article class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
       <nav class="mb-8 text-sm">
-        <a href="index.html" class="text-vscode-accent hover:underline">&larr; Back to Blog</a>
+        <a href="index.html" class="text-accent hover:underline">&larr; Back to Blog</a>
       </nav>
 
       <header class="mb-8">
         <div class="flex flex-wrap gap-2 mb-4">
-          <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">tutorial</span><span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">workflows</span>
+          <span class="text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">tutorial</span><span class="text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">workflows</span>
         </div>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-ink tracking-tight font-display mb-4">
           Lanes X Superpower
         </h1>
-        <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+        <div class="flex items-center gap-4 text-sm text-ink-faint">
           <span>January 17, 2026</span>
           <span>&middot;</span>
           <span>9 min read</span>
         </div>
       </header>
 
-      <div class="prose dark:prose-invert max-w-none">
+      <div class="prose max-w-none">
         <h2>Introduction</h2>
 <p>When I first discovered the <strong>Superpowers</strong> plugin, I viewed it as a <strong>Lanes</strong> competitor. It provides users with skills that must be executed in a specific order to harness <strong>Claude</strong> and deliver consistent results—something <strong>Lanes</strong> also <strong>tries</strong> to achieve with <strong>its</strong> workflows feature. But quickly, I realised that <strong>Superpowers</strong> does not <strong>compete</strong> with <strong>Lanes</strong>; it <strong>synergises</strong> with it perfectly.</p>
 <p>The creators describe it as: <em>"A complete software development workflow for your coding agents..."</em> However, it is up to the user to ensure they follow each step manually. This can be repetitive and prone to error due to adherence issues—something <strong>Lanes</strong> can easily solve. Additionally, Superpowers lacks the session management functionality that <strong>Lanes</strong> provides.</p>
@@ -134,14 +241,14 @@
 <p>I decided this is something I definitely wanted to try, and since I was thinking of starting a blog I thought addings a blogging feature to Lanes would be a great project to try this on. So yes, this is a blog about how I created a blog :D.</p>
 <h2>Setup</h2>
 <p>Superpowers was very easy to setup, I followed their readme and ran the following in claude</p>
-<div class="relative my-4 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
+<div class="relative my-4 rounded-xl border border-border bg-surface-1 overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
           <div class="flex gap-2">
             <div class="w-3 h-3 rounded-full bg-red-500"></div>
             <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div class="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
-          <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">bash</div>
+          <div class="ml-4 text-xs text-ink-faint font-mono">bash</div>
         </div>
         <pre style="margin: 0; border-top-left-radius: 0; border-top-right-radius: 0;"><code class="language-{bash}">/plugin marketplace add obra/superpowers-marketplace
 /plugin install superpowers@superpowers-marketplace
@@ -149,14 +256,14 @@
       </div>
 <p>Then I had to enable Superpowers in my <code>settings.local.json</code> file. Lanes will make sure that your local settings file is copied into each of your worktrees, so you do not need to worry about untracked changes which you have defined in local files!</p>
 <p>I then had to define the Superpowers workflow, this was easy because Superpowers have a suggested workflow in their README. I kept the instructions in each workflow step very simple as I wanted to make sure to not conflict with any instructions in the skills, this means I also did not use an loops or agents in my workflow as Superpowers should manage this.</p>
-<div class="relative my-4 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
+<div class="relative my-4 rounded-xl border border-border bg-surface-1 overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
           <div class="flex gap-2">
             <div class="w-3 h-3 rounded-full bg-red-500"></div>
             <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div class="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
-          <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">superpowers.yaml</div>
+          <div class="ml-4 text-xs text-ink-faint font-mono">superpowers.yaml</div>
         </div>
         <pre style="margin: 0; border-top-left-radius: 0; border-top-right-radius: 0;"><code class="language-{superpowers.yaml}">name: superpower
 description: Standard starting workflow recommended by the Superpowers team
@@ -189,14 +296,14 @@ steps:
 </code></pre>
       </div>
 <p>I left my starting prompt to be super basic, as I wanted the brainstorming feature of Superpowers to do it's job in defining the scope of the work.</p>
-<div class="relative my-4 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
+<div class="relative my-4 rounded-xl border border-border bg-surface-1 overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
           <div class="flex gap-2">
             <div class="w-3 h-3 rounded-full bg-red-500"></div>
             <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div class="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
-          <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">prompt.txt</div>
+          <div class="ml-4 text-xs text-ink-faint font-mono">prompt.txt</div>
         </div>
         <pre style="margin: 0; border-top-left-radius: 0; border-top-right-radius: 0;"><code class="language-{prompt.txt}">I think the lanes website could use a blog. This can showcase projects    
 created by lanes or other lanes related content.
@@ -310,14 +417,14 @@ It would need to support variable text, images etc.
 </tr>
 </tbody></table>
 <p>The main agent used 87% of its context during the running of the complete workflow, breakdown below. 70-80k tokens were used for subagent management, this means creating the prompts for the subagents and processing their responses and general back and forth between the agent and subagent. This is a huge amount of the main window, but it is a lot less than would be needed if the main agent were to do all the work (Task 7 on its own used 98k of subagent tokens). This means that the blog implementation used 987k tokens to complete. If I were paying per token and used claude-sonnet it would have cost me about $10, I think this is a fair amount for the feature.</p>
-<div class="relative my-4 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
+<div class="relative my-4 rounded-xl border border-border bg-surface-1 overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
           <div class="flex gap-2">
             <div class="w-3 h-3 rounded-full bg-red-500"></div>
             <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div class="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
-          <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">context.txt</div>
+          <div class="ml-4 text-xs text-ink-faint font-mono">context.txt</div>
         </div>
         <pre style="margin: 0; border-top-left-radius: 0; border-top-right-radius: 0;"><code class="language-{context.txt}">⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛀ ⛁   glm-4.7 · 130k/200k tokens (65%)
 ⛀ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁ ⛁   ⛁ System prompt: 2.7k tokens (1.4%)
@@ -347,47 +454,83 @@ It would need to support variable text, images etc.
 
     </article>
     </main>
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6 flex-wrap">
-                <a href="../index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                <a href="index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                <a href="../docs.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
+
+    <!-- Footer -->
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="../index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Home</a>
+                    <a href="index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="../docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
+        syncThemeIcons();
 
-        updateIcons();
-
-        themeToggle.addEventListener('click', () => {
-            if (document.documentElement.classList.contains('dark')) {
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav ---
+        const mobileNav = document.getElementById('mobile-nav');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNav.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNav.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        mobileNav.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
         });
     </script>
 </body>

--- a/docs/blog/2026-01-26-lanes-1-1.html
+++ b/docs/blog/2026-01-26-lanes-1-1.html
@@ -6,6 +6,12 @@
     <title>Lanes 1.1: Changing Lanes In a Fast Agentic World - Lanes</title>
     <meta name="description" content="Manage multiple, isolated Claude Code sessions directly inside VS Code.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -13,19 +19,31 @@
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
-                    }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
+                    },
+                    fontFamily: {
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -33,67 +51,156 @@
         }
     </script>
     <style>
-        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
-        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; }
-        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; }
-        .prose p { margin: 1em 0; line-height: 1.7; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Mobile nav --- */
+        .mobile-nav {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        /* --- Prose styles --- */
+        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; color: var(--ink); }
+        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; color: var(--ink); }
+        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; color: var(--ink); }
+        .prose p { margin: 1em 0; line-height: 1.7; color: var(--ink-muted); }
         .prose ul, .prose ol { margin: 1em 0; padding-left: 1.5em; }
         .prose ul { list-style-type: disc; }
         .prose ul ul { list-style-type: circle; }
         .prose ul ul ul { list-style-type: square; }
         .prose ol { list-style-type: decimal; }
-        .prose li { margin: 0.5em 0; }
-        .prose a { color: #007acc; text-decoration: underline; }
-        .prose a:hover { color: #005a9e; }
-        .prose code { background: rgba(0,0,0,0.08); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace; }
-        .prose pre { background: #1e1e1e; color: #d4d4d4; padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid rgba(255,255,255,0.1); }
+        .prose li { margin: 0.5em 0; color: var(--ink-muted); }
+        .prose a { color: var(--accent); text-decoration: underline; }
+        .prose a:hover { opacity: 0.8; }
+        .prose code { background: var(--surface-2); color: var(--ink-muted); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, monospace; }
+        .prose pre { background: var(--surface-2); color: var(--ink-muted); padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid var(--border); }
         .prose pre code { background: transparent; padding: 0; color: inherit; }
-        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; }
-        .prose blockquote { border-left: 4px solid #007acc; padding-left: 1em; margin: 1em 0; color: #666; }
-        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid #e5e7eb; border-radius: 6px; overflow: hidden; }
-        .prose table thead { background: #f3f4f6; border-bottom: 2px solid #e5e7eb; }
-        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: #1f2937; border-right: 1px solid #e5e7eb; }
+        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; border: 1px solid var(--border); }
+        .prose blockquote { border-left: 4px solid var(--accent); padding-left: 1em; margin: 1em 0; color: var(--ink-muted); }
+        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+        .prose table thead { background: var(--surface-2); border-bottom: 2px solid var(--border); }
+        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: var(--ink); border-right: 1px solid var(--border); }
         .prose table th:last-child { border-right: none; }
-        .prose table td { padding: 0.75em 1em; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb; }
+        .prose table td { padding: 0.75em 1em; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); }
         .prose table td:last-child { border-right: none; }
         .prose table tbody tr:last-child td { border-bottom: none; }
-        .prose table tbody tr:nth-child(even) { background: #f9fafb; }
-        .prose table tbody tr:hover { background: #f3f4f6; }
-        .dark .prose table { border: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table thead { background: #2d2d2d; border-bottom: 2px solid rgba(255,255,255,0.1); }
-        .dark .prose table th { color: #f9fafb; border-right: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table td { border-right: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table tbody tr:last-child td { border-bottom: none; }
-        .dark .prose table tbody tr:nth-child(even) { background: rgba(255,255,255,0.05); }
-        .dark .prose table tbody tr:hover { background: rgba(255,255,255,0.1); }
-        .dark .prose code { background: rgba(255,255,255,0.1); }
+        .prose table tbody tr:nth-child(even) { background: var(--surface-1); }
+        .prose table tbody tr:hover { background: var(--surface-2); }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav" class="mobile-nav fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="../index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="../index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="../index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Blog</a>
+            <a href="../docs.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
+
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                    <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                    <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="../index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                        <a href="../index.html#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="../index.html#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="index.html" class="text-vscode-accent font-medium transition-colors">Blog</a>
-                        <a href="../docs.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="../index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="../index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="../index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Blog</a>
+                    <a href="../docs.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-mobile" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
                 </div>
             </div>
@@ -103,24 +210,24 @@
 
     <article class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
       <nav class="mb-8 text-sm">
-        <a href="index.html" class="text-vscode-accent hover:underline">&larr; Back to Blog</a>
+        <a href="index.html" class="text-accent hover:underline">&larr; Back to Blog</a>
       </nav>
 
       <header class="mb-8">
         <div class="flex flex-wrap gap-2 mb-4">
-          <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">release</span>
+          <span class="text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">release</span>
         </div>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-ink tracking-tight font-display mb-4">
           Lanes 1.1: Changing Lanes In a Fast Agentic World
         </h1>
-        <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+        <div class="flex items-center gap-4 text-sm text-ink-faint">
           <span>January 26, 2026</span>
           <span>&middot;</span>
           <span>5 min read</span>
         </div>
       </header>
 
-      <div class="prose dark:prose-invert max-w-none">
+      <div class="prose max-w-none">
         <p>In December, it felt like the world finally woke up to <strong>Claude Code</strong> This sudden fanaticism caught me by surprise, as a long term Claude Code user I hadn't really noticed much of a difference since the release of Claude's Opus 4.5 in November and to be honest, Opus wasn't much of an improvement over Sonnet 4.5 which released in September.</p>
 <p>Despite this, the hype is justified, Claude Code has changed how I work. But let’s be real: it’s not perfect. Anthropic is certainly aware of this, recently they have been seriously ramping up development of new features in Claude Code, often implementing features inspired by the open-source community.</p>
 <p>Key features introduced by Anthropic in the last 2 weeks:</p>
@@ -188,47 +295,83 @@
 
     </article>
     </main>
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6 flex-wrap">
-                <a href="../index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                <a href="index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                <a href="../docs.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
+
+    <!-- Footer -->
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="../index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Home</a>
+                    <a href="index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="../docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
+        syncThemeIcons();
 
-        updateIcons();
-
-        themeToggle.addEventListener('click', () => {
-            if (document.documentElement.classList.contains('dark')) {
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav ---
+        const mobileNav = document.getElementById('mobile-nav');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNav.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNav.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        mobileNav.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
         });
     </script>
 </body>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -6,6 +6,12 @@
     <title>Blog - Lanes</title>
     <meta name="description" content="Manage multiple, isolated Claude Code sessions directly inside VS Code.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -13,19 +19,31 @@
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
-                    }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
+                    },
+                    fontFamily: {
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -33,67 +51,156 @@
         }
     </script>
     <style>
-        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
-        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; }
-        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; }
-        .prose p { margin: 1em 0; line-height: 1.7; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Mobile nav --- */
+        .mobile-nav {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        /* --- Prose styles --- */
+        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; color: var(--ink); }
+        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; color: var(--ink); }
+        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; color: var(--ink); }
+        .prose p { margin: 1em 0; line-height: 1.7; color: var(--ink-muted); }
         .prose ul, .prose ol { margin: 1em 0; padding-left: 1.5em; }
         .prose ul { list-style-type: disc; }
         .prose ul ul { list-style-type: circle; }
         .prose ul ul ul { list-style-type: square; }
         .prose ol { list-style-type: decimal; }
-        .prose li { margin: 0.5em 0; }
-        .prose a { color: #007acc; text-decoration: underline; }
-        .prose a:hover { color: #005a9e; }
-        .prose code { background: rgba(0,0,0,0.08); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace; }
-        .prose pre { background: #1e1e1e; color: #d4d4d4; padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid rgba(255,255,255,0.1); }
+        .prose li { margin: 0.5em 0; color: var(--ink-muted); }
+        .prose a { color: var(--accent); text-decoration: underline; }
+        .prose a:hover { opacity: 0.8; }
+        .prose code { background: var(--surface-2); color: var(--ink-muted); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, monospace; }
+        .prose pre { background: var(--surface-2); color: var(--ink-muted); padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid var(--border); }
         .prose pre code { background: transparent; padding: 0; color: inherit; }
-        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; }
-        .prose blockquote { border-left: 4px solid #007acc; padding-left: 1em; margin: 1em 0; color: #666; }
-        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid #e5e7eb; border-radius: 6px; overflow: hidden; }
-        .prose table thead { background: #f3f4f6; border-bottom: 2px solid #e5e7eb; }
-        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: #1f2937; border-right: 1px solid #e5e7eb; }
+        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; border: 1px solid var(--border); }
+        .prose blockquote { border-left: 4px solid var(--accent); padding-left: 1em; margin: 1em 0; color: var(--ink-muted); }
+        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+        .prose table thead { background: var(--surface-2); border-bottom: 2px solid var(--border); }
+        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: var(--ink); border-right: 1px solid var(--border); }
         .prose table th:last-child { border-right: none; }
-        .prose table td { padding: 0.75em 1em; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb; }
+        .prose table td { padding: 0.75em 1em; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); }
         .prose table td:last-child { border-right: none; }
         .prose table tbody tr:last-child td { border-bottom: none; }
-        .prose table tbody tr:nth-child(even) { background: #f9fafb; }
-        .prose table tbody tr:hover { background: #f3f4f6; }
-        .dark .prose table { border: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table thead { background: #2d2d2d; border-bottom: 2px solid rgba(255,255,255,0.1); }
-        .dark .prose table th { color: #f9fafb; border-right: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table td { border-right: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table tbody tr:last-child td { border-bottom: none; }
-        .dark .prose table tbody tr:nth-child(even) { background: rgba(255,255,255,0.05); }
-        .dark .prose table tbody tr:hover { background: rgba(255,255,255,0.1); }
-        .dark .prose code { background: rgba(255,255,255,0.1); }
+        .prose table tbody tr:nth-child(even) { background: var(--surface-1); }
+        .prose table tbody tr:hover { background: var(--surface-2); }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav" class="mobile-nav fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="../index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="../index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="../index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Blog</a>
+            <a href="../docs.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
+
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                    <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                    <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="../index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                        <a href="../index.html#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="../index.html#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="index.html" class="text-vscode-accent font-medium transition-colors">Blog</a>
-                        <a href="../docs.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="../index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="../index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="../index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Blog</a>
+                    <a href="../docs.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-mobile" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
                 </div>
             </div>
@@ -103,56 +210,56 @@
 
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12">
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-ink tracking-tight font-display mb-4">
           Lanes Blog
         </h1>
-        <p class="text-lg text-gray-600 dark:text-gray-400">
+        <p class="text-lg text-ink-muted">
           Projects, tutorials, and updates from the Lanes community
         </p>
       </div>
 
       <div class="flex gap-2 mb-8 flex-wrap justify-center">
-        <button class="tag-btn active px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-vscode-accent text-white" data-tag="all">All Posts</button>
-        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700" data-tag="release">release</button>
-        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700" data-tag="tutorial">tutorial</button>
-        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700" data-tag="workflows">workflows</button>
+        <button class="tag-btn active px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-accent text-white" data-tag="all">All Posts</button>
+        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-surface-2 text-ink-muted hover:bg-surface-3" data-tag="release">release</button>
+        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-surface-2 text-ink-muted hover:bg-surface-3" data-tag="tutorial">tutorial</button>
+        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-surface-2 text-ink-muted hover:bg-surface-3" data-tag="workflows">workflows</button>
       </div>
 
       <div class="grid gap-6" id="posts-container">
 
-        <article class="bg-white dark:bg-[#1e1e1e] rounded-xl border border-gray-200 dark:border-white/10 p-6 hover:border-vscode-accent/50 transition-colors">
+        <article class="bg-surface-0 rounded-xl border border-border p-6 hover:border-accent/40 transition-colors">
           <div class="flex flex-wrap gap-2 mb-3">
-            <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">release</span>
+            <span class="tag-text text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">release</span>
           </div>
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-3">
-            <a href="2026-01-26-lanes-1-1.html" class="hover:text-vscode-accent transition-colors">Lanes 1.1: Changing Lanes In a Fast Agentic World</a>
+          <h2 class="text-2xl font-bold text-ink mb-3 font-display">
+            <a href="2026-01-26-lanes-1-1.html" class="hover:text-accent transition-colors">Lanes 1.1: Changing Lanes In a Fast Agentic World</a>
           </h2>
-          <p class="text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">Lanes 1.1 has just release. Learn all about it&#039;s new features here.</p>
-          <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+          <p class="text-ink-muted mb-4 line-clamp-2">Lanes 1.1 has just release. Learn all about it&#039;s new features here.</p>
+          <div class="flex items-center gap-4 text-sm text-ink-faint">
             <span>January 26, 2026</span>
             <span>&middot;</span>
             <span>5 min read</span>
           </div>
-          <a href="2026-01-26-lanes-1-1.html" class="inline-flex items-center gap-2 text-vscode-accent hover:underline font-medium mt-4">
+          <a href="2026-01-26-lanes-1-1.html" class="inline-flex items-center gap-2 text-accent hover:underline font-medium mt-4">
             Read more
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
           </a>
         </article>
 
-        <article class="bg-white dark:bg-[#1e1e1e] rounded-xl border border-gray-200 dark:border-white/10 p-6 hover:border-vscode-accent/50 transition-colors">
+        <article class="bg-surface-0 rounded-xl border border-border p-6 hover:border-accent/40 transition-colors">
           <div class="flex flex-wrap gap-2 mb-3">
-            <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">tutorial</span><span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">workflows</span>
+            <span class="tag-text text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">tutorial</span><span class="tag-text text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">workflows</span>
           </div>
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-3">
-            <a href="2026-01-17-lanes-x-superpower.html" class="hover:text-vscode-accent transition-colors">Lanes X Superpower</a>
+          <h2 class="text-2xl font-bold text-ink mb-3 font-display">
+            <a href="2026-01-17-lanes-x-superpower.html" class="hover:text-accent transition-colors">Lanes X Superpower</a>
           </h2>
-          <p class="text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">Learn how to use Lanes&#039; structured workflow system with the Superpowers skills plugin to guide AI agents through complex tasks.</p>
-          <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+          <p class="text-ink-muted mb-4 line-clamp-2">Learn how to use Lanes&#039; structured workflow system with the Superpowers skills plugin to guide AI agents through complex tasks.</p>
+          <div class="flex items-center gap-4 text-sm text-ink-faint">
             <span>January 17, 2026</span>
             <span>&middot;</span>
             <span>9 min read</span>
           </div>
-          <a href="2026-01-17-lanes-x-superpower.html" class="inline-flex items-center gap-2 text-vscode-accent hover:underline font-medium mt-4">
+          <a href="2026-01-17-lanes-x-superpower.html" class="inline-flex items-center gap-2 text-accent hover:underline font-medium mt-4">
             Read more
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
           </a>
@@ -168,7 +275,7 @@
         // Store original order
         const postsData = Array.from(allPosts).map(article => ({
           element: article,
-          tags: Array.from(article.querySelectorAll('.text-blue-600')).map(el => el.textContent.toLowerCase())
+          tags: Array.from(article.querySelectorAll('.tag-text')).map(el => el.textContent.toLowerCase())
         }));
 
         tagBtns.forEach(btn => {
@@ -177,11 +284,11 @@
 
             // Update active button
             tagBtns.forEach(b => {
-              b.classList.remove('bg-vscode-accent', 'text-white');
-              b.classList.add('bg-gray-200', 'dark:bg-gray-800', 'text-gray-700', 'dark:text-gray-300');
+              b.classList.remove('bg-accent', 'text-white');
+              b.classList.add('bg-surface-2', 'text-ink-muted');
             });
-            btn.classList.remove('bg-gray-200', 'dark:bg-gray-800', 'text-gray-700', 'dark:text-gray-300');
-            btn.classList.add('bg-vscode-accent', 'text-white');
+            btn.classList.remove('bg-surface-2', 'text-ink-muted');
+            btn.classList.add('bg-accent', 'text-white');
 
             // Filter posts
             postsContainer.innerHTML = '';
@@ -195,47 +302,83 @@
       </script>
     </div>
     </main>
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6 flex-wrap">
-                <a href="../index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                <a href="index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                <a href="../docs.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
+
+    <!-- Footer -->
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="../index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Home</a>
+                    <a href="index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="../docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
+        syncThemeIcons();
 
-        updateIcons();
-
-        themeToggle.addEventListener('click', () => {
-            if (document.documentElement.classList.contains('dark')) {
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav ---
+        const mobileNav = document.getElementById('mobile-nav');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNav.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNav.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        mobileNav.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
         });
     </script>
 </body>

--- a/docs/docs-shell.html
+++ b/docs/docs-shell.html
@@ -1,0 +1,623 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Documentation - Lanes</title>
+    <meta name="description" content="Complete documentation for Lanes - Learn how to manage multiple AI coding sessions (Claude Code, Codex CLI) in VS Code using Git worktrees.">
+    <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    colors: {
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
+                    },
+                    fontFamily: {
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
+                }
+            }
+        }
+    </script>
+    <script>
+        if (localStorage.theme === 'light') {
+            document.documentElement.classList.remove('dark');
+        } else {
+            document.documentElement.classList.add('dark');
+        }
+    </script>
+    <style>
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Sidebar styling --- */
+        .sidebar-link {
+            transition: all 0.2s ease;
+            color: var(--ink-muted);
+        }
+        .sidebar-link:hover {
+            background-color: var(--surface-2);
+            color: var(--ink);
+        }
+        .sidebar-link.active {
+            background-color: var(--accent);
+            color: #ffffff !important;
+        }
+        .sidebar-link.active svg {
+            color: #ffffff;
+        }
+
+        /* Mobile nav link styling */
+        .mobile-nav-link {
+            transition: all 0.2s ease;
+            color: var(--ink-muted);
+        }
+        .mobile-nav-link:hover {
+            background-color: var(--surface-2);
+            color: var(--ink);
+        }
+        .mobile-nav-link.active {
+            background-color: var(--accent);
+            color: #ffffff !important;
+        }
+        .mobile-nav-link.active svg {
+            color: #ffffff;
+        }
+
+        /* Section transitions */
+        .doc-section {
+            animation: fadeIn 0.3s ease;
+        }
+        @keyframes fadeIn {
+            from { opacity: 0; transform: translateY(10px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+
+        /* Sticky sidebar */
+        @media (min-width: 1024px) {
+            .docs-sidebar {
+                position: sticky;
+                top: 5rem;
+                height: fit-content;
+                max-height: calc(100vh - 7rem);
+                overflow-y: auto;
+            }
+        }
+
+        /* --- Mobile nav drawer --- */
+        .mobile-nav-drawer {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav-drawer.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+    </style>
+</head>
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav-drawer" class="mobile-nav-drawer fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="blog/index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Blog</a>
+            <a href="docs.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
+
+    <!-- Navigation -->
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <a href="index.html" class="flex items-center gap-2.5">
+                        <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                        <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    </a>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
+                </div>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="blog/index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-m" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="pt-20 pb-16">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-12 lg:gap-8">
+
+                <!-- Sidebar Navigation -->
+                <aside class="hidden lg:block lg:col-span-3 docs-sidebar">
+                    <div class="bg-surface-1 rounded-xl border border-border p-4">
+                        <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Sessions</h3>
+                        <nav class="space-y-1">
+                            <button data-section="create-session" class="sidebar-link active w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                <span>Create a New Session</span>
+                            </button>
+                            <button data-section="worktrees" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                <span>Understanding Worktrees</span>
+                            </button>
+                            <button data-section="permission-modes" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                <span>Permission Modes</span>
+                            </button>
+                            <button data-section="git-review" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                <span>Reviewing Changes</span>
+                            </button>
+                        </nav>
+
+                        <!-- Features Section Group -->
+                        <div class="mt-6 pt-4 border-t border-border">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Features</h3>
+                            <nav class="space-y-1">
+                                <button data-section="multi-agent" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                                    <span>Multi-Agent Support</span>
+                                </button>
+                                <button data-section="file-attachments" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
+                                    <span>File Attachments</span>
+                                </button>
+                                <button data-section="tmux-terminal" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    <span>Tmux Terminal</span>
+                                </button>
+                                <button data-section="local-settings" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <span>Local Settings</span>
+                                </button>
+                            </nav>
+                        </div>
+
+                        <!-- Workflow Section Group -->
+                        <div class="mt-6 pt-4 border-t border-border">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Workflows</h3>
+                            <nav class="space-y-1">
+                                <button data-section="workflows-intro" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                    <span>Introduction to Workflows</span>
+                                </button>
+                                <button data-section="workflow-structure" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
+                                    <span>Workflow Structure</span>
+                                </button>
+                                <button data-section="creating-workflow" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path></svg>
+                                    <span>Creating a Workflow</span>
+                                </button>
+                                <button data-section="lanes-mcp" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <span>Lanes MCP</span>
+                                </button>
+                            </nav>
+
+                        <!-- Contributing -->
+                        <div class="border-t border-border pt-4">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Contributing</h3>
+                            <nav class="space-y-1">
+                                <button data-section="contributing" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
+                                    <span>Contributing</span>
+                                </button>
+                            </nav>
+                        </div>
+                        </div>
+                    </div>
+                </aside>
+
+                <!-- Mobile Navigation (collapsible) -->
+                <div class="lg:hidden mb-8">
+                    <button id="mobile-nav-toggle" class="w-full bg-surface-1 rounded-xl border border-border p-4 flex items-center justify-between text-ink font-medium">
+                        <span id="mobile-nav-current">Create a New Session</span>
+                        <svg class="w-5 h-5 transition-transform" id="mobile-nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+                    </button>
+                    <nav id="mobile-nav" class="hidden mt-2 bg-surface-1 rounded-xl border border-border p-4">
+                        <!-- Getting Started -->
+                        <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Documentation</p>
+                        <div class="space-y-1 mb-4">
+                            <button data-section="create-session" class="mobile-nav-link active w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                <span>Create a New Session</span>
+                            </button>
+                            <button data-section="worktrees" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                <span>Understanding Worktrees</span>
+                            </button>
+                            <button data-section="permission-modes" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                <span>Permission Modes</span>
+                            </button>
+                            <button data-section="git-review" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                <span>Reviewing Changes</span>
+                            </button>
+                        </div>
+                        <!-- Features -->
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Features</p>
+                            <div class="space-y-1 mb-4">
+                                <button data-section="multi-agent" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                                    <span>Multi-Agent Support</span>
+                                </button>
+                                <button data-section="file-attachments" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
+                                    <span>File Attachments</span>
+                                </button>
+                                <button data-section="tmux-terminal" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    <span>Tmux Terminal</span>
+                                </button>
+                                <button data-section="local-settings" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <span>Local Settings</span>
+                                </button>
+                            </div>
+                        </div>
+                        <!-- Workflows -->
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Workflows</p>
+                            <div class="space-y-1">
+                                <button data-section="workflows-intro" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                    <span>Introduction to Workflows</span>
+                                </button>
+                                <button data-section="workflow-structure" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
+                                    <span>Workflow Structure</span>
+                                </button>
+                                <button data-section="creating-workflow" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path></svg>
+                                    <span>Creating a Workflow</span>
+                                </button>
+                                <button data-section="lanes-mcp" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <span>Lanes MCP</span>
+                                </button>
+                            </div>
+                        </div>
+                        <!-- Contributing -->
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Contributing</p>
+                            <div class="space-y-1">
+                                <button data-section="contributing" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
+                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
+                                    <span>Contributing</span>
+                                </button>
+                            </div>
+                        </div>
+                    </nav>
+                </div>
+
+                <!-- Main Documentation Content -->
+                <div class="lg:col-span-9">
+                    <div class="max-w-4xl mx-auto">
+
+                        <!-- Page Header -->
+                        <div class="mb-8">
+                            <h1 class="text-4xl font-bold text-ink font-display mb-2">Documentation</h1>
+                            <p class="text-lg text-ink-muted">
+                                Everything you need to get started with Lanes.
+                            </p>
+                        </div>
+
+                        <!-- SECTIONS -->
+
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="blog/index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script>
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
+        }
+        syncThemeIcons();
+
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
+                document.documentElement.classList.remove('dark');
+                localStorage.theme = 'light';
+            } else {
+                document.documentElement.classList.add('dark');
+                localStorage.theme = 'dark';
+            }
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-m').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav drawer ---
+        const mobileNavDrawer = document.getElementById('mobile-nav-drawer');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNavDrawer.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNavDrawer.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        // Close mobile nav on link click
+        mobileNavDrawer.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
+        });
+
+        // --- Section navigation ---
+        const sectionNames = {
+            'create-session': 'Create a New Session',
+            'worktrees': 'Understanding Worktrees',
+            'permission-modes': 'Permission Modes',
+            'git-review': 'Reviewing Changes',
+            'multi-agent': 'Multi-Agent Support',
+            'file-attachments': 'File Attachments',
+            'tmux-terminal': 'Tmux Terminal',
+            'local-settings': 'Local Settings',
+            'workflows-intro': 'Introduction to Workflows',
+            'workflow-structure': 'Workflow Structure',
+            'creating-workflow': 'Creating a Workflow',
+            'lanes-mcp': 'Lanes MCP',
+            'contributing': 'Contributing'
+        };
+
+        // Docs sidebar mobile navigation toggle
+        const docsNavToggle = document.getElementById('mobile-nav-toggle');
+        const docsNav = document.getElementById('mobile-nav');
+        const docsNavIcon = document.getElementById('mobile-nav-icon');
+        const docsNavCurrent = document.getElementById('mobile-nav-current');
+
+        docsNavToggle.addEventListener('click', () => {
+            docsNav.classList.toggle('hidden');
+            docsNavIcon.style.transform = docsNav.classList.contains('hidden') ? 'rotate(0deg)' : 'rotate(180deg)';
+        });
+
+        // Section navigation functionality
+        const sidebarLinks = document.querySelectorAll('.sidebar-link');
+        const mobileNavLinks = document.querySelectorAll('.mobile-nav-link');
+        const sections = document.querySelectorAll('.doc-section');
+
+        function showSection(sectionId) {
+            // Hide all sections
+            sections.forEach(section => {
+                section.classList.add('hidden');
+            });
+
+            // Show the target section
+            const targetSection = document.getElementById(sectionId);
+            if (targetSection) {
+                targetSection.classList.remove('hidden');
+            }
+
+            // Update sidebar active state
+            sidebarLinks.forEach(link => {
+                link.classList.remove('active');
+                if (link.dataset.section === sectionId) {
+                    link.classList.add('active');
+                }
+            });
+
+            // Update mobile nav active state
+            mobileNavLinks.forEach(link => {
+                link.classList.remove('active');
+                if (link.dataset.section === sectionId) {
+                    link.classList.add('active');
+                }
+            });
+
+            // Update mobile nav current section text
+            if (docsNavCurrent && sectionNames[sectionId]) {
+                docsNavCurrent.textContent = sectionNames[sectionId];
+            }
+
+            // Close docs mobile nav
+            docsNav.classList.add('hidden');
+            docsNavIcon.style.transform = 'rotate(0deg)';
+
+            // Scroll to top of content area
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+
+            // Update URL hash without triggering scroll
+            history.replaceState(null, null, `#${sectionId}`);
+        }
+
+        // Add click handlers to sidebar links
+        sidebarLinks.forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const sectionId = link.dataset.section;
+                showSection(sectionId);
+            });
+        });
+
+        // Add click handlers to mobile nav links
+        mobileNavLinks.forEach(link => {
+            link.addEventListener('click', (e) => {
+                e.preventDefault();
+                const sectionId = link.dataset.section;
+                showSection(sectionId);
+            });
+        });
+
+        // Handle internal anchor links to sections
+        document.querySelectorAll('a[href^="#"]').forEach(link => {
+            link.addEventListener('click', (e) => {
+                const sectionId = link.getAttribute('href').slice(1);
+                if (sectionNames[sectionId]) {
+                    e.preventDefault();
+                    showSection(sectionId);
+                }
+            });
+        });
+
+        // Handle initial load with hash in URL
+        window.addEventListener('load', () => {
+            const hash = window.location.hash.slice(1);
+            if (hash && sectionNames[hash]) {
+                showSection(hash);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -6,6 +6,12 @@
     <title>Documentation - Lanes</title>
     <meta name="description" content="Complete documentation for Lanes - Learn how to manage multiple AI coding sessions (Claude Code, Codex CLI) in VS Code using Git worktrees.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -13,23 +19,31 @@
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
                     },
                     fontFamily: {
-                        mono: ['SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-                        sans: ['system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif']
-                    }
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -37,29 +51,56 @@
         }
     </script>
     <style>
-        .terminal-shadow { box-shadow: 0 10px 30px -10px rgba(0,0,0,0.5); }
-        .glow { box-shadow: 0 0 20px rgba(0, 122, 204, 0.3); }
-        @keyframes pulse-slow { 0%, 100% { opacity: 1; } 50% { opacity: 0.7; } }
-        .animate-pulse-slow { animation: pulse-slow 2s ease-in-out infinite; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
 
-        /* Sidebar styling */
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Sidebar styling --- */
         .sidebar-link {
             transition: all 0.2s ease;
-            color: #6b7280;
-        }
-        .dark .sidebar-link {
-            color: #9ca3af;
+            color: var(--ink-muted);
         }
         .sidebar-link:hover {
-            background-color: rgba(0, 0, 0, 0.05);
-            color: #111827;
-        }
-        .dark .sidebar-link:hover {
-            background-color: rgba(255, 255, 255, 0.05);
-            color: #ffffff;
+            background-color: var(--surface-2);
+            color: var(--ink);
         }
         .sidebar-link.active {
-            background-color: #007acc;
+            background-color: var(--accent);
             color: #ffffff !important;
         }
         .sidebar-link.active svg {
@@ -69,21 +110,14 @@
         /* Mobile nav link styling */
         .mobile-nav-link {
             transition: all 0.2s ease;
-            color: #6b7280;
-        }
-        .dark .mobile-nav-link {
-            color: #9ca3af;
+            color: var(--ink-muted);
         }
         .mobile-nav-link:hover {
-            background-color: rgba(0, 0, 0, 0.05);
-            color: #111827;
-        }
-        .dark .mobile-nav-link:hover {
-            background-color: rgba(255, 255, 255, 0.05);
-            color: #ffffff;
+            background-color: var(--surface-2);
+            color: var(--ink);
         }
         .mobile-nav-link.active {
-            background-color: #007acc;
+            background-color: var(--accent);
             color: #ffffff !important;
         }
         .mobile-nav-link.active svg {
@@ -103,82 +137,113 @@
         @media (min-width: 1024px) {
             .docs-sidebar {
                 position: sticky;
-                top: 6rem;
+                top: 5rem;
                 height: fit-content;
-                max-height: calc(100vh - 8rem);
+                max-height: calc(100vh - 7rem);
                 overflow-y: auto;
             }
         }
+
+        /* --- Mobile nav drawer --- */
+        .mobile-nav-drawer {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav-drawer.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased selection:bg-vscode-accent selection:text-white transition-colors duration-200">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav-drawer" class="mobile-nav-drawer fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="blog/index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Blog</a>
+            <a href="docs.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
 
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <a href="index.html" class="flex items-center gap-2">
-                        <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                        <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <a href="index.html" class="flex items-center gap-2.5">
+                        <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                        <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
                     </a>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <!-- Desktop Navigation -->
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                        <a href="index.html#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="index.html#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="blog/index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                        <a href="docs.html" class="text-vscode-accent font-medium transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="blog/index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                     </button>
                 </div>
-
-                <!-- Mobile Navigation Controls -->
-                <div class="flex md:hidden items-center gap-2">
-                    <button id="theme-toggle-mobile" class="p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon-mobile" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon-mobile" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-m" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
                     </button>
-                    <button id="main-mobile-nav-toggle" class="p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle navigation menu">
-                        <svg id="hamburger-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-                        <svg id="close-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
-                </div>
-            </div>
-
-            <!-- Mobile Navigation Menu -->
-            <div id="main-mobile-nav" class="hidden md:hidden border-t border-gray-200 dark:border-white/10 bg-white/95 dark:bg-vscode-bg/95">
-                <div class="px-4 py-3 space-y-2">
-                    <a href="index.html" class="block py-2 px-3 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors">Home</a>
-                    <a href="index.html#features" class="block py-2 px-3 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors">Features</a>
-                    <a href="index.html#how-it-works" class="block py-2 px-3 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors">How it Works</a>
-                    <a href="blog/index.html" class="block py-2 px-3 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors">Blog</a>
-                    <a href="docs.html" class="block py-2 px-3 text-vscode-accent font-medium hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors">Docs</a>
-                    <a href="https://github.com/FilipeJesus/lanes" class="block py-2 px-3 bg-vscode-accent hover:bg-blue-600 text-white rounded-md font-medium transition-all text-center">View on GitHub</a>
                 </div>
             </div>
         </div>
     </nav>
 
     <!-- Main Content -->
-    <main class="pt-24 pb-16">
+    <main class="pt-20 pb-16">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="lg:grid lg:grid-cols-12 lg:gap-8">
 
                 <!-- Sidebar Navigation -->
                 <aside class="hidden lg:block lg:col-span-3 docs-sidebar">
-                    <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-4">
-                        <h3 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Sessions</h3>
+                    <div class="bg-surface-1 rounded-xl border border-border p-4">
+                        <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Sessions</h3>
                         <nav class="space-y-1">
                             <button data-section="create-session" class="sidebar-link active w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -199,8 +264,8 @@
                         </nav>
 
                         <!-- Features Section Group -->
-                        <div class="mt-6 pt-4 border-t border-gray-200 dark:border-white/10">
-                            <h3 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Features</h3>
+                        <div class="mt-6 pt-4 border-t border-border">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Features</h3>
                             <nav class="space-y-1">
                                 <button data-section="multi-agent" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
@@ -222,8 +287,8 @@
                         </div>
 
                         <!-- Workflow Section Group -->
-                        <div class="mt-6 pt-4 border-t border-gray-200 dark:border-white/10">
-                            <h3 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Workflows</h3>
+                        <div class="mt-6 pt-4 border-t border-border">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Workflows</h3>
                             <nav class="space-y-1">
                                 <button data-section="workflows-intro" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
@@ -244,8 +309,8 @@
                             </nav>
 
                         <!-- Contributing -->
-                        <div class="border-t border-gray-200 dark:border-white/10 pt-4">
-                            <h3 class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-3">Contributing</h3>
+                        <div class="border-t border-border pt-4">
+                            <h3 class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-3">Contributing</h3>
                             <nav class="space-y-1">
                                 <button data-section="contributing" class="sidebar-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
@@ -259,13 +324,13 @@
 
                 <!-- Mobile Navigation (collapsible) -->
                 <div class="lg:hidden mb-8">
-                    <button id="mobile-nav-toggle" class="w-full bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-4 flex items-center justify-between text-gray-900 dark:text-white font-medium">
+                    <button id="mobile-nav-toggle" class="w-full bg-surface-1 rounded-xl border border-border p-4 flex items-center justify-between text-ink font-medium">
                         <span id="mobile-nav-current">Create a New Session</span>
                         <svg class="w-5 h-5 transition-transform" id="mobile-nav-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
                     </button>
-                    <nav id="mobile-nav" class="hidden mt-2 bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-4">
+                    <nav id="mobile-nav" class="hidden mt-2 bg-surface-1 rounded-xl border border-border p-4">
                         <!-- Getting Started -->
-                        <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 px-3">Documentation</p>
+                        <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Documentation</p>
                         <div class="space-y-1 mb-4">
                             <button data-section="create-session" class="mobile-nav-link active w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                 <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
@@ -285,8 +350,8 @@
                             </button>
                         </div>
                         <!-- Features -->
-                        <div class="border-t border-gray-200 dark:border-white/10 pt-3">
-                            <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 px-3">Features</p>
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Features</p>
                             <div class="space-y-1 mb-4">
                                 <button data-section="multi-agent" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
@@ -307,8 +372,8 @@
                             </div>
                         </div>
                         <!-- Workflows -->
-                        <div class="border-t border-gray-200 dark:border-white/10 pt-3">
-                            <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 px-3">Workflows</p>
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Workflows</p>
                             <div class="space-y-1">
                                 <button data-section="workflows-intro" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
@@ -329,8 +394,8 @@
                             </div>
                         </div>
                         <!-- Contributing -->
-                        <div class="border-t border-gray-200 dark:border-white/10 pt-3">
-                            <p class="text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 px-3">Contributing</p>
+                        <div class="border-t border-border pt-3">
+                            <p class="text-xs font-bold text-ink-faint uppercase tracking-wide font-mono mb-2 px-3">Contributing</p>
                             <div class="space-y-1">
                                 <button data-section="contributing" class="mobile-nav-link w-full flex items-center gap-3 py-2 px-3 text-sm text-left rounded-lg">
                                     <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
@@ -343,46 +408,45 @@
 
                 <!-- Main Documentation Content -->
                 <div class="lg:col-span-9">
-                    <div class="prose prose-gray dark:prose-invert max-w-4xl mx-auto">
+                    <div class="max-w-4xl mx-auto">
 
                         <!-- Page Header -->
                         <div class="mb-8">
-                            <h1 class="text-4xl font-bold text-gray-900 dark:text-white mb-2">Documentation</h1>
-                            <p class="text-lg text-gray-600 dark:text-gray-400">
+                            <h1 class="text-4xl font-bold text-ink font-display mb-2">Documentation</h1>
+                            <p class="text-lg text-ink-muted">
                                 Everything you need to get started with Lanes.
                             </p>
                         </div>
 
-                        <!-- Section 1: Create a New Session -->
-                        <section id="create-session" class="doc-section mb-16 scroll-mt-24">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                                                <section id="create-session" class="doc-section mb-16 scroll-mt-24">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Create a New Session</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Create a New Session</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Creating a new session in Lanes is straightforward. Each session is isolated and runs in its own Git worktree, giving Claude Code a clean workspace to work in without affecting your main codebase.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- Step 1: Prerequisites -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Before You Start</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Before You Start</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Make sure you have:
                                         </p>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4">
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
                                             <li>Opened a folder or workspace in VS Code</li>
-                                            <li>A Git repository initialized (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">git init</code> if needed)</li>
-                                            <li>Claude Code installed globally (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">npm install -g @anthropic-ai/claude-code</code>)</li>
-                                            <li>Logged into Claude (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">claude login</code>)</li>
-                                            <li><code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">jq</code> installed for status tracking (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">brew install jq</code> on macOS or <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">apt install jq</code> on Linux)</li>
-                                            <li><em>Optional:</em> Codex CLI installed (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">npm install -g @openai/codex</code>) for OpenAI agent support</li>
+                                            <li>A Git repository initialized (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">git init</code> if needed)</li>
+                                            <li>Claude Code installed globally (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">npm install -g @anthropic-ai/claude-code</code>)</li>
+                                            <li>Logged into Claude (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">claude login</code>)</li>
+                                            <li><code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">jq</code> installed for status tracking (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">brew install jq</code> on macOS or <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">apt install jq</code> on Linux)</li>
+                                            <li><em>Optional:</em> Codex CLI installed (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">npm install -g @openai/codex</code>) for OpenAI agent support</li>
                                         </ul>
-                                        <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3 mt-3">
-                                            <p class="text-xs text-yellow-800 dark:text-yellow-300">
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 mt-3">
+                                            <p class="text-xs text-amber-600 dark:text-amber-400">
                                                 <strong>Note:</strong> Lanes currently supports macOS and Linux. Windows is not yet supported (WSL may work).
                                             </p>
                                         </div>
@@ -390,17 +454,17 @@
 
                                     <!-- Step 2: Open Lanes Sidebar -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Step 1: Open the Lanes Sidebar</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 1: Open the Lanes Sidebar</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Click the Lanes icon in the VS Code activity bar (the vertical bar on the far left) to open the Lanes panel. You'll see the session creation form at the top.
                                         </p>
-                                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mt-3">
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4 mt-3">
                                             <div class="flex gap-2">
-                                                <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <svg class="w-5 h-5 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-blue-800 dark:text-blue-300 font-medium">Tip</p>
-                                                    <p class="text-sm text-blue-700 dark:text-blue-400 mt-1">
-                                                        Can't find the Lanes icon? Use the command palette (<kbd class="text-xs bg-blue-100 dark:bg-blue-800 px-1 rounded">Cmd+Shift+P</kbd>) and search for "Lanes: Create Session".
+                                                    <p class="text-sm text-accent font-medium">Tip</p>
+                                                    <p class="text-sm text-accent mt-1">
+                                                        Can't find the Lanes icon? Use the command palette (<kbd class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">Cmd+Shift+P</kbd>) and search for "Lanes: Create Session".
                                                     </p>
                                                 </div>
                                             </div>
@@ -409,169 +473,169 @@
 
                                     <!-- Step 3: Fill in Session Details -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Step 2: Fill in the Session Form</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 2: Fill in the Session Form</h3>
+                                        <p class="text-ink-muted mb-4">
                                             The form has several fields to configure your session. Here's what each one does:
                                         </p>
 
                                         <div class="space-y-6">
                                             <!-- Agent Selection -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-vscode-accent text-white rounded-full flex items-center justify-center text-xs font-bold">1</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">1</span>
                                                     Agent Selection
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     Choose which AI coding agent to use for this session. Click the agent logo to switch between available agents.
                                                 </p>
                                                 <div class="space-y-2 text-sm">
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">Claude Code</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Anthropic's coding agent — uses hooks for status tracking</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">Claude Code</code>
+                                                        <span class="text-ink-muted">Anthropic's coding agent — uses hooks for status tracking</span>
                                                     </div>
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">Codex CLI</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">OpenAI's coding agent — uses polling for session ID capture</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">Codex CLI</code>
+                                                        <span class="text-ink-muted">OpenAI's coding agent — uses polling for session ID capture</span>
                                                     </div>
                                                 </div>
-                                                <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded p-3 mt-3">
-                                                    <p class="text-xs text-blue-800 dark:text-blue-300">
-                                                        <strong>Tip:</strong> Set a default agent with the <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">lanes.defaultAgent</code> setting to skip this step.
+                                                <div class="bg-accent-dim border border-accent/20 rounded-lg p-3 mt-3">
+                                                    <p class="text-xs text-accent">
+                                                        <strong>Tip:</strong> Set a default agent with the <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">lanes.defaultAgent</code> setting to skip this step.
                                                     </p>
                                                 </div>
                                             </div>
 
                                             <!-- Session Name -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-vscode-accent text-white rounded-full flex items-center justify-center text-xs font-bold">2</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">2</span>
                                                     Session Name <span class="text-red-500 ml-1">*</span>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     A unique identifier for your session. This becomes the Git branch name, so use descriptive, Git-safe names.
                                                 </p>
-                                                <div class="bg-gray-100 dark:bg-black/40 rounded p-3 font-mono text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                                <div class="bg-surface-2 rounded-lg p-3 font-mono text-sm text-ink-muted mb-2">
                                                     <span class="text-green-600 dark:text-green-400">✓ Good:</span> fix-login-bug, add-dark-mode, refactor-api-client<br>
                                                     <span class="text-red-600 dark:text-red-400">✗ Bad:</span> my session, task#123, testing!!!
                                                 </div>
-                                                <p class="text-xs text-gray-500 dark:text-gray-500 italic">
+                                                <p class="text-xs text-ink-faint italic">
                                                     Allowed characters: letters, numbers, hyphens, underscores, dots, and slashes
                                                 </p>
                                             </div>
 
                                             <!-- Source Branch -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs font-bold">3</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">3</span>
                                                     Source Branch (optional)
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     The branch to create the worktree from. If left empty, Lanes uses your current HEAD.
                                                 </p>
-                                                <div class="bg-gray-100 dark:bg-black/40 rounded p-3 text-sm text-gray-700 dark:text-gray-300">
-                                                    <strong>Example:</strong> Enter <code class="bg-gray-200 dark:bg-black/60 px-1 rounded">main</code> to always start from main, or <code class="bg-gray-200 dark:bg-black/60 px-1 rounded">develop</code> for your development branch.
+                                                <div class="bg-surface-2 rounded-lg p-3 text-sm text-ink-muted">
+                                                    <strong>Example:</strong> Enter <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">main</code> to always start from main, or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">develop</code> for your development branch.
                                                 </div>
                                                 <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded p-3 mt-3">
-                                                    <p class="text-xs text-yellow-800 dark:text-yellow-300">
+                                                    <p class="text-xs text-amber-600 dark:text-amber-400">
                                                         <strong>Note:</strong> The source branch must already exist. Lanes will create a new branch (with the session name) from this branch.
                                                     </p>
                                                 </div>
                                             </div>
 
                                             <!-- Starting Prompt -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs font-bold">4</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">4</span>
                                                     Starting Prompt (optional)
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     The initial task description sent to Claude Code when the session starts. Be specific about what you want Claude to do.
                                                 </p>
-                                                <div class="bg-gray-100 dark:bg-black/40 rounded p-3 font-mono text-xs text-gray-700 dark:text-gray-300 mb-2">
+                                                <div class="bg-surface-2 rounded-lg p-3 font-mono text-xs text-ink-muted mb-2">
                                                     Example: "Fix the authentication bug where users get logged out after 5 minutes. The issue seems to be in the token refresh logic in src/auth/TokenManager.ts"
                                                 </div>
-                                                <p class="text-xs text-gray-500 dark:text-gray-500 italic">
+                                                <p class="text-xs text-ink-faint italic">
                                                     Leave empty if you want to start with a blank session and provide instructions manually.
                                                 </p>
                                             </div>
 
                                             <!-- File Attachments -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs font-bold">5</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">5</span>
                                                     File Attachments (optional)
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     Drag-and-drop or click to attach files to your session. File contents are included with the starting prompt, giving the agent additional context.
                                                 </p>
-                                                <div class="bg-gray-100 dark:bg-black/40 rounded p-3 text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                                <div class="bg-surface-2 rounded-lg p-3 text-sm text-ink-muted mb-2">
                                                     <strong>Use cases:</strong> Design specs, API schemas, screenshots, reference implementations, or any file the agent should read before starting.
                                                 </div>
-                                                <p class="text-xs text-gray-500 dark:text-gray-500 italic">
+                                                <p class="text-xs text-ink-faint italic">
                                                     A progress indicator shows upload status for each file.
                                                 </p>
                                             </div>
 
                                             <!-- Permission Mode -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-vscode-accent text-white rounded-full flex items-center justify-center text-xs font-bold">6</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">6</span>
                                                     Permission Mode
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Controls what Claude Code can do without asking for permission. Choose based on your trust level and workflow:
                                                 </p>
                                                 <div class="space-y-2 text-sm">
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">default</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Standard behavior - asks for permission on sensitive operations</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">default</code>
+                                                        <span class="text-ink-muted">Standard behavior - asks for permission on sensitive operations</span>
                                                     </div>
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">acceptEdits</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Auto-accepts file edits (recommended for most workflows)</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">acceptEdits</code>
+                                                        <span class="text-ink-muted">Auto-accepts file edits (recommended for most workflows)</span>
                                                     </div>
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">dontAsk</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Auto-deny tools unless explicitly allowed by an allow rule</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">dontAsk</code>
+                                                        <span class="text-ink-muted">Auto-deny tools unless explicitly allowed by an allow rule</span>
                                                     </div>
                                                     <div class="flex gap-2">
-                                                        <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">bypassPermissions</code>
-                                                        <span class="text-gray-600 dark:text-gray-400">Runs all commands automatically (use with caution)</span>
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">bypassPermissions</code>
+                                                        <span class="text-ink-muted">Runs all commands automatically (use with caution)</span>
                                                     </div>
                                                 </div>
-                                                <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded p-3 mt-3">
-                                                    <p class="text-xs text-blue-800 dark:text-blue-300">
-                                                        <strong>Recommendation:</strong> Start with <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">default</code> or <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">acceptEdits</code> until you're comfortable with how Claude works.
+                                                <div class="bg-accent-dim border border-accent/20 rounded-lg p-3 mt-3">
+                                                    <p class="text-xs text-accent">
+                                                        <strong>Recommendation:</strong> Start with <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">default</code> or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">acceptEdits</code> until you're comfortable with how Claude works.
                                                     </p>
                                                 </div>
                                             </div>
 
                                             <!-- Workflow Template -->
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
-                                                    <span class="w-6 h-6 bg-gray-400 text-white rounded-full flex items-center justify-center text-xs font-bold">7</span>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">7</span>
                                                     Workflow Template (optional)
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     Choose a structured workflow to guide Claude through your task. Workflows define clear phases like plan, implement, test, and review.
                                                 </p>
                                                 <div class="space-y-2 text-sm mb-3">
                                                     <div class="flex gap-2 items-start">
-                                                        <span class="text-gray-500 dark:text-gray-500 flex-shrink-0">•</span>
+                                                        <span class="text-ink-faint flex-shrink-0">•</span>
                                                         <div>
-                                                            <strong class="text-gray-900 dark:text-white">None (ad-hoc mode):</strong>
-                                                            <span class="text-gray-600 dark:text-gray-400"> Freeform session - Claude works without a predefined structure</span>
+                                                            <strong class="text-ink">None (ad-hoc mode):</strong>
+                                                            <span class="text-ink-muted"> Freeform session - Claude works without a predefined structure</span>
                                                         </div>
                                                     </div>
                                                     <div class="flex gap-2 items-start">
-                                                        <span class="text-gray-500 dark:text-gray-500 flex-shrink-0">•</span>
+                                                        <span class="text-ink-faint flex-shrink-0">•</span>
                                                         <div>
-                                                            <strong class="text-gray-900 dark:text-white">Custom Workflows:</strong>
-                                                            <span class="text-gray-600 dark:text-gray-400"> Your own workflows from <code class="text-xs bg-gray-200 dark:bg-black/40 px-1 rounded">.lanes/workflows/</code></span>
+                                                            <strong class="text-ink">Custom Workflows:</strong>
+                                                            <span class="text-ink-muted"> Your own workflows from <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/workflows/</code></span>
                                                         </div>
                                                     </div>
                                                 </div>
-                                                <p class="text-xs text-gray-500 dark:text-gray-500 italic">
+                                                <p class="text-xs text-ink-faint italic">
                                                     Click the refresh button (↻) to reload the workflow list if you just added new workflow files.
                                                 </p>
                                             </div>
@@ -580,53 +644,53 @@
 
                                     <!-- Step 4: Create the Session -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Step 3: Click "Create Session"</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 3: Click "Create Session"</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Once you've filled in the required fields, click the <strong>Create Session</strong> button. Lanes will:
                                         </p>
                                         <div class="space-y-3">
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">1</div>
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">1</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Create a new Git worktree</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Located at <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.worktrees/[session-name]</code> - a complete, isolated copy of your repository</p>
+                                                    <p class="text-ink font-medium">Create a new Git worktree</p>
+                                                    <p class="text-sm text-ink-muted">Located at <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.worktrees/[session-name]</code> - a complete, isolated copy of your repository</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">2</div>
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">2</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Create a new branch</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Named after your session, branched from the source branch (or current HEAD)</p>
+                                                    <p class="text-ink font-medium">Create a new branch</p>
+                                                    <p class="text-sm text-ink-muted">Named after your session, branched from the source branch (or current HEAD)</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">3</div>
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">3</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Open a dedicated terminal</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Each session gets its own terminal window in VS Code</p>
+                                                    <p class="text-ink font-medium">Open a dedicated terminal</p>
+                                                    <p class="text-sm text-ink-muted">Each session gets its own terminal window in VS Code</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">4</div>
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">4</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Launch the selected agent</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">With your starting prompt, file attachments (if any), and selected permission mode</p>
+                                                    <p class="text-ink font-medium">Launch the selected agent</p>
+                                                    <p class="text-sm text-ink-muted">With your starting prompt, file attachments (if any), and selected permission mode</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-6 h-6 bg-green-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">5</div>
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">5</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Initialize workflow (if selected)</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Sets up the MCP server and prepares the workflow state</p>
+                                                    <p class="text-ink font-medium">Initialize workflow (if selected)</p>
+                                                    <p class="text-sm text-ink-muted">Sets up the MCP server and prepares the workflow state</p>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
 
                                     <!-- What Happens Next -->
-                                    <div class="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-6">
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">What Happens Next?</h3>
-                                        <div class="space-y-3 text-gray-700 dark:text-gray-300">
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">What Happens Next?</h3>
+                                        <div class="space-y-3 text-ink-muted">
                                             <p>
                                                 <strong>Terminal Opens:</strong> You'll see a new terminal window appear with Claude Code running. The terminal title shows your session name.
                                             </p>
@@ -644,41 +708,41 @@
 
                                     <!-- Tips and Best Practices -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Tips for Success</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Tips for Success</h3>
                                         <div class="space-y-3">
                                             <div class="flex gap-3 items-start">
                                                 <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-gray-900 dark:text-white font-medium">Use descriptive session names</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Names like <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">fix-user-logout-bug</code> are more helpful than <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">session1</code></p>
+                                                    <p class="text-sm text-ink font-medium">Use descriptive session names</p>
+                                                    <p class="text-sm text-ink-muted">Names like <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">fix-user-logout-bug</code> are more helpful than <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">session1</code></p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
                                                 <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-gray-900 dark:text-white font-medium">Be specific in your prompts</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Include file paths, expected behavior, and any relevant context</p>
+                                                    <p class="text-sm text-ink font-medium">Be specific in your prompts</p>
+                                                    <p class="text-sm text-ink-muted">Include file paths, expected behavior, and any relevant context</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
                                                 <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-gray-900 dark:text-white font-medium">Start with a clean working directory</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Commit or stash changes in your main branch before creating sessions</p>
+                                                    <p class="text-sm text-ink font-medium">Start with a clean working directory</p>
+                                                    <p class="text-sm text-ink-muted">Commit or stash changes in your main branch before creating sessions</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
                                                 <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-gray-900 dark:text-white font-medium">Use workflows for complex tasks</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Features with multiple files, testing requirements, or documentation needs benefit from structured workflows</p>
+                                                    <p class="text-sm text-ink font-medium">Use workflows for complex tasks</p>
+                                                    <p class="text-sm text-ink-muted">Features with multiple files, testing requirements, or documentation needs benefit from structured workflows</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
                                                 <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-gray-900 dark:text-white font-medium">One task per session</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Keep sessions focused on a single goal - create multiple sessions for multiple tasks</p>
+                                                    <p class="text-sm text-ink font-medium">One task per session</p>
+                                                    <p class="text-sm text-ink-muted">Keep sessions focused on a single goal - create multiple sessions for multiple tasks</p>
                                                 </div>
                                             </div>
                                         </div>
@@ -686,23 +750,23 @@
 
                                     <!-- Common Issues -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Troubleshooting Common Issues</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Troubleshooting Common Issues</h3>
                                         <div class="space-y-3">
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <p class="text-sm font-bold text-red-900 dark:text-red-300 mb-1">Error: "Session name already exists"</p>
-                                                <p class="text-sm text-red-700 dark:text-red-400">A session with this name is already active, or a branch with this name exists. Choose a different name or delete the existing session first.</p>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Session name already exists"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">A session with this name is already active, or a branch with this name exists. Choose a different name or delete the existing session first.</p>
                                             </div>
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <p class="text-sm font-bold text-red-900 dark:text-red-300 mb-1">Error: "Not a git repository"</p>
-                                                <p class="text-sm text-red-700 dark:text-red-400">Run <code class="bg-red-100 dark:bg-red-800 px-1 rounded">git init</code> in your project folder to initialize a Git repository.</p>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Not a git repository"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Run <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">git init</code> in your project folder to initialize a Git repository.</p>
                                             </div>
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <p class="text-sm font-bold text-red-900 dark:text-red-300 mb-1">Error: "Claude Code not found"</p>
-                                                <p class="text-sm text-red-700 dark:text-red-400">Install Claude Code globally: <code class="bg-red-100 dark:bg-red-800 px-1 rounded">npm install -g @anthropic-ai/claude-code</code></p>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Claude Code not found"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Install Claude Code globally: <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">npm install -g @anthropic-ai/claude-code</code></p>
                                             </div>
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <p class="text-sm font-bold text-red-900 dark:text-red-300 mb-1">Error: "Codex CLI not found"</p>
-                                                <p class="text-sm text-red-700 dark:text-red-400">Install Codex CLI globally: <code class="bg-red-100 dark:bg-red-800 px-1 rounded">npm install -g @openai/codex</code>. Make sure you have an OpenAI API key configured.</p>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Codex CLI not found"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Install Codex CLI globally: <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">npm install -g @openai/codex</code>. Make sure you have an OpenAI API key configured.</p>
                                             </div>
                                         </div>
                                     </div>
@@ -710,57 +774,56 @@
                             </div>
                         </section>
 
-                        <!-- Section 2: Understanding Worktrees -->
                         <section id="worktrees" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Understanding Worktrees</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Understanding Worktrees</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Git worktrees are the foundation of Lanes' isolation strategy. They allow you to have multiple working directories attached to the same repository, enabling you to work on multiple tasks simultaneously without conflicts.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- What are Git Worktrees? -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">What are Git Worktrees?</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-xl font-bold text-ink mb-3">What are Git Worktrees?</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Imagine you're working on a feature in your project, but suddenly need to fix a critical bug. Normally, you'd have to:
                                         </p>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4 mb-4">
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4 mb-4">
                                             <li>Stash or commit your incomplete work</li>
                                             <li>Switch branches</li>
                                             <li>Fix the bug</li>
                                             <li>Switch back</li>
                                             <li>Restore your work-in-progress</li>
                                         </ul>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            <strong class="text-gray-900 dark:text-white">Git worktrees solve this problem.</strong> They let you check out multiple branches simultaneously, each in its own separate directory. Think of it as having multiple copies of your project, each on a different branch, but all sharing the same Git database.
+                                        <p class="text-ink-muted mb-4">
+                                            <strong class="text-ink">Git worktrees solve this problem.</strong> They let you check out multiple branches simultaneously, each in its own separate directory. Think of it as having multiple copies of your project, each on a different branch, but all sharing the same Git database.
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 font-mono text-sm text-gray-800 dark:text-gray-300 mb-4">
-                                            <span class="text-gray-600 dark:text-gray-500"># Your repository structure with Lanes</span><br>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-4">
+                                            <span class="text-ink-faint"># Your repository structure with Lanes</span><br>
                                             my-project/<br>
-                                            ├── .git/                <span class="text-gray-600 dark:text-gray-500"># Shared git database (history, commits, refs)</span><br>
-                                            ├── src/                 <span class="text-gray-600 dark:text-gray-500"># Your main working directory</span><br>
+                                            ├── .git/                <span class="text-ink-faint"># Shared git database (history, commits, refs)</span><br>
+                                            ├── src/                 <span class="text-ink-faint"># Your main working directory</span><br>
                                             ├── package.json<br>
-                                            └── .worktrees/          <span class="text-gray-600 dark:text-gray-500"># Lanes stores worktrees here</span><br>
-                                            &nbsp;&nbsp;&nbsp;&nbsp;├── fix-login-bug/   <span class="text-gray-600 dark:text-gray-500"># Claude working on bug fix</span><br>
+                                            └── .worktrees/          <span class="text-ink-faint"># Lanes stores worktrees here</span><br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;├── fix-login-bug/   <span class="text-ink-faint"># Claude working on bug fix</span><br>
                                             &nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├── src/<br>
                                             &nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;└── package.json<br>
-                                            &nbsp;&nbsp;&nbsp;&nbsp;└── add-dark-mode/   <span class="text-gray-600 dark:text-gray-500"># Claude working on new feature</span><br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;└── add-dark-mode/   <span class="text-ink-faint"># Claude working on new feature</span><br>
                                             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├── src/<br>
                                             &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└── package.json
                                         </div>
-                                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4">
                                             <div class="flex gap-2">
-                                                <svg class="w-5 h-5 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <svg class="w-5 h-5 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
                                                 <div>
-                                                    <p class="text-sm text-blue-800 dark:text-blue-300 font-medium">Key Insight</p>
-                                                    <p class="text-sm text-blue-700 dark:text-blue-400 mt-1">
-                                                        Each worktree is a complete working directory with its own files, but they all share the same <code class="text-xs bg-blue-100 dark:bg-blue-800 px-1 rounded">.git</code> database. This means commits made in one worktree are immediately visible in all others, but the working files remain isolated.
+                                                    <p class="text-sm text-accent font-medium">Key Insight</p>
+                                                    <p class="text-sm text-accent mt-1">
+                                                        Each worktree is a complete working directory with its own files, but they all share the same <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.git</code> database. This means commits made in one worktree are immediately visible in all others, but the working files remain isolated.
                                                     </p>
                                                 </div>
                                             </div>
@@ -769,76 +832,76 @@
 
                                     <!-- How Lanes Uses Worktrees -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">How Lanes Uses Worktrees</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-xl font-bold text-ink mb-3">How Lanes Uses Worktrees</h3>
+                                        <p class="text-ink-muted mb-4">
                                             When you create a new Lanes session, here's what happens under the hood:
                                         </p>
                                         <div class="space-y-3 mb-4">
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-8 h-8 bg-purple-500 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">1</div>
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">1</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Creates a new branch</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Named after your session (e.g., <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">fix-login-bug</code>), branched from your source branch</p>
+                                                    <p class="text-ink font-medium">Creates a new branch</p>
+                                                    <p class="text-sm text-ink-muted">Named after your session (e.g., <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">fix-login-bug</code>), branched from your source branch</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-8 h-8 bg-purple-500 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">2</div>
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">2</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Creates a worktree directory</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Located at <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.worktrees/fix-login-bug/</code> with a full checkout of your project</p>
+                                                    <p class="text-ink font-medium">Creates a worktree directory</p>
+                                                    <p class="text-sm text-ink-muted">Located at <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.worktrees/fix-login-bug/</code> with a full checkout of your project</p>
                                                 </div>
                                             </div>
                                             <div class="flex gap-3 items-start">
-                                                <div class="w-8 h-8 bg-purple-500 text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">3</div>
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">3</div>
                                                 <div>
-                                                    <p class="text-gray-900 dark:text-white font-medium">Launches Claude Code</p>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">Claude works exclusively in the worktree directory, completely isolated from your main workspace</p>
+                                                    <p class="text-ink font-medium">Launches Claude Code</p>
+                                                    <p class="text-sm text-ink-muted">Claude works exclusively in the worktree directory, completely isolated from your main workspace</p>
                                                 </div>
                                             </div>
                                         </div>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 font-mono text-sm text-gray-800 dark:text-gray-300">
-                                            <span class="text-gray-600 dark:text-gray-500"># Git command that Lanes runs (simplified):</span><br>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted">
+                                            <span class="text-ink-faint"># Git command that Lanes runs (simplified):</span><br>
                                             git worktree add .worktrees/fix-login-bug -b fix-login-bug
                                         </div>
                                     </div>
 
                                     <!-- Benefits of Isolation -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Benefits of Complete Isolation</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Benefits of Complete Isolation</h3>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-gradient-to-br from-green-50 to-green-100 dark:from-green-900/20 dark:to-green-800/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
                                                 <div class="flex items-center gap-2 mb-2">
                                                     <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white">No File Conflicts</h4>
+                                                    <h4 class="font-bold text-ink">No File Conflicts</h4>
                                                 </div>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Changes in one session never affect files in another. You can run multiple Claude sessions simultaneously without any interference.
                                                 </p>
                                             </div>
-                                            <div class="bg-gradient-to-br from-blue-50 to-blue-100 dark:from-blue-900/20 dark:to-blue-800/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
                                                 <div class="flex items-center gap-2 mb-2">
-                                                    <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white">Clean Starting State</h4>
+                                                    <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                                    <h4 class="font-bold text-ink">Clean Starting State</h4>
                                                 </div>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Each session starts fresh from your source branch. No leftover files or uncommitted changes from previous work.
                                                 </p>
                                             </div>
-                                            <div class="bg-gradient-to-br from-purple-50 to-purple-100 dark:from-purple-900/20 dark:to-purple-800/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
                                                 <div class="flex items-center gap-2 mb-2">
                                                     <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white">No Context Switching</h4>
+                                                    <h4 class="font-bold text-ink">No Context Switching</h4>
                                                 </div>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    Say goodbye to <code class="text-xs bg-purple-100 dark:bg-purple-800 px-1 rounded">git stash</code>. Your main workspace stays exactly as you left it while Claude works elsewhere.
+                                                <p class="text-sm text-ink-muted">
+                                                    Say goodbye to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">git stash</code>. Your main workspace stays exactly as you left it while Claude works elsewhere.
                                                 </p>
                                             </div>
-                                            <div class="bg-gradient-to-br from-orange-50 to-orange-100 dark:from-orange-900/20 dark:to-orange-800/20 border border-orange-200 dark:border-orange-800 rounded-lg p-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
                                                 <div class="flex items-center gap-2 mb-2">
                                                     <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path></svg>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white">Parallel Workflows</h4>
+                                                    <h4 class="font-bold text-ink">Parallel Workflows</h4>
                                                 </div>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Run multiple agents on different tasks at the same time. One fixing bugs, another implementing features.
                                                 </p>
                                             </div>
@@ -849,52 +912,51 @@
                             </div>
                         </section>
 
-                        <!-- Section 3: Permission Modes -->
                         <section id="permission-modes" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Permission Modes</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Permission Modes</h2>
                                 </div>
 
                                 <div class="mb-8">
-                                    <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                    <p class="text-ink-muted mb-4">
                                         Permission modes control how Claude Code interacts with your files and executes commands. Each mode offers a different balance between automation and control, allowing you to choose the level of oversight that matches your workflow and security requirements.
                                     </p>
-                                    <p class="text-gray-600 dark:text-gray-400">
+                                    <p class="text-ink-muted">
                                         When creating a new session, you can select the permission mode from the dropdown in the session form. The mode you choose will apply to Claude's entire session in that worktree.
                                     </p>
                                 </div>
 
                                 <!-- Quick Comparison Table -->
                                 <div class="mb-8 overflow-x-auto">
-                                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Quick Comparison</h3>
+                                    <h3 class="text-xl font-bold text-ink mb-4">Quick Comparison</h3>
                                     <table class="w-full text-sm border-collapse">
                                         <thead>
-                                            <tr class="bg-gray-100 dark:bg-black/30">
-                                                <th class="text-left p-3 font-semibold text-gray-900 dark:text-white border-b border-gray-300 dark:border-gray-700">Mode</th>
-                                                <th class="text-left p-3 font-semibold text-gray-900 dark:text-white border-b border-gray-300 dark:border-gray-700">File Edits</th>
-                                                <th class="text-left p-3 font-semibold text-gray-900 dark:text-white border-b border-gray-300 dark:border-gray-700">Commands</th>
-                                                <th class="text-left p-3 font-semibold text-gray-900 dark:text-white border-b border-gray-300 dark:border-gray-700">Best For</th>
+                                            <tr class="bg-surface-2">
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Mode</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">File Edits</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Commands</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Best For</th>
                                             </tr>
                                         </thead>
-                                        <tbody class="text-gray-600 dark:text-gray-400">
-                                            <tr class="border-b border-gray-200 dark:border-gray-800">
-                                                <td class="p-3 font-medium text-gray-900 dark:text-white">default</td>
+                                        <tbody class="text-ink-muted">
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">default</td>
                                                 <td class="p-3">Ask first</td>
                                                 <td class="p-3">Ask first unless allowed by an allow rule</td>
                                                 <td class="p-3">Standard interactive workflow</td>
                                             </tr>
-                                            <tr class="border-b border-gray-200 dark:border-gray-800">
-                                                <td class="p-3 font-medium text-gray-900 dark:text-white">acceptEdits</td>
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">acceptEdits</td>
                                                 <td class="p-3">Auto-approve</td>
                                                 <td class="p-3">Ask first unless allowed by an allow rule</td>
                                                 <td class="p-3">Fast coding, careful with commands</td>
                                             </tr>
-                                            <tr class="border-b border-gray-200 dark:border-gray-800">
-                                                <td class="p-3 font-medium text-gray-900 dark:text-white">dontAsk</td>
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">dontAsk</td>
                                                 <td class="p-3">Auto-approve</td>
                                                 <td class="p-3">Auto-deny unless allowed by an allow rule</td>
                                                 <td class="p-3">Auto-deny tools unless explicitly allowed by an allow rule</td>
@@ -910,12 +972,12 @@
                                 </div>
 
                                 <!-- How to Select -->
-                                <div class="mt-8 bg-gray-100 dark:bg-black/30 rounded-lg p-6">
-                                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">How to Select a Permission Mode</h3>
+                                <div class="mt-8 bg-surface-2 rounded-lg p-6">
+                                    <h3 class="text-xl font-bold text-ink mb-4">How to Select a Permission Mode</h3>
                                     <div class="space-y-4">
                                         <div>
-                                            <h4 class="font-semibold text-gray-900 dark:text-white mb-2">When Creating a Session</h4>
-                                            <ol class="list-decimal list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4">
+                                            <h4 class="font-semibold text-ink mb-2">When Creating a Session</h4>
+                                            <ol class="list-decimal list-inside text-ink-muted space-y-2 ml-4">
                                                 <li>Open the Lanes sidebar in VS Code</li>
                                                 <li>Fill out the session form with your session name and prompt</li>
                                                 <li>Select your desired permission mode from the "Permission Mode" dropdown</li>
@@ -923,7 +985,7 @@
                                             </ol>
                                         </div>
                                         <div>
-                                            <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <p class="text-sm text-ink-muted">
                                                 The permission mode is set when the session is created and applies to Claude's entire session in that worktree. Choose carefully based on your task and trust level.
                                             </p>
                                         </div>
@@ -933,43 +995,42 @@
                             </div>
                         </section>
 
-                        <!-- Section 4: Reviewing Changes -->
                         <section id="git-review" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Reviewing Changes</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Reviewing Changes</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Lanes includes a built-in code review tool that lets you view changes, add comments, and generate review feedback for your coding agents.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- Opening the Diff Viewer -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Opening the Git Changes Viewer</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Opening the Git Changes Viewer</h3>
+                                        <p class="text-ink-muted mb-4">
                                             To review changes made in a session:
                                         </p>
                                         <ol class="space-y-3 mb-4">
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300">Click the <strong class="text-gray-900 dark:text-white">"Show Git Changes"</strong> button in the session's action bar (the diff icon)</p>
+                                                    <p class="text-ink-muted">Click the <strong class="text-ink">"Show Git Changes"</strong> button in the session's action bar (the diff icon)</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300">A new panel opens showing all file changes between your session branch and the comparison branch</p>
+                                                    <p class="text-ink-muted">A new panel opens showing all file changes between your session branch and the comparison branch</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300">This can be slow when there are many changes.</p>
+                                                    <p class="text-ink-muted">This can be slow when there are many changes.</p>
                                                 </div>
                                             </li>
                                         </ol>
@@ -977,32 +1038,32 @@
 
                                     <!-- Understanding the Diff View -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Understanding the Diff View</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Understanding the Diff View</h3>
+                                        <p class="text-ink-muted mb-4">
                                             The diff viewer shows changes in a unified diff format:
                                         </p>
                                         <div class="space-y-4">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2">Comparison Branch</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
-                                                    By default, changes are compared against <code class="text-xs bg-gray-200 dark:bg-black/40 px-1 rounded">main</code> or <code class="text-xs bg-gray-200 dark:bg-black/40 px-1 rounded">master</code>.
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Comparison Branch</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    By default, changes are compared against <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">main</code> or <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">master</code>.
                                                     You can change this using the branch selector dropdown at the top of the diff panel.
                                                 </p>
                                             </div>
                                             <div class="grid md:grid-cols-2 gap-4">
                                                 <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
-                                                    <h5 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                                    <h5 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                         <span class="text-green-600 dark:text-green-400">+</span> Added Lines
                                                     </h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <p class="text-sm text-ink-muted">
                                                         Lines highlighted in green are new additions to the codebase.
                                                     </p>
                                                 </div>
                                                 <div class="bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 p-4">
-                                                    <h5 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                                    <h5 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                         <span class="text-red-600 dark:text-red-400">-</span> Removed Lines
                                                     </h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <p class="text-sm text-ink-muted">
                                                         Lines highlighted in red have been deleted from the original.
                                                     </p>
                                                 </div>
@@ -1012,35 +1073,35 @@
 
                                     <!-- Adding Review Comments -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Adding Review Comments</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Adding Review Comments</h3>
+                                        <p class="text-ink-muted mb-4">
                                             You can add comments to specific lines in the diff to provide feedback:
                                         </p>
                                         <ol class="space-y-3 mb-4">
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300"><strong class="text-gray-900 dark:text-white">Click on any line</strong> in the diff view to select it</p>
+                                                    <p class="text-ink-muted"><strong class="text-ink">Click on any line</strong> in the diff view to select it</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300"><strong class="text-gray-900 dark:text-white">Type your comment</strong> in the input field that appears</p>
+                                                    <p class="text-ink-muted"><strong class="text-ink">Type your comment</strong> in the input field that appears</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300"><strong class="text-gray-900 dark:text-white">Press Enter</strong> to save the comment</p>
+                                                    <p class="text-ink-muted"><strong class="text-ink">Press Enter</strong> to save the comment</p>
                                                 </div>
                                             </li>
                                         </ol>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <p class="text-ink-muted mb-4">
                                             Comments are displayed inline with the code, making it easy to track your feedback as you review.
                                         </p>
-                                        <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                                            <p class="text-sm text-yellow-800 dark:text-yellow-300">
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-amber-600 dark:text-amber-400">
                                                 <strong>Note:</strong> Comments are stored locally in the diff viewer session. They are not persisted to git or any external system.
                                             </p>
                                         </div>
@@ -1048,50 +1109,50 @@
 
                                     <!-- Submitting Review -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Submitting Your Review</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Submitting Your Review</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Once you've added all your comments, you can generate a formatted review to share with your coding agent:
                                         </p>
                                         <ol class="space-y-3 mb-6">
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300">Click the <strong class="text-gray-900 dark:text-white">"Submit Review"</strong> button at the top of the diff panel</p>
+                                                    <p class="text-ink-muted">Click the <strong class="text-ink">"Submit Review"</strong> button at the top of the diff panel</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300">The review is <strong class="text-gray-900 dark:text-white">automatically copied to your clipboard</strong> in a structured markdown format</p>
+                                                    <p class="text-ink-muted">The review is <strong class="text-ink">automatically copied to your clipboard</strong> in a structured markdown format</p>
                                                 </div>
                                             </li>
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-7 h-7 bg-vscode-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
                                                 <div class="flex-1">
-                                                    <p class="text-gray-700 dark:text-gray-300"><strong class="text-gray-900 dark:text-white">Paste</strong> the review into your coding agent's terminal or chat</p>
+                                                    <p class="text-ink-muted"><strong class="text-ink">Paste</strong> the review into your coding agent's terminal or chat</p>
                                                 </div>
                                             </li>
                                         </ol>
 
-                                        <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">Clipboard Format</h4>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h4 class="text-lg font-semibold text-ink mb-3">Clipboard Format</h4>
+                                        <p class="text-ink-muted mb-4">
                                             The generated review follows a structured markdown format that's easy for AI agents to parse:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">Example: Clipboard Output</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Example: Clipboard Output</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-purple-600 dark:text-purple-400"># Code Review Comments</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-600 dark:text-purple-400"># Code Review Comments</span>
 
 <span class="text-blue-600 dark:text-blue-400">## docs/docs.html</span>
 
-<span class="text-gray-600 dark:text-gray-400">**Line 38** (added):</span>
+<span class="text-ink-muted">**Line 38** (added):</span>
 ```
 +    &lt;/script&gt;
 ```
 <span class="text-green-600 dark:text-green-400">&gt; Is this really a script tag? It seems misplaced.</span>
 
-<span class="text-gray-600 dark:text-gray-400">**Line 142** (added):</span>
+<span class="text-ink-muted">**Line 142** (added):</span>
 ```
 +    const user = await getUser();
 ```
@@ -1099,7 +1160,7 @@
 
 <span class="text-blue-600 dark:text-blue-400">## src/utils/helper.ts</span>
 
-<span class="text-gray-600 dark:text-gray-400">**Line 25** (removed):</span>
+<span class="text-ink-muted">**Line 25** (removed):</span>
 ```
 -    // TODO: Remove this hack
 ```
@@ -1111,38 +1172,37 @@
                             </div>
                         </section>
 
-                        <!-- Section: Multi-Agent Support -->
                         <section id="multi-agent" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Multi-Agent Support</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Multi-Agent Support</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Lanes supports multiple AI coding agents. Choose the best agent for each task, or mix agents across sessions.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- Supported Agents -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Supported Agents</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Supported Agents</h3>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2">Claude Code</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">Anthropic's coding agent with deep code understanding and multi-file editing capabilities.</p>
-                                                <ul class="text-xs text-gray-500 dark:text-gray-500 space-y-1">
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Claude Code</h4>
+                                                <p class="text-sm text-ink-muted mb-2">Anthropic's coding agent with deep code understanding and multi-file editing capabilities.</p>
+                                                <ul class="text-xs text-ink-faint space-y-1">
                                                     <li>&#x2022; Status tracking via hooks</li>
                                                     <li>&#x2022; Permission modes (default, acceptEdits, bypassPermissions)</li>
                                                     <li>&#x2022; MCP workflow support built-in</li>
-                                                    <li>&#x2022; Session resume with <code class="bg-gray-200 dark:bg-black/40 px-1 rounded">--resume</code></li>
+                                                    <li>&#x2022; Session resume with <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">--resume</code></li>
                                                 </ul>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2">Codex CLI</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">OpenAI's command-line coding agent for code generation and editing tasks.</p>
-                                                <ul class="text-xs text-gray-500 dark:text-gray-500 space-y-1">
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Codex CLI</h4>
+                                                <p class="text-sm text-ink-muted mb-2">OpenAI's command-line coding agent for code generation and editing tasks.</p>
+                                                <ul class="text-xs text-ink-faint space-y-1">
                                                     <li>&#x2022; Status tracking via polling</li>
                                                     <li>&#x2022; TOML-based configuration</li>
                                                     <li>&#x2022; MCP workflow support via config overrides</li>
@@ -1154,46 +1214,46 @@
 
                                     <!-- How to Select -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Selecting an Agent</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Selecting an Agent</h3>
+                                        <p class="text-ink-muted mb-3">
                                             In the session creation form, click the agent logo at the top to cycle between available agents. The selected agent's logo is displayed inline, and the form adjusts available options accordingly.
                                         </p>
-                                        <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                                            <p class="text-sm text-blue-800 dark:text-blue-300">
-                                                <strong>Default agent:</strong> Set <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">lanes.defaultAgent</code> in VS Code settings to <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">"claude-code"</code> or <code class="bg-blue-100 dark:bg-blue-800 px-1 rounded">"codex"</code> to pre-select your preferred agent.
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4">
+                                            <p class="text-sm text-accent">
+                                                <strong>Default agent:</strong> Set <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">lanes.defaultAgent</code> in VS Code settings to <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">"claude-code"</code> or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">"codex"</code> to pre-select your preferred agent.
                                             </p>
                                         </div>
                                     </div>
 
                                     <!-- Differences Between Agents -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Differences Between Agents</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Differences Between Agents</h3>
                                         <div class="overflow-x-auto">
                                             <table class="w-full text-sm">
                                                 <thead>
-                                                    <tr class="border-b border-gray-200 dark:border-white/10">
-                                                        <th class="text-left py-2 px-3 font-bold text-gray-900 dark:text-white">Feature</th>
-                                                        <th class="text-left py-2 px-3 font-bold text-gray-900 dark:text-white">Claude Code</th>
-                                                        <th class="text-left py-2 px-3 font-bold text-gray-900 dark:text-white">Codex CLI</th>
+                                                    <tr class="border-b border-border">
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Feature</th>
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Claude Code</th>
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Codex CLI</th>
                                                     </tr>
                                                 </thead>
-                                                <tbody class="text-gray-600 dark:text-gray-400">
-                                                    <tr class="border-b border-gray-100 dark:border-white/5">
+                                                <tbody class="text-ink-muted">
+                                                    <tr class="border-b border-border">
                                                         <td class="py-2 px-3">Status tracking</td>
                                                         <td class="py-2 px-3">Hook-based (real-time)</td>
                                                         <td class="py-2 px-3">Polling-based</td>
                                                     </tr>
-                                                    <tr class="border-b border-gray-100 dark:border-white/5">
+                                                    <tr class="border-b border-border">
                                                         <td class="py-2 px-3">Session ID capture</td>
                                                         <td class="py-2 px-3">Via hooks</td>
                                                         <td class="py-2 px-3">Via polling</td>
                                                     </tr>
-                                                    <tr class="border-b border-gray-100 dark:border-white/5">
+                                                    <tr class="border-b border-border">
                                                         <td class="py-2 px-3">Configuration format</td>
                                                         <td class="py-2 px-3">JSON</td>
                                                         <td class="py-2 px-3">TOML</td>
                                                     </tr>
-                                                    <tr class="border-b border-gray-100 dark:border-white/5">
+                                                    <tr class="border-b border-border">
                                                         <td class="py-2 px-3">MCP workflows</td>
                                                         <td class="py-2 px-3">Native support</td>
                                                         <td class="py-2 px-3">Via config overrides</td>
@@ -1211,66 +1271,65 @@
                             </div>
                         </section>
 
-                        <!-- Section: File Attachments -->
                         <section id="file-attachments" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">File Attachments</h2>
+                                    <h2 class="text-3xl font-bold text-ink">File Attachments</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Attach files to your session to give the agent additional context before it starts working. Files are read and their contents are included with the starting prompt.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- How to Attach -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">How to Attach Files</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">How to Attach Files</h3>
+                                        <p class="text-ink-muted mb-3">
                                             In the session creation form, you can attach files in two ways:
                                         </p>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4">
-                                            <li><strong class="text-gray-900 dark:text-white">Click to browse:</strong> Click the attachment area to open a file picker</li>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Click to browse:</strong> Click the attachment area to open a file picker</li>
                                         </ul>
                                     </div>
 
                                     <!-- Upload Progress -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Upload Progress</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Upload Progress</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Each attached file shows an upload progress indicator. Once uploaded, file contents are processed and ready to be included with your prompt.
                                         </p>
                                     </div>
 
                                     <!-- How Contents Are Included -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">How Contents Are Included</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">How Contents Are Included</h3>
+                                        <p class="text-ink-muted mb-3">
                                             When you create the session, file contents are appended to the starting prompt. The agent receives the full text of each file along with the filename, giving it immediate access to the context it needs.
                                         </p>
                                     </div>
 
                                     <!-- Use Cases -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Common Use Cases</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Common Use Cases</h3>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Design Specifications</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Attach design docs or mockup descriptions so the agent understands the target UI/UX.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Design Specifications</h4>
+                                                <p class="text-xs text-ink-muted">Attach design docs or mockup descriptions so the agent understands the target UI/UX.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">API Schemas</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Include OpenAPI specs or GraphQL schemas for API integration tasks.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">API Schemas</h4>
+                                                <p class="text-xs text-ink-muted">Include OpenAPI specs or GraphQL schemas for API integration tasks.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Reference Code</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Attach example implementations or patterns you want the agent to follow.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Reference Code</h4>
+                                                <p class="text-xs text-ink-muted">Attach example implementations or patterns you want the agent to follow.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Bug Reports</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Include error logs, stack traces, or issue descriptions for debugging sessions.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Bug Reports</h4>
+                                                <p class="text-xs text-ink-muted">Include error logs, stack traces, or issue descriptions for debugging sessions.</p>
                                             </div>
                                         </div>
                                     </div>
@@ -1278,58 +1337,57 @@
                             </div>
                         </section>
 
-                        <!-- Section: Tmux Terminal -->
                         <section id="tmux-terminal" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Tmux Terminal</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Tmux Terminal</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Lanes can use tmux as an alternative terminal backend instead of VS Code's built-in terminals. Tmux sessions persist independently of VS Code, making them more resilient to window reloads and crashes.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- Benefits -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Benefits</h3>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4">
-                                            <li><strong class="text-gray-900 dark:text-white">Persistence:</strong> Sessions survive VS Code restarts and window reloads</li>
-                                            <li><strong class="text-gray-900 dark:text-white">Resilience:</strong> Agent continues running even if VS Code crashes</li>
-                                            <li><strong class="text-gray-900 dark:text-white">Scrollback:</strong> Full terminal history preserved in tmux</li>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Benefits</h3>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Persistence:</strong> Sessions survive VS Code restarts and window reloads</li>
+                                            <li><strong class="text-ink">Resilience:</strong> Agent continues running even if VS Code crashes</li>
+                                            <li><strong class="text-ink">Scrollback:</strong> Full terminal history preserved in tmux</li>
                                         </ul>
                                     </div>
 
                                     <!-- Configuration -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Configuration</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Configuration</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Set the terminal mode in VS Code settings:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 font-mono text-sm text-gray-800 dark:text-gray-300 mb-3">
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-3">
                                             <span class="text-blue-600 dark:text-blue-400">"lanes.terminalMode"</span>: <span class="text-green-600 dark:text-green-400">"tmux"</span>
                                         </div>
                                         <div class="space-y-2 text-sm">
                                             <div class="flex gap-2">
-                                                <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">vscode</code>
-                                                <span class="text-gray-600 dark:text-gray-400">Default — uses VS Code's built-in terminal</span>
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">vscode</code>
+                                                <span class="text-ink-muted">Default — uses VS Code's built-in terminal</span>
                                             </div>
                                             <div class="flex gap-2">
-                                                <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">tmux</code>
-                                                <span class="text-gray-600 dark:text-gray-400">Uses tmux for persistent terminal sessions</span>
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">tmux</code>
+                                                <span class="text-ink-muted">Uses tmux for persistent terminal sessions</span>
                                             </div>
                                         </div>
                                     </div>
 
                                     <!-- Prerequisites -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Prerequisites</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Prerequisites</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Tmux must be installed on your system:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 font-mono text-sm text-gray-800 dark:text-gray-300">
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted">
                                             <span class="text-green-600 dark:text-green-400">$</span> brew install tmux <span class="text-gray-500"># macOS</span><br>
                                             <span class="text-green-600 dark:text-green-400">$</span> sudo apt-get install tmux <span class="text-gray-500"># Ubuntu/Debian</span>
                                         </div>
@@ -1337,8 +1395,8 @@
 
                                     <!-- Per-Session Mode -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Per-Session Persistence</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Per-Session Persistence</h3>
+                                        <p class="text-ink-muted mb-3">
                                             The terminal mode is stored per session, so each session remembers whether it was created with VS Code or tmux terminals. Changing the global setting only affects new sessions.
                                         </p>
                                     </div>
@@ -1346,72 +1404,71 @@
                             </div>
                         </section>
 
-                        <!-- Section: Local Settings -->
                         <section id="local-settings" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Local Settings Propagation</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Local Settings Propagation</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
-                                    Lanes can automatically propagate your <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">.claude/settings.local.json</code> file from your base repository to each worktree. This ensures your local Claude Code configuration is available in all sessions.
+                                <p class="text-ink-muted mb-6">
+                                    Lanes can automatically propagate your <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/settings.local.json</code> file from your base repository to each worktree. This ensures your local Claude Code configuration is available in all sessions.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- Configuration -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Configuration</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Configuration</h3>
+                                        <p class="text-ink-muted mb-3">
                                             Add to your VS Code settings:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 font-mono text-sm text-gray-800 dark:text-gray-300 mb-4">
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-4">
                                             <span class="text-blue-600 dark:text-blue-400">"lanes.localSettingsPropagation"</span>: <span class="text-green-600 dark:text-green-400">"copy"</span>
                                         </div>
                                         <div class="space-y-2 text-sm">
                                             <div class="flex gap-2">
-                                                <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">copy</code>
-                                                <span class="text-gray-600 dark:text-gray-400">Default — copies the settings file to each worktree. Works on all platforms.</span>
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">copy</code>
+                                                <span class="text-ink-muted">Default — copies the settings file to each worktree. Works on all platforms.</span>
                                             </div>
                                             <div class="flex gap-2">
-                                                <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">symlink</code>
-                                                <span class="text-gray-600 dark:text-gray-400">Creates a symbolic link. More efficient but may require developer mode on Windows.</span>
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">symlink</code>
+                                                <span class="text-ink-muted">Creates a symbolic link. More efficient but may require developer mode on Windows.</span>
                                             </div>
                                             <div class="flex gap-2">
-                                                <code class="bg-gray-200 dark:bg-black/40 px-2 py-0.5 rounded text-xs flex-shrink-0">disabled</code>
-                                                <span class="text-gray-600 dark:text-gray-400">Does not propagate settings to worktrees.</span>
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">disabled</code>
+                                                <span class="text-ink-muted">Does not propagate settings to worktrees.</span>
                                             </div>
                                         </div>
                                     </div>
 
                                     <!-- How It Works -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">How It Works</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-3">
-                                            When you create a new session (worktree), Lanes checks if <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">.claude/settings.local.json</code> exists in your base repository. If it does and propagation is enabled, the file is copied or symlinked to <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">&lt;worktree&gt;/.claude/settings.local.json</code>.
+                                        <h3 class="text-xl font-bold text-ink mb-3">How It Works</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            When you create a new session (worktree), Lanes checks if <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/settings.local.json</code> exists in your base repository. If it does and propagation is enabled, the file is copied or symlinked to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">&lt;worktree&gt;/.claude/settings.local.json</code>.
                                         </p>
                                     </div>
 
                                     <!-- Use Cases -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Common Use Cases</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Common Use Cases</h3>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Environment Variables</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Set custom <code class="bg-gray-200 dark:bg-black/40 px-1 rounded">ANTHROPIC_DEFAULT_HAIKU_MODEL</code> for all sessions.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Environment Variables</h4>
+                                                <p class="text-xs text-ink-muted">Set custom <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">ANTHROPIC_DEFAULT_HAIKU_MODEL</code> for all sessions.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Model Settings</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Configure default models or permission modes across all worktrees.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Model Settings</h4>
+                                                <p class="text-xs text-ink-muted">Configure default models or permission modes across all worktrees.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">Custom Hooks</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Define hooks that apply to all sessions automatically.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Custom Hooks</h4>
+                                                <p class="text-xs text-ink-muted">Define hooks that apply to all sessions automatically.</p>
                                             </div>
-                                            <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-1 text-sm">API Keys</h4>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400">Propagate API key configurations so agents in every worktree can access required services.</p>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">API Keys</h4>
+                                                <p class="text-xs text-ink-muted">Propagate API key configurations so agents in every worktree can access required services.</p>
                                             </div>
                                         </div>
                                     </div>
@@ -1419,69 +1476,68 @@
                             </div>
                         </section>
 
-                        <!-- Section 5: Introduction to Workflows -->
                         <section id="workflows-intro" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Introduction to Workflows</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Introduction to Workflows</h2>
                                 </div>
 
-                                <p class="text-gray-600 dark:text-gray-400 mb-8 text-lg">
-                                    Workflows are structured development processes that guide Claude through proven phases like planning, implementation, testing, and review. Built on research from <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-vscode-accent hover:underline">Anthropic's long-running agent harnesses</a>, they bring consistency and quality to complex development tasks.
+                                <p class="text-ink-muted mb-8 text-lg">
+                                    Workflows are structured development processes that guide Claude through proven phases like planning, implementation, testing, and review. Built on research from <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline">Anthropic's long-running agent harnesses</a>, they bring consistency and quality to complex development tasks.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- What are Workflows? -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">What are Workflows?</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-xl font-bold text-ink mb-4">What are Workflows?</h3>
+                                        <p class="text-ink-muted mb-4">
                                             A workflow is like a development playbook that Claude follows step-by-step. Each workflow defines:
                                         </p>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path>
                                                     </svg>
                                                     Phases
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                <p class="text-sm text-ink-muted">
                                                     The sequence of steps (plan, implement, test, review) that ensure thorough development
                                                 </p>
                                             </div>
-                                            <div class="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
                                                     </svg>
                                                     Specialized Agents
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                <p class="text-sm text-ink-muted">
                                                     Different "roles" for Claude with specific tools and restrictions (orchestrator, implementer, tester, reviewer)
                                                 </p>
                                             </div>
-                                            <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                                                     </svg>
                                                     Repeatable Loops
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                <p class="text-sm text-ink-muted">
                                                     Patterns that repeat for each task (implement → test → review → resolve)
                                                 </p>
                                             </div>
-                                            <div class="bg-orange-50 dark:bg-orange-900/20 border border-orange-200 dark:border-orange-800 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                                     </svg>
                                                     Progress Tracking
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                <p class="text-sm text-ink-muted">
                                                     Automatic state persistence so Claude can resume work across context windows
                                                 </p>
                                             </div>
@@ -1490,57 +1546,57 @@
 
                                     <!-- Why Use Workflows? -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Why Use Workflows?</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-4">Why Use Workflows?</h3>
                                         <div class="space-y-4">
                                             <div class="flex items-start gap-3">
-                                                <div class="w-8 h-8 bg-blue-500/20 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                <div class="w-8 h-8 bg-accent/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                                                     <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                                                     </svg>
                                                 </div>
                                                 <div>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Consistent Structure</h4>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h4 class="font-bold text-ink mb-1">Consistent Structure</h4>
+                                                    <p class="text-sm text-ink-muted">
                                                         Every task follows the same proven pattern: plan before coding, test after implementation, review before completion. This prevents common mistakes like coding without a plan or skipping tests.
                                                     </p>
                                                 </div>
                                             </div>
                                             <div class="flex items-start gap-3">
-                                                <div class="w-8 h-8 bg-purple-500/20 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                <div class="w-8 h-8 bg-violet-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                                                     <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
                                                     </svg>
                                                 </div>
                                                 <div>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Higher Quality</h4>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h4 class="font-bold text-ink mb-1">Higher Quality</h4>
+                                                    <p class="text-sm text-ink-muted">
                                                         Specialized agents bring focused expertise to each phase. The reviewer agent only reads code (can't edit), ensuring objective feedback. The tester focuses solely on test quality.
                                                     </p>
                                                 </div>
                                             </div>
                                             <div class="flex items-start gap-3">
-                                                <div class="w-8 h-8 bg-green-500/20 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                <div class="w-8 h-8 bg-emerald-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                                                     <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                                     </svg>
                                                 </div>
                                                 <div>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Built-in Checkpoints</h4>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h4 class="font-bold text-ink mb-1">Built-in Checkpoints</h4>
+                                                    <p class="text-sm text-ink-muted">
                                                         Workflows prevent Claude from jumping ahead or getting sidetracked. Each phase must complete before moving to the next, ensuring nothing is skipped.
                                                     </p>
                                                 </div>
                                             </div>
                                             <div class="flex items-start gap-3">
-                                                <div class="w-8 h-8 bg-orange-500/20 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                <div class="w-8 h-8 bg-amber-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
                                                     <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                                     </svg>
                                                 </div>
                                                 <div>
-                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Seamless Context Continuity</h4>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
-                                                        Workflow state is saved to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow-state.json</code> after each step. If Claude runs out of context or the session ends, you can resume exactly where you left off.
+                                                    <h4 class="font-bold text-ink mb-1">Seamless Context Continuity</h4>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Workflow state is saved to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> after each step. If Claude runs out of context or the session ends, you can resume exactly where you left off.
                                                     </p>
                                                 </div>
                                             </div>
@@ -1549,53 +1605,53 @@
 
                                                                         <!-- Built-in Workflow Types -->
                                                                         <div>
-                                                                            <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">Built-in Workflow Types</h3>
-                                                                            <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                                                            <h3 class="text-xl font-bold text-ink mb-4">Built-in Workflow Types</h3>
+                                                                            <p class="text-ink-muted mb-4">
                                                                                 Lanes includes four workflow templates out of the box. Each is optimized for a specific type of development work:
                                                                             </p>
                                                                             <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
-                                                                                <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                                                                                    <div class="w-10 h-10 bg-blue-500/20 rounded-lg flex items-center justify-center mb-3">
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center mb-3">
                                                                                         <span class="text-blue-600 dark:text-blue-400 font-bold text-sm">FT</span>
                                                                                     </div>
-                                                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-2 text-sm">Feature Dev</h4>
-                                                                                    <p class="text-xs text-gray-600 dark:text-gray-400">
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Feature Dev</h4>
+                                                                                    <p class="text-xs text-ink-muted">
                                                                                         New features with tests and review.
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                                                    <div class="w-10 h-10 bg-red-500/20 rounded-lg flex items-center justify-center mb-3">
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-red-500/10 rounded-lg flex items-center justify-center mb-3">
                                                                                         <span class="text-red-600 dark:text-red-400 font-bold text-sm">BF</span>
                                                                                     </div>
-                                                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-2 text-sm">Bug Fix</h4>
-                                                                                    <p class="text-xs text-gray-600 dark:text-gray-400">
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Bug Fix</h4>
+                                                                                    <p class="text-xs text-ink-muted">
                                                                                         Investigate and fix bugs safely.
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4">
-                                                                                    <div class="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center mb-3">
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-violet-500/10 rounded-lg flex items-center justify-center mb-3">
                                                                                         <span class="text-purple-600 dark:text-purple-400 font-bold text-sm">RF</span>
                                                                                     </div>
-                                                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-2 text-sm">Refactor</h4>
-                                                                                    <p class="text-xs text-gray-600 dark:text-gray-400">
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Refactor</h4>
+                                                                                    <p class="text-xs text-ink-muted">
                                                                                         Improve code quality safely.
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="bg-gray-50 dark:bg-gray-900/20 border border-gray-200 dark:border-gray-800 rounded-lg p-4">
-                                                                                    <div class="w-10 h-10 bg-gray-500/20 rounded-lg flex items-center justify-center mb-3">
-                                                                                        <span class="text-gray-600 dark:text-gray-400 font-bold text-sm">DF</span>
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-surface-2 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-ink-muted font-bold text-sm">DF</span>
                                                                                     </div>
-                                                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-2 text-sm">Default</h4>
-                                                                                    <p class="text-xs text-gray-600 dark:text-gray-400">
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Default</h4>
+                                                                                    <p class="text-xs text-ink-muted">
                                                                                         General-purpose tasks.
                                                                                     </p>
                                                                                 </div>
-                                                                                <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
-                                                                                    <div class="w-10 h-10 bg-green-500/20 rounded-lg flex items-center justify-center mb-3">
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center mb-3">
                                                                                         <span class="text-green-600 dark:text-green-400 font-bold text-sm">CW</span>
                                                                                     </div>
-                                                                                    <h4 class="font-bold text-gray-900 dark:text-white mb-2 text-sm">Custom</h4>
-                                                                                    <p class="text-xs text-gray-600 dark:text-gray-400">
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Custom</h4>
+                                                                                    <p class="text-xs text-ink-muted">
                                                                                         Your own workflows.
                                                                                     </p>
                                                                                 </div>
@@ -1605,45 +1661,45 @@
 
                                     <!-- Starting a Workflow -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">How to Start a Workflow Session</h3>
-                                        <div class="bg-gray-50 dark:bg-black/30 rounded-lg p-6 border border-gray-200 dark:border-white/10">
+                                        <h3 class="text-xl font-bold text-ink mb-4">How to Start a Workflow Session</h3>
+                                        <div class="bg-surface-1 rounded-lg p-6 border border-border">
                                             <div class="space-y-4">
                                                 <div class="flex items-start gap-3">
-                                                    <div class="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs">1</div>
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">1</div>
                                                     <div>
-                                                        <p class="text-gray-700 dark:text-gray-300">
+                                                        <p class="text-ink-muted">
                                                             <strong>Click "New Session"</strong> in the Lanes sidebar
                                                         </p>
                                                     </div>
                                                 </div>
                                                 <div class="flex items-start gap-3">
-                                                    <div class="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs">3</div>
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">3</div>
                                                     <div>
-                                                        <p class="text-gray-700 dark:text-gray-300">
+                                                        <p class="text-ink-muted">
                                                             <strong>Enter a branch name</strong> (e.g., "feat-user-auth" or "fix-login-bug")
                                                         </p>
                                                     </div>
                                                 </div>
                                                 <div class="flex items-start gap-3">
-                                                    <div class="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs">4</div>
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">4</div>
                                                     <div>
-                                                        <p class="text-gray-700 dark:text-gray-300">
+                                                        <p class="text-ink-muted">
                                                             <strong>Describe your goal</strong> to Claude (e.g., "Add user authentication with email and password")
                                                         </p>
                                                     </div>
                                                 </div>
                                                 <div class="flex items-start gap-3">
-                                                    <div class="flex-shrink-0 w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center font-bold text-xs">2</div>
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">2</div>
                                                     <div>
-                                                        <p class="text-gray-700 dark:text-gray-300">
+                                                        <p class="text-ink-muted">
                                                             <strong>Choose a workflow type</strong> from the dropdown (If you have not created a custom workflow you will need to. You can learn how in the Creating Workflows section.)
                                                         </p>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="mt-4 pt-4 border-t border-gray-200 dark:border-gray-600">
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
-                                                    Claude will automatically follow the workflow phases, creating a <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow-state.json</code> file to track progress and saving workflow state after each step.
+                                            <div class="mt-4 pt-4 border-t border-border">
+                                                <p class="text-sm text-ink-muted">
+                                                    Claude will automatically follow the workflow phases, creating a <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> file to track progress and saving workflow state after each step.
                                                 </p>
                                             </div>
                                         </div>
@@ -1651,16 +1707,16 @@
 
                                     <!-- When to Use Workflows -->
                                     <div>
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-4">When to Use Workflows vs. Ad-Hoc Sessions</h3>
+                                        <h3 class="text-xl font-bold text-ink mb-4">When to Use Workflows vs. Ad-Hoc Sessions</h3>
                                         <div class="grid md:grid-cols-2 gap-4">
-                                            <div class="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-5">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-5">
+                                                <h4 class="font-bold text-ink mb-3 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                                                     </svg>
                                                     Use Workflows For:
                                                 </h4>
-                                                <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                                                <ul class="space-y-2 text-sm text-ink-muted">
                                                     <li class="flex items-start gap-2">
                                                         <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
                                                         <span>New features with multiple components</span>
@@ -1687,14 +1743,14 @@
                                                     </li>
                                                 </ul>
                                             </div>
-                                            <div class="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-5">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-5">
+                                                <h4 class="font-bold text-ink mb-3 flex items-center gap-2">
                                                     <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
                                                     </svg>
                                                     Use Ad-Hoc Sessions For:
                                                 </h4>
-                                                <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                                                <ul class="space-y-2 text-sm text-ink-muted">
                                                     <li class="flex items-start gap-2">
                                                         <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
                                                         <span>Quick fixes (typos, small tweaks)</span>
@@ -1722,37 +1778,37 @@
                                                 </ul>
                                             </div>
                                         </div>
-                                        <div class="mt-4 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                                            <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                <strong class="text-yellow-800 dark:text-yellow-300">Tip:</strong> Start with a workflow for quality work. You can always switch to ad-hoc if the structure feels unnecessary. Workflows add minimal overhead but provide significant benefits for anything beyond trivial changes.
+                                        <div class="mt-4 bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-ink-muted">
+                                                <strong class="text-amber-600 dark:text-amber-400">Tip:</strong> Start with a workflow for quality work. You can always switch to ad-hoc if the structure feels unnecessary. Workflows add minimal overhead but provide significant benefits for anything beyond trivial changes.
                                             </p>
                                         </div>
                                     </div>
 
                                     <!-- Next Steps -->
-                                    <div class="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-6">
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Want to Learn More?</h3>
-                                        <p class="text-gray-700 dark:text-gray-300 mb-4">
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Want to Learn More?</h3>
+                                        <p class="text-ink-muted mb-4">
                                             This introduction covered the basics of workflows. For deeper understanding:
                                         </p>
-                                        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                                        <ul class="space-y-2 text-sm text-ink-muted">
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="#workflow-templates" class="text-vscode-accent hover:underline">Workflow Templates</a> - Learn YAML syntax and create custom workflows
+                                                <a href="#workflow-templates" class="text-accent hover:underline">Workflow Templates</a> - Learn YAML syntax and create custom workflows
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="#lanes-mcp" class="text-vscode-accent hover:underline">Lanes MCP</a> - Understand how workflows use Model Context Protocol
+                                                <a href="#lanes-mcp" class="text-accent hover:underline">Lanes MCP</a> - Understand how workflows use Model Context Protocol
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-vscode-accent hover:underline" target="_blank">Anthropic's Research Paper</a> - The science behind workflow harnesses
+                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline" target="_blank">Anthropic's Research Paper</a> - The science behind workflow harnesses
                                             </li>
                                         </ul>
                                     </div>
@@ -1760,67 +1816,66 @@
                             </div>
                         </section>
 
-                        <!-- Section 6: Workflow Structure -->
                         <section id="workflow-structure" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Workflow Structure</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Workflow Structure</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     This section covers the YAML structure of workflow templates, including how to define agents, create loops, and configure steps.
                                 </p>
 
                                 <div class="space-y-10">
                                     <!-- YAML Structure Overview -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">YAML Structure Overview</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            Workflow templates are YAML files. Simple workflows only need <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">name</code>, <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">description</code>, and <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">steps</code>. The <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">agents</code> and <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">loops</code> sections are optional for more complex workflows:
+                                        <h3 class="text-2xl font-bold text-ink mb-4">YAML Structure Overview</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Workflow templates are YAML files. Simple workflows only need <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">name</code>, <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">description</code>, and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">steps</code>. The <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">agents</code> and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">loops</code> sections are optional for more complex workflows:
                                         </p>
 
                                         <div class="space-y-4">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">name</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">name</h4>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> Yes<br>
                                                     <strong>Purpose:</strong> Identifies the workflow. Must be unique within your project.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">description</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">description</h4>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> Yes<br>
                                                     <strong>Purpose:</strong> Human-readable description shown in the workflow selector.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">agents</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">agents</h4>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> object<br>
                                                     <strong>Required:</strong> No (optional)<br>
                                                     <strong>Purpose:</strong> Defines specialized agents with tool permissions and restrictions. Only needed for complex workflows requiring sub-agents.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">loops</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">loops</h4>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> object<br>
                                                     <strong>Required:</strong> No (optional)<br>
                                                     <strong>Purpose:</strong> Reusable sub-workflows that iterate over tasks. Only needed for workflows that process multiple items.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h4 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">steps</h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">steps</h4>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> array<br>
                                                     <strong>Required:</strong> Yes (must have at least one step)<br>
                                                     <strong>Purpose:</strong> The main workflow sequence, executed in order.
@@ -1831,16 +1886,16 @@
 
                                     <!-- Agents Definition -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Agents Definition</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Agents Definition</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Agents are specialized roles that execute workflow steps. Each agent has specific capabilities and restrictions.
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">Agent Configuration</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Agent Configuration</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-purple-400">agents:</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">agents:</span>
   <span class="text-blue-400">orchestrator:</span>
     <span class="text-green-400">description:</span> Plans work and coordinates sub-agents
 
@@ -1853,16 +1908,16 @@
 
                                     <!-- Steps -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Steps (Main Workflow Sequence)</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Steps (Main Workflow Sequence)</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Steps define the main workflow sequence. They are executed in order from top to bottom.
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">Main Steps</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Main Steps</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-purple-400">steps:</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">steps:</span>
   - <span class="text-green-400">id:</span> plan
     <span class="text-green-400">type:</span> action
     <span class="text-green-400">agent:</span> orchestrator
@@ -1894,53 +1949,53 @@
       Review the implementation as a whole...</code></pre>
                                         </div>
 
-                                        <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">Step Fields</h4>
+                                        <h4 class="text-lg font-semibold text-ink mb-3">Step Fields</h4>
                                         <div class="space-y-3">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">id</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">id</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> Yes<br>
                                                     Unique identifier for this step. For loop steps, must match a loop name.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">type</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">type</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> Yes<br>
                                                     <strong>Valid values:</strong> action, loop, ralph
 
                                         <div class="grid md:grid-cols-3 gap-4 mb-4">
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">action</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">action</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     A single operation performed by an agent. Used for planning, reviewing, or any one-off task.
                                                 </p>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                <p class="text-xs text-ink-faint">
                                                     <strong>Required fields:</strong> id, type, instructions<br>
                                                     <strong>Optional fields:</strong> agent
                                                 </p>
                                             </div>
 
-                                            <div class="bg-orange-50 dark:bg-orange-900/20 border-l-4 border-orange-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">loop</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">loop</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     Iterates over a list of tasks, executing the loop's sub-steps for each task.
                                                 </p>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                <p class="text-xs text-ink-faint">
                                                     <strong>Required fields:</strong> id, type<br>
-                                                    <strong>Note:</strong> The id must match a loop name defined in the <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">loops:</code> section
+                                                    <strong>Note:</strong> The id must match a loop name defined in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">loops:</code> section
                                                 </p>
                                             </div>
 
-                                            <div class="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">ralph</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                            <div class="bg-surface-1 border-l-4 border-accent p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">ralph</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     Repeats the same task n times for iterative refinement. Claude works on the task multiple times to improve quality.
                                                 </p>
-                                                <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                <p class="text-xs text-ink-faint">
                                                     <strong>Required fields:</strong> id, type, instructions, n<br>
                                                     <strong>Optional fields:</strong> agent
                                                 </p>
@@ -1950,9 +2005,9 @@
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">agent</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">agent</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> No (for action steps)<br>
                                                     <strong>Not applicable:</strong> For loop steps (agents are specified in loop sub-steps)<br>
@@ -1961,9 +2016,9 @@
                                                 </p>
                                             </div>
 
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">instructions</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">instructions</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> Yes (for action and ralph steps)<br>
                                                     <strong>Not applicable:</strong> For loop steps (instructions are in loop sub-steps)<br>
@@ -1971,19 +2026,19 @@
                                                 </p>
                                             </div>
 
-                                            <div class="bg-blue-50 dark:bg-blue-900/20 border-l-4 border-blue-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">n</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-accent p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">n</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> integer<br>
                                                     <strong>Required:</strong> Yes (for ralph steps only)<br>
                                                     <strong>Valid values:</strong> Positive integer (1 or greater)<br>
-                                                    Number of times to repeat the step. Each iteration stores its output with a unique key (e.g., <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">step-id.1</code>, <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">step-id.2</code>).
+                                                    Number of times to repeat the step. Each iteration stores its output with a unique key (e.g., <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">step-id.1</code>, <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">step-id.2</code>).
                                                 </p>
                                             </div>
 
-                                            <div class="bg-purple-50 dark:bg-purple-900/20 border-l-4 border-purple-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">on_fail</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-violet-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">on_fail</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> No<br>
                                                     <strong>Valid values:</strong> retry, skip, abort<br>
@@ -1992,25 +2047,25 @@
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">context</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">context</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> string<br>
                                                     <strong>Required:</strong> No<br>
                                                     <strong>Valid values:</strong> clear<br>
                                                     <strong>Default:</strong> (no change)<br>
-                                                    When set to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">clear</code>, Lanes will clear the Claude session context when this step begins. This gives the orchestrator a fresh context window for larger development loops. Use this only if you are confident your workflow saves plans in artefacts that can be reloaded.
+                                                    When set to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">clear</code>, Lanes will clear the Claude session context when this step begins. This gives the orchestrator a fresh context window for larger development loops. Use this only if you are confident your workflow saves plans in artefacts that can be reloaded.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-1 font-mono text-sm">artefacts</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">artefacts</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     <strong>Type:</strong> boolean<br>
                                                     <strong>Required:</strong> No<br>
                                                     <strong>Valid values:</strong> true, false<br>
                                                     <strong>Default:</strong> false<br>
-                                                    When set to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">true</code>, Lanes introduces a hook that tracks all files created during this step. Downstream steps are made aware of these artefacts and can read them to gain context. This is especially useful when combined with <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">context: clear</code> to preserve important work across context resets.
+                                                    When set to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">true</code>, Lanes introduces a hook that tracks all files created during this step. Downstream steps are made aware of these artefacts and can read them to gain context. This is especially useful when combined with <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> to preserve important work across context resets.
                                                 </p>
                                             </div>
                                         </div>
@@ -2018,17 +2073,17 @@
 
                                     <!-- Loops and Sub-steps -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Loops and Sub-steps</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Loops and Sub-steps</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Loops are reusable sub-workflows that execute a sequence of steps for each task in a list.
                                             They enable structured iteration over features, fixes, or refactors.
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">Loop Definition</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Loop Definition</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-purple-400">loops:</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">loops:</span>
   <span class="text-blue-400">feature_development:</span>
     - <span class="text-green-400">id:</span> implement
       <span class="text-green-400">agent:</span> implementer
@@ -2071,33 +2126,33 @@
 
                                     <!-- Task Variables -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Task Variables</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Task Variables</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Within loop sub-step instructions, you can reference task properties using curly brace syntax:
                                         </p>
 
                                         <div class="grid md:grid-cols-3 gap-4 mb-4">
-                                            <div class="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">{task.id}</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">{task.id}</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     The unique identifier for the current task (e.g., "add-login-form").
                                                 </p>
                                             </div>
 
-                                            <div class="bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-200 dark:border-indigo-800 rounded-lg p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">{task.title}</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">{task.title}</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     The concise title of the current task (e.g., "Login form UI").
                                                 </p>
                                             </div>
 
                                         </div>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">Example: Using Task Variables</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Example: Using Task Variables</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-green-400">instructions:</span> |
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-green-400">instructions:</span> |
   Implement: {task.title}
 
   Task ID for reference: {task.id}
@@ -2112,89 +2167,88 @@
                             </div>
                         </section>
 
-                        <!-- Section 7: Creating a Workflow -->
                         <section id="creating-workflow" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Creating a Workflow</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Creating a Workflow</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     Learn how to create custom workflows for your projects, with a complete annotated example and best practices.
                                 </p>
 
                                 <div class="space-y-10">
                                     <!-- Creating Custom Workflows -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Step-by-Step Guide</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Step-by-Step Guide</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Custom workflows let you define project-specific development processes. They appear in the "Custom" section of the workflow dropdown.
                                         </p>
                                         <ol class="space-y-4 mb-6">
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Define corresponding agents (if needed)</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400 mb-2">
+                                                    <h5 class="font-semibold text-ink mb-1">Define corresponding agents (if needed)</h5>
+                                                    <p class="text-sm text-ink-muted mb-2">
                                                         First thing you will want to do is make sure you have already created all the agents you want to use in your workflow ahead of time. This is because agent names in your workflow must match either inline definitions or external agent files.
                                                     </p>
-                                                    <div class="bg-gray-100 dark:bg-black/30 rounded p-2 font-mono text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                                    <div class="bg-surface-2 rounded-lg p-2 font-mono text-sm text-ink-muted mb-2">
                                                         mkdir -p .claude/agents<br>
                                                         # Create .claude/agents/my-agent.md
                                                     </div>
-                                                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                                                    <p class="text-xs text-ink-faint">
                                                         Note: Inline agent definitions in the workflow file take precedence over external files.
                                                     </p>
                                                 </div>
                                             </li>
 
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Start creating a workflow document</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h5 class="font-semibold text-ink mb-1">Start creating a workflow document</h5>
+                                                    <p class="text-sm text-ink-muted">
                                                         Open the Lanes sidebar → Open the "Workflow" window → Press the '+' icon.
                                                     </p>
                                                 </div>
                                             </li>
 
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Start creating a workflow document</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
-                                                        If you like, choose a template to start from (feature, bugfix, refactor, or default). This will create a new YAML file in <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.lanes/workflows/</code>.
+                                                    <h5 class="font-semibold text-ink mb-1">Start creating a workflow document</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        If you like, choose a template to start from (feature, bugfix, refactor, or default). This will create a new YAML file in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/workflows/</code>.
                                                     </p>
                                                 </div>
                                             </li>
 
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">4</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">4</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Write your workflow</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h5 class="font-semibold text-ink mb-1">Write your workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
                                                         Edit your the template document, you can use the examples below or use the Workflow Structure page for guidance.
                                                     </p>
                                                 </div>
                                             </li>
 
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">5</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">5</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Validate your workflow</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h5 class="font-semibold text-ink mb-1">Validate your workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
                                                         The lanes extension comes with the 'Validate Workflow' command which you cna find in your command palette. This will check your workflow for common errors and help ensure it is correctly formatted.
                                                     </p>
                                                 </div>
                                             </li>
 
                                             <li class="flex gap-3">
-                                                <span class="flex-shrink-0 w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold text-sm">6</span>
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">6</span>
                                                 <div class="flex-1">
-                                                    <h5 class="font-semibold text-gray-900 dark:text-white mb-1">Use the new Workflow</h5>
-                                                    <p class="text-sm text-gray-600 dark:text-gray-400">
+                                                    <h5 class="font-semibold text-ink mb-1">Use the new Workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
                                                         The workflow should now appear in the workflow dropdown in the Lanes New Session window. You might need to use the refresh button. Select it to start using your custom workflow for new worktrees.
                                                     </p>
                                                 </div>
@@ -2205,16 +2259,16 @@
 
                                     <!-- Simple Workflow Example -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Simple Workflow Example</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Simple Workflow Example</h3>
+                                        <p class="text-ink-muted mb-4">
                                             For straightforward tasks, you can create a workflow with just steps—no agents or loops required. The main Claude agent handles all steps directly:
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">simple-workflow.yaml</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">simple-workflow.yaml</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-gray-500"># A minimal workflow - just name, description, and steps</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-gray-500"># A minimal workflow - just name, description, and steps</span>
 <span class="text-purple-400">name:</span> simple-task
 <span class="text-purple-400">description:</span> Execute a straightforward task
 
@@ -2237,8 +2291,8 @@
       Update documentation if needed.</code></pre>
                                         </div>
 
-                                        <div class="bg-blue-50 dark:bg-blue-900/20 rounded-lg p-4 mb-4">
-                                            <p class="text-sm text-blue-800 dark:text-blue-200">
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4 mb-4">
+                                            <p class="text-sm text-accent">
                                                 <strong>Tip:</strong> Simple workflows are great for quick prototypes, single-developer tasks, or when you don't need specialized phases.
                                             </p>
                                         </div>
@@ -2246,16 +2300,16 @@
 
                                     <!-- Context and Artefacts Example -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Context Management and Artefact Tracking</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            For larger features, you can use <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">context: clear</code> to give Claude a fresh context window between planning and implementation. Combine this with <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">artefacts: true</code> to preserve important work across the reset:
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Context Management and Artefact Tracking</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            For larger features, you can use <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> to give Claude a fresh context window between planning and implementation. Combine this with <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">artefacts: true</code> to preserve important work across the reset:
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden mb-4">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">context-aware-workflow.yaml</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">context-aware-workflow.yaml</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-purple-400">name:</span> feature-with-context-reset
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">name:</span> feature-with-context-reset
 <span class="text-purple-400">description:</span> Large feature development with context management
 
 <span class="text-purple-400">steps:</span>
@@ -2281,40 +2335,40 @@
                                         </div>
 
                                         <div class="grid md:grid-cols-2 gap-4 mb-4">
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">Why use context: clear?</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">Why use context: clear?</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     Large features can exhaust Claude's context window. Clearing between planning and implementation gives the orchestrator a fresh start while the saved plans guide implementation.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-amber-50 dark:bg-amber-900/20 border-l-4 border-amber-500 p-4">
-                                                <h5 class="font-bold text-gray-900 dark:text-white mb-2 font-mono text-sm">Why use artefacts: true?</h5>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">Why use artefacts: true?</h5>
+                                                <p class="text-sm text-ink-muted">
                                                     When context is cleared, downstream steps need to know what files were created. Artefact tracking makes these files visible to subsequent steps.
                                                 </p>
                                             </div>
                                         </div>
 
-                                        <div class="bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 p-4">
-                                            <p class="text-sm text-red-800 dark:text-red-200">
-                                                <strong>Important:</strong> Only use <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">context: clear</code> when you're confident your workflow saves plans in artefacts. Without saved plans, the implementation step won't have the necessary context.
+                                        <div class="bg-red-500/10 border border-red-500/20 p-4">
+                                            <p class="text-sm text-red-600 dark:text-red-400">
+                                                <strong>Important:</strong> Only use <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> when you're confident your workflow saves plans in artefacts. Without saved plans, the implementation step won't have the necessary context.
                                             </p>
                                         </div>
                                     </div>
 
                                     <!-- Complete Annotated Example -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Complete Annotated Example (with Agents and Loops)</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Complete Annotated Example (with Agents and Loops)</h3>
+                                        <p class="text-ink-muted mb-4">
                                             For complex workflows that need specialized agents and iteration over tasks, here's a complete template with detailed annotations:
                                         </p>
 
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg overflow-hidden">
-                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-black/40">
-                                                <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">my-custom-workflow.yaml</span>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">my-custom-workflow.yaml</span>
                                             </div>
-                                            <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto" style="max-height: 600px;"><code><span class="text-gray-500"># ==============================================================================</span>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto" style="max-height: 600px;"><code><span class="text-gray-500"># ==============================================================================</span>
 <span class="text-gray-500"># WORKFLOW TEMPLATE: Custom Feature Development</span>
 <span class="text-gray-500"># ==============================================================================</span>
 
@@ -2471,45 +2525,45 @@
 
                                     <!-- Best Practices -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Best Practices for Custom Workflows</h3>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Best Practices for Custom Workflows</h3>
 
                                         <div class="space-y-4">
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Keep Agent Roles Focused</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Each agent should have a single, clear responsibility. Don't create "super agents" that can do everything.
                                                     Focused agents enforce separation of concerns and prevent mistakes.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use Clear, Specific Instructions</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Instructions should be explicit and actionable. Include numbered steps, expected outputs, and what NOT to do.
                                                     Remember that different Claude instances will execute these instructions across context windows.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use on_fail Strategically</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    • <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">retry</code> - For test failures or transient issues<br>
-                                                    • <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">skip</code> - For optional steps that might fail<br>
-                                                    • <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">abort</code> (default) - For critical steps that must succeed
+                                                <p class="text-sm text-ink-muted">
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">retry</code> - For test failures or transient issues<br>
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">skip</code> - For optional steps that might fail<br>
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">abort</code> (default) - For critical steps that must succeed
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use Task Variables</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    Always reference <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">{task.id}</code> and <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">{task.title}</code>
+                                                <p class="text-sm text-ink-muted">
+                                                    Always reference <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">{task.id}</code> and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">{task.title}</code>
                                                     in loop instructions. This provides context across different tasks and helps Claude understand what it's working on.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Test Your Workflow</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
+                                                <p class="text-sm text-ink-muted">
                                                     Before rolling out a custom workflow to your team, test it on a real task. Verify that:
                                                     • Each step produces the expected output
                                                     • Agents execute their roles correctly
@@ -2518,10 +2572,10 @@
                                                 </p>
                                             </div>
 
-                                            <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
                                                 <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Version Control Your Workflows</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    Commit your <code class="text-xs bg-green-200 dark:bg-green-900/50 px-1 rounded">.lanes/workflows/</code> directory to git.
+                                                <p class="text-sm text-ink-muted">
+                                                    Commit your <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.lanes/workflows/</code> directory to git.
                                                     This ensures your team uses consistent workflows and you can track changes over time.
                                                 </p>
                                             </div>
@@ -2530,40 +2584,40 @@
 
                                     <!-- Validation and Debugging -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Validation and Debugging</h3>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Validation and Debugging</h3>
 
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <p class="text-ink-muted mb-4">
                                             Lanes validates workflow templates when they're loaded. Common validation errors:
                                         </p>
 
                                         <div class="space-y-3">
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <h5 class="font-bold text-red-900 dark:text-red-200 mb-2 font-mono text-sm">Agent 'X' references unknown agent 'Y'</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Agent 'X' references unknown agent 'Y'</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     A step references an agent that isn't defined. Check:
                                                 </p>
-                                                <ul class="text-sm text-gray-700 dark:text-gray-300 list-disc list-inside ml-4">
+                                                <ul class="text-sm text-ink-muted list-disc list-inside ml-4">
                                                     <li>Is the agent name spelled correctly?</li>
-                                                    <li>Is the agent defined in the <code class="text-xs bg-red-200 dark:bg-red-900/50 px-1 rounded">agents:</code> section?</li>
-                                                    <li>Does a matching file exist in <code class="text-xs bg-red-200 dark:bg-red-900/50 px-1 rounded">.claude/agents/</code>?</li>
+                                                    <li>Is the agent defined in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">agents:</code> section?</li>
+                                                    <li>Does a matching file exist in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.claude/agents/</code>?</li>
                                                 </ul>
                                             </div>
 
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <h5 class="font-bold text-red-900 dark:text-red-200 mb-2 font-mono text-sm">Loop step 'X' references unknown loop definition</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300">
-                                                    A <code class="text-xs bg-red-200 dark:bg-red-900/50 px-1 rounded">type: loop</code> step's <code class="text-xs bg-red-200 dark:bg-red-900/50 px-1 rounded">id</code>
-                                                    doesn't match any loop in the <code class="text-xs bg-red-200 dark:bg-red-900/50 px-1 rounded">loops:</code> section.
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Loop step 'X' references unknown loop definition</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    A <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">type: loop</code> step's <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">id</code>
+                                                    doesn't match any loop in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">loops:</code> section.
                                                     The loop step ID must exactly match a loop name.
                                                 </p>
                                             </div>
 
-                                            <div class="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4">
-                                                <h5 class="font-bold text-red-900 dark:text-red-200 mb-2 font-mono text-sm">Invalid YAML syntax</h5>
-                                                <p class="text-sm text-gray-700 dark:text-gray-300 mb-2">
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Invalid YAML syntax</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
                                                     YAML parsing failed. Common issues:
                                                 </p>
-                                                <ul class="text-sm text-gray-700 dark:text-gray-300 list-disc list-inside ml-4">
+                                                <ul class="text-sm text-ink-muted list-disc list-inside ml-4">
                                                     <li>Incorrect indentation (YAML uses 2 spaces, not tabs)</li>
                                                     <li>Missing colons after keys</li>
                                                     <li>Unquoted strings with special characters</li>
@@ -2574,23 +2628,23 @@
                                     </div>
 
                                     <!-- Next Steps -->
-                                    <div class="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-6">
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Next Steps</h3>
-                                        <p class="text-gray-700 dark:text-gray-300 mb-4">
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Next Steps</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Now that you understand workflow templates, you might want to:
                                         </p>
-                                        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                                        <ul class="space-y-2 text-sm text-ink-muted">
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="#lanes-mcp" class="text-vscode-accent hover:underline">Learn about the Lanes MCP Server</a> - Understanding how workflows communicate with Claude
+                                                <a href="#lanes-mcp" class="text-accent hover:underline">Learn about the Lanes MCP Server</a> - Understanding how workflows communicate with Claude
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <span>Study the built-in workflows in <code class="text-xs bg-blue-200 dark:bg-blue-900/50 px-1 rounded">workflows/</code> for real-world examples</span>
+                                                <span>Study the built-in workflows in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">workflows/</code> for real-world examples</span>
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -2602,7 +2656,7 @@
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-vscode-accent hover:underline" target="_blank">Read Anthropic's research</a> on effective harnesses for long-running agents
+                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline" target="_blank">Read Anthropic's research</a> on effective harnesses for long-running agents
                                             </li>
                                         </ul>
                                     </div>
@@ -2610,36 +2664,35 @@
                             </div>
                         </section>
 
-                        <!-- Section 8: Lanes MCP -->
                         <section id="lanes-mcp" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
                                 <div class="flex items-center gap-4 mb-6">
-                                    <div class="w-12 h-12 rounded-lg bg-vscode-accent/10 flex items-center justify-center">
-                                        <svg class="w-6 h-6 text-vscode-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
                                     </div>
-                                    <h2 class="text-3xl font-bold text-gray-900 dark:text-white">Lanes MCP</h2>
+                                    <h2 class="text-3xl font-bold text-ink">Lanes MCP</h2>
                                 </div>
-                                <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                <p class="text-ink-muted mb-6">
                                     The Lanes Model Context Protocol (MCP) server enables workflows to maintain state, track progress, and coordinate between agents across context windows. This technical explains how the MCP integration works under the hood.
                                 </p>
 
                                 <div class="space-y-8">
                                     <!-- What is MCP? -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">What is MCP?</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            The <strong class="text-gray-900 dark:text-white">Model Context Protocol (MCP)</strong> is Anthropic's open protocol that enables AI assistants to securely connect to data sources and tools. It provides a standardized way to extend Claude with custom capabilities while maintaining security and control.
+                                        <h3 class="text-2xl font-bold text-ink mb-4">What is MCP?</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The <strong class="text-ink">Model Context Protocol (MCP)</strong> is Anthropic's open protocol that enables AI assistants to securely connect to data sources and tools. It provides a standardized way to extend Claude with custom capabilities while maintaining security and control.
                                         </p>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <p class="text-ink-muted mb-4">
                                             The Lanes MCP server is a specialized MCP implementation that gives Claude fine-grained control over workflow execution:
                                         </p>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4">
-                                            <li><strong class="text-gray-900 dark:text-white">Workflow State Management:</strong> Tracks current position in workflow, step outputs, and task progress</li>
-                                            <li><strong class="text-gray-900 dark:text-white">Session Management:</strong> Allows Claude to request creation of new Lanes sessions programmatically</li>
-                                            <li><strong class="text-gray-900 dark:text-white">Context Preservation:</strong> Maintains history across steps so agents can reference earlier work</li>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Workflow State Management:</strong> Tracks current position in workflow, step outputs, and task progress</li>
+                                            <li><strong class="text-ink">Session Management:</strong> Allows Claude to request creation of new Lanes sessions programmatically</li>
+                                            <li><strong class="text-ink">Context Preservation:</strong> Maintains history across steps so agents can reference earlier work</li>
                                         </ul>
-                                        <div class="mt-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
-                                            <p class="text-sm text-blue-900 dark:text-blue-300">
+                                        <div class="mt-4 bg-accent-dim border border-accent/20 rounded-lg p-4">
+                                            <p class="text-sm text-accent">
                                                 <strong>Learn more:</strong> Visit <a href="https://modelcontextprotocol.io/" class="underline hover:text-blue-700 dark:hover:text-blue-400" target="_blank">modelcontextprotocol.io</a> for the official MCP specification.
                                             </p>
                                         </div>
@@ -2647,12 +2700,12 @@
 
                                     <!-- Architecture -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Architecture</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Architecture</h3>
+                                        <p class="text-ink-muted mb-4">
                                             When you start a workflow session, Lanes automatically spins up an MCP server process that communicates with Claude via stdio:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-6 mb-4">
-                                            <pre class="text-sm font-mono text-gray-800 dark:text-gray-300 overflow-x-auto"><code>┌─────────────────────────────────────────────────────────┐
+                                        <div class="bg-surface-2 rounded-lg p-6 mb-4">
+                                            <pre class="text-sm font-mono text-ink-muted overflow-x-auto"><code>┌─────────────────────────────────────────────────────────┐
 │                    VS Code Extension                    │
 │                                                         │
 │  ┌──────────────────────────────────────────────────┐  │
@@ -2708,41 +2761,41 @@
 │  Calls MCP tools to navigate workflow steps             │
 └─────────────────────────────────────────────────────────┘</code></pre>
                                         </div>
-                                        <p class="text-gray-600 dark:text-gray-400">
+                                        <p class="text-ink-muted">
                                             The MCP server runs in the background for the lifetime of the session. Claude can call the MCP tools at any time to query or update workflow state.
                                         </p>
                                     </div>
 
                                     <!-- MCP Tools -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">MCP Tools Reference</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">MCP Tools Reference</h3>
+                                        <p class="text-ink-muted mb-4">
                                             The Lanes MCP server exposes six tools that Claude uses to control workflow execution:
                                         </p>
 
                                         <!-- Tool: workflow_start -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">workflow_start</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_start</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Initialize the workflow and return the first step instructions. If the workflow was previously started, returns the current status (enables resume).
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <div class="mb-2">
                                                             <span class="text-blue-600 dark:text-blue-400">summary</span>
                                                             <span class="text-gray-500">?: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Optional brief summary (max 10 words)</span>
+                                                            <span class="text-ink-muted ml-2">// Optional brief summary (max 10 words)</span>
                                                         </div>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "status": "active",
   "step": {
     "id": "plan",
@@ -2760,8 +2813,8 @@
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example Usage:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <span class="text-purple-600 dark:text-purple-400">workflow_start</span>(<span class="text-green-600 dark:text-green-400">"Add user authentication"</span>)
                                                     </div>
                                                 </div>
@@ -2770,32 +2823,32 @@
 
                                         <!-- Tool: workflow_set_tasks -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">workflow_set_tasks</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_set_tasks</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Associate tasks with a loop step. Each task will be iterated through the loop's sub-steps.</code>.
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <div class="mb-2">
                                                             <span class="text-blue-600 dark:text-blue-400">loop_id</span>
                                                             <span class="text-gray-500">: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Loop step ID to associate tasks with</span>
+                                                            <span class="text-ink-muted ml-2">// Loop step ID to associate tasks with</span>
                                                         </div>
                                                         <div>
                                                             <span class="text-blue-600 dark:text-blue-400">tasks</span>
                                                             <span class="text-gray-500">: Task[]</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Array of task objects</span>
+                                                            <span class="text-ink-muted ml-2">// Array of task objects</span>
                                                         </div>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Task Object:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Task Object:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
   "id": string,            // Unique identifier
   "title": string,         // Human-readable title
   "description"?: string   // Optional detailed description
@@ -2803,18 +2856,18 @@
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
   "success": true,
   "tasksSet": 3
 }</pre>
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example Usage:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200"><span class="text-purple-600 dark:text-purple-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
   {
     <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"login-form"</span>,
     <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Create login form"</span>,
@@ -2833,23 +2886,23 @@
 
                                         <!-- Tool: workflow_status -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">workflow_status</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_status</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Get current workflow position with full context. Returns the current step, sub-step (if in a loop), agent, instructions, and progress.
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-                                                        <span class="text-gray-600 dark:text-gray-400">None</span>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns (in loop):</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns (in loop):</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "status": "active",
   "step": {
     "id": "feature_development",
@@ -2879,27 +2932,27 @@
 
                                         <!-- Tool: workflow_advance -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">workflow_advance</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_advance</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                                                    Complete the current step/sub-step and advance to the next. When a task completes (all sub-steps done), automatically updates <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow-state.json</code> to mark the task as <code class="text-xs">passes: true</code>.
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Complete the current step/sub-step and advance to the next. When a task completes (all sub-steps done), automatically updates <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> to mark the task as <code class="text-xs">passes: true</code>.
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <div>
                                                             <span class="text-blue-600 dark:text-blue-400">output</span>
                                                             <span class="text-gray-500">: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Summary of what was accomplished</span>
+                                                            <span class="text-ink-muted ml-2">// Summary of what was accomplished</span>
                                                         </div>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "status": "active",
   "step": {
     "id": "feature_development",
@@ -2921,8 +2974,8 @@
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example Usage:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <span class="text-purple-600 dark:text-purple-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Implemented login form with email and password fields"</span>)
                                                     </div>
                                                 </div>
@@ -2931,23 +2984,23 @@
 
                                         <!-- Tool: workflow_context -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">workflow_context</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_context</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Get outputs from previous steps. Returns a record keyed by step path (e.g., <code class="text-xs">"plan"</code> or <code class="text-xs">"feature_development.login-form.implement"</code>).
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-                                                        <span class="text-gray-600 dark:text-gray-400">None</span>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "plan": "Analyzed requirements. Identified 2 tasks: login-form, auth-api",
   "define_tasks": "Created task list with 2 tasks",
   "feature_development.login-form.implement": "Implemented login form with...",
@@ -2956,7 +3009,7 @@
 }</pre>
                                                     </div>
                                                 </div>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400 mt-3">
+                                                <p class="text-xs text-ink-muted mt-3">
                                                     This enables agents to reference earlier work and build upon previous decisions.
                                                 </p>
                                             </div>
@@ -2964,51 +3017,51 @@
 
                                         <!-- Tool: session_create -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">session_create</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">session_create</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                                                    Request creation of a new Lanes session. Writes a config file to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.lanes/pending-sessions/</code> that the VS Code extension monitors and processes.
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Request creation of a new Lanes session. Writes a config file to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/pending-sessions/</code> that the VS Code extension monitors and processes.
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
                                                         <div class="mb-2">
                                                             <span class="text-blue-600 dark:text-blue-400">name</span>
                                                             <span class="text-gray-500">: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Session name (sanitized for git)</span>
+                                                            <span class="text-ink-muted ml-2">// Session name (sanitized for git)</span>
                                                         </div>
                                                         <div class="mb-2">
                                                             <span class="text-blue-600 dark:text-blue-400">sourceBranch</span>
                                                             <span class="text-gray-500">: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Branch to create worktree from</span>
+                                                            <span class="text-ink-muted ml-2">// Branch to create worktree from</span>
                                                         </div>
                                                         <div class="mb-2">
                                                             <span class="text-blue-600 dark:text-blue-400">prompt</span>
                                                             <span class="text-gray-500">?: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Optional starting prompt</span>
+                                                            <span class="text-ink-muted ml-2">// Optional starting prompt</span>
                                                         </div>
                                                         <div>
                                                             <span class="text-blue-600 dark:text-blue-400">workflow</span>
                                                             <span class="text-gray-500">?: string</span>
-                                                            <span class="text-gray-600 dark:text-gray-400 ml-2">// Workflow template (feature, bugfix, etc.)</span>
+                                                            <span class="text-ink-muted ml-2">// Workflow template (feature, bugfix, etc.)</span>
                                                         </div>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
   "success": true,
   "configPath": ".lanes/pending-sessions/fix-auth-bug-1736454321.json"
 }</pre>
                                                     </div>
                                                 </div>
                                                 <div>
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example Usage:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200"><span class="text-purple-600 dark:text-purple-400">session_create</span>(
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">session_create</span>(
   <span class="text-green-600 dark:text-green-400">"fix-auth-bug"</span>,
   <span class="text-green-600 dark:text-green-400">"main"</span>,
   <span class="text-green-600 dark:text-green-400">"Fix authentication timeout issue"</span>,
@@ -3021,36 +3074,36 @@
 
                                         <!-- Tool: session_clear -->
                                         <div class="mb-6">
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-5">
-                                                <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-3">
-                                                    <code class="text-base bg-gray-200 dark:bg-black/40 px-2 py-1 rounded">session_clear</code>
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">session_clear</code>
                                                 </h4>
-                                                <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+                                                <p class="text-sm text-ink-muted mb-3">
                                                     Clear the Claude session's context window. This gives the agent a fresh start while preserving the workflow state. Useful when transitioning between planning and implementation phases for large features.
                                                 </p>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Parameters:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-                                                        <span class="text-gray-600 dark:text-gray-400">None</span>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Returns:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono">
-<pre class="text-gray-800 dark:text-gray-200">{
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
   "success": true,
   "message": "Session context cleared"
 }</pre>
                                                     </div>
                                                 </div>
                                                 <div class="mb-3">
-                                                    <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example Usage:</p>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200"><span class="text-purple-600 dark:text-purple-400">session_clear</span>()</pre>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">session_clear</span>()</pre>
                                                     </div>
                                                 </div>
-                                                <p class="text-xs text-gray-600 dark:text-gray-400 mt-3">
-                                                    <strong>Note:</strong> This is typically called automatically by Lanes when a workflow step has <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">context: clear</code> set. You can also call it manually if needed.
+                                                <p class="text-xs text-ink-muted mt-3">
+                                                    <strong>Note:</strong> This is typically called automatically by Lanes when a workflow step has <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> set. You can also call it manually if needed.
                                                 </p>
                                             </div>
                                         </div>
@@ -3058,19 +3111,19 @@
 
                                     <!-- Workflow State Persistence -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Workflow State Persistence</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
-                                            The MCP server persists workflow state to <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow-state.json</code> in the worktree root after every state change. This enables:
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Workflow State Persistence</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The MCP server persists workflow state to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> in the worktree root after every state change. This enables:
                                         </p>
-                                        <ul class="list-disc list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4 mb-4">
-                                            <li><strong class="text-gray-900 dark:text-white">Resume capability:</strong> If Claude crashes or loses context, calling <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow_start</code> again restores to the current position</li>
-                                            <li><strong class="text-gray-900 dark:text-white">Context preservation:</strong> All step outputs are stored and accessible via <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">workflow_context</code></li>
-                                            <li><strong class="text-gray-900 dark:text-white">Progress tracking:</strong> Current step, task progress, and completion status are persisted</li>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4 mb-4">
+                                            <li><strong class="text-ink">Resume capability:</strong> If Claude crashes or loses context, calling <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow_start</code> again restores to the current position</li>
+                                            <li><strong class="text-ink">Context preservation:</strong> All step outputs are stored and accessible via <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow_context</code></li>
+                                            <li><strong class="text-ink">Progress tracking:</strong> Current step, task progress, and completion status are persisted</li>
                                         </ul>
                                         <div class="mb-4">
-                                            <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Example workflow-state.json:</p>
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-300">{
+                                            <p class="text-xs font-semibold text-ink-muted mb-2">Example workflow-state.json:</p>
+                                            <div class="bg-surface-2 rounded-lg p-4 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "status": "active",
   "currentStepIndex": 2,
   "currentSubStepIndex": 1,
@@ -3100,8 +3153,8 @@
 }</pre>
                                             </div>
                                         </div>
-                                        <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-4">
-                                            <p class="text-sm text-yellow-900 dark:text-yellow-300">
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-amber-600 dark:text-amber-400">
                                                 <strong>Important:</strong> The workflow state file is automatically managed by the MCP server. Do not manually edit this file.
                                             </p>
                                         </div>
@@ -3109,78 +3162,78 @@
 
                                     <!-- Example Usage Flow -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Example Usage Flow</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Example Usage Flow</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Here's how Claude uses the MCP tools to execute a typical workflow:
                                         </p>
-                                        <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-6">
+                                        <div class="bg-surface-2 rounded-lg p-6">
                                             <div class="space-y-4 text-sm font-mono">
                                                 <div>
                                                     <div class="text-purple-600 dark:text-purple-400 mb-1">// 1. Start the workflow</div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 mb-2">
-                                                        <span class="text-gray-700 dark:text-gray-300">Claude calls: </span>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
                                                         <span class="text-blue-600 dark:text-blue-400">workflow_start</span>(<span class="text-green-600 dark:text-green-400">"Add user authentication"</span>)
                                                     </div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3">
-                                                        <span class="text-gray-700 dark:text-gray-300">Returns: </span>
-                                                        <span class="text-gray-600 dark:text-gray-400">"Step 1: plan" with instructions</span>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Step 1: plan" with instructions</span>
                                                     </div>
                                                 </div>
 
                                                 <div class="border-l-2 border-blue-500 pl-4">
                                                     <div class="text-purple-600 dark:text-purple-400 mb-1">// 2. Claude reads code and plans the work</div>
-                                                    <div class="text-gray-600 dark:text-gray-400 mb-2">Analyzes codebase, identifies 2 tasks needed...</div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 mb-2">
-                                                        <span class="text-gray-700 dark:text-gray-300">Claude calls: </span>
+                                                    <div class="text-ink-muted mb-2">Analyzes codebase, identifies 2 tasks needed...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
                                                         <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Analyzed requirements. Need 2 tasks: login form and auth API"</span>)
                                                     </div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3">
-                                                        <span class="text-gray-700 dark:text-gray-300">Returns: </span>
-                                                        <span class="text-gray-600 dark:text-gray-400">"Step 2: define_tasks" with instructions</span>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Step 2: define_tasks" with instructions</span>
                                                     </div>
                                                 </div>
 
                                                 <div class="border-l-2 border-green-500 pl-4">
                                                     <div class="text-purple-600 dark:text-purple-400 mb-1">// 3. Define the task list</div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 mb-2 overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-200"><span class="text-gray-700 dark:text-gray-300">Claude calls: </span><span class="text-blue-600 dark:text-blue-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2 overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-ink-muted">Claude calls: </span><span class="text-blue-600 dark:text-blue-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
   { <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"login-form"</span>, <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Create login form"</span>, ... },
   { <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"auth-api"</span>, <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Implement auth API"</span>, ... }
 ])</pre>
                                                     </div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3">
-                                                        <span class="text-gray-700 dark:text-gray-300">Returns: </span>
-                                                        <span class="text-gray-600 dark:text-gray-400">"Task 1/2: implement login-form" with instructions</span>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: implement login-form" with instructions</span>
                                                     </div>
                                                 </div>
 
                                                 <div class="border-l-2 border-yellow-500 pl-4">
                                                     <div class="text-purple-600 dark:text-purple-400 mb-1">// 4. Implement the first task</div>
-                                                    <div class="text-gray-600 dark:text-gray-400 mb-2">Claude writes the login form code...</div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 mb-2">
-                                                        <span class="text-gray-700 dark:text-gray-300">Claude calls: </span>
+                                                    <div class="text-ink-muted mb-2">Claude writes the login form code...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
                                                         <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Implemented login form with email and password fields"</span>)
                                                     </div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3">
-                                                        <span class="text-gray-700 dark:text-gray-300">Returns: </span>
-                                                        <span class="text-gray-600 dark:text-gray-400">"Task 1/2: test login-form" with instructions</span>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: test login-form" with instructions</span>
                                                     </div>
                                                 </div>
 
                                                 <div class="border-l-2 border-red-500 pl-4">
                                                     <div class="text-purple-600 dark:text-purple-400 mb-1">// 5. Run tests</div>
-                                                    <div class="text-gray-600 dark:text-gray-400 mb-2">Claude runs test suite, fixes any failures...</div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3 mb-2">
-                                                        <span class="text-gray-700 dark:text-gray-300">Claude calls: </span>
+                                                    <div class="text-ink-muted mb-2">Claude runs test suite, fixes any failures...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
                                                         <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"All tests pass"</span>)
                                                     </div>
-                                                    <div class="bg-white dark:bg-black/20 rounded p-3">
-                                                        <span class="text-gray-700 dark:text-gray-300">Returns: </span>
-                                                        <span class="text-gray-600 dark:text-gray-400">"Task 1/2: review login-form" with instructions</span>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: review login-form" with instructions</span>
                                                     </div>
                                                 </div>
 
-                                                <div class="text-gray-600 dark:text-gray-400 text-center py-2">
+                                                <div class="text-ink-muted text-center py-2">
                                                     ... and so on through all tasks and steps ...
                                                 </div>
                                             </div>
@@ -3189,19 +3242,19 @@
 
                                     <!-- MCP Configuration -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">MCP Configuration</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">MCP Configuration</h3>
+                                        <p class="text-ink-muted mb-4">
                                             The Lanes MCP server is automatically configured when you create a workflow session. The VS Code extension:
                                         </p>
-                                        <ol class="list-decimal list-inside text-gray-600 dark:text-gray-400 space-y-2 ml-4 mb-4">
+                                        <ol class="list-decimal list-inside text-ink-muted space-y-2 ml-4 mb-4">
                                             <li>Spawns the MCP server process with the workflow path and worktree path</li>
-                                            <li>Generates a <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">.claude/mcp.json</code> config file in the worktree</li>
-                                            <li>Passes the config to Claude Code via the <code class="text-xs bg-gray-200 dark:bg-black/30 px-1 rounded">--mcp-config</code> flag</li>
+                                            <li>Generates a <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/mcp.json</code> config file in the worktree</li>
+                                            <li>Passes the config to Claude Code via the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">--mcp-config</code> flag</li>
                                         </ol>
                                         <div class="mb-4">
-                                            <p class="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">Generated .claude/mcp.json:</p>
-                                            <div class="bg-gray-100 dark:bg-black/30 rounded-lg p-4 text-xs font-mono overflow-x-auto">
-<pre class="text-gray-800 dark:text-gray-300">{
+                                            <p class="text-xs font-semibold text-ink-muted mb-2">Generated .claude/mcp.json:</p>
+                                            <div class="bg-surface-2 rounded-lg p-4 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
   "mcpServers": {
     "lanes-workflow": {
       "command": "node",
@@ -3215,35 +3268,35 @@
 }</pre>
                                             </div>
                                         </div>
-                                        <p class="text-gray-600 dark:text-gray-400">
+                                        <p class="text-ink-muted">
                                             The MCP server runs in the background for the lifetime of the session. It's automatically stopped when the session is closed.
                                         </p>
                                     </div>
 
                                     <!-- Next Steps -->
-                                    <div class="bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-6">
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Next Steps</h3>
-                                        <p class="text-gray-700 dark:text-gray-300 mb-4">
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Next Steps</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Now that you understand the Lanes MCP server, you might want to:
                                         </p>
-                                        <ul class="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                                        <ul class="space-y-2 text-sm text-ink-muted">
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <span>Explore the MCP server source code in <code class="text-xs bg-blue-200 dark:bg-blue-900/50 px-1 rounded">src/mcp/</code></span>
+                                                <span>Explore the MCP server source code in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">src/mcp/</code></span>
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="#workflow-templates" class="text-vscode-accent hover:underline">Review the Workflow Templates documentation</a> to understand how workflows are structured
+                                                <a href="#workflow-templates" class="text-accent hover:underline">Review the Workflow Templates documentation</a> to understand how workflows are structured
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                                                 </svg>
-                                                <a href="https://modelcontextprotocol.io/" class="text-vscode-accent hover:underline" target="_blank">Read the MCP specification</a> to understand the protocol
+                                                <a href="https://modelcontextprotocol.io/" class="text-accent hover:underline" target="_blank">Read the MCP specification</a> to understand the protocol
                                             </li>
                                             <li class="flex items-center gap-2">
                                                 <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -3257,21 +3310,20 @@
                             </div>
                         </section>
 
-                        <!-- Section: Contributing -->
                         <section id="contributing" class="doc-section mb-16 scroll-mt-24 hidden">
-                            <div class="bg-white dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-8">
-                                <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-6">Contributing to Lanes</h2>
-                                <p class="text-gray-600 dark:text-gray-400 mb-8">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <h2 class="text-3xl font-bold text-ink mb-6">Contributing to Lanes</h2>
+                                <p class="text-ink-muted mb-8">
                                     Lanes is an open-source project, and we welcome contributions from the community. Whether you want to report a bug, suggest a feature, or contribute code, here's how to get involved.
                                 </p>
 
                                 <!-- Development Guidelines -->
                                 <div>
-                                    <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Development Guidelines</h3>
-                                    <p class="text-gray-600 dark:text-gray-400 mb-6">
+                                    <h3 class="text-2xl font-bold text-ink mb-4">Development Guidelines</h3>
+                                    <p class="text-ink-muted mb-6">
                                         Interested in contributing code? Check out our comprehensive contribution guide for development setup, coding standards, and the pull request process.
                                     </p>
-                                    <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="inline-flex items-center gap-2 bg-purple-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-purple-700 transition-colors mb-6">
+                                    <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="inline-flex items-center gap-2 bg-violet-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-violet-700 transition-colors mb-6">
                                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
                                         </svg>
@@ -3282,24 +3334,24 @@
                                 <div class="space-y-8">
                                     <!-- Reporting Issues -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Reporting Issues</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Reporting Issues</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Found a bug? Please report it through our issue tracker with as much detail as possible.
                                         </p>
-                                            <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">Issue Template</h4>
-                                            <div class="text-sm text-gray-600 dark:text-gray-400 space-y-3 mb-3">
+                                            <h4 class="text-lg font-semibold text-ink mb-3">Issue Template</h4>
+                                            <div class="text-sm text-ink-muted space-y-3 mb-3">
                                                 <p>When reporting a bug, please include the following information:</p>
-                                                <div class="bg-white dark:bg-vscode-sidebar rounded-md p-4 font-mono text-xs space-y-2 border border-gray-200 dark:border-white/10 mb-6">
-                                                    <p><strong class="text-gray-900 dark:text-white">**Description**</strong><br>A clear description of the issue</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Steps to Reproduce**</strong><br>1. Go to...<br>2. Click on...<br>3. See error</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Expected Behavior**</strong><br>What should happen</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Actual Behavior**</strong><br>What actually happens</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Environment**</strong><br>- OS: [e.g., macOS 14.0]<br>- VS Code version: [e.g., 1.85.0]<br>- Lanes version: [e.g., v1.0.2]<br>- Node version: [e.g., v18.17.0]</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Logs**</strong><br>[Relevant error messages or console output]</p>
+                                                <div class="bg-surface-1 rounded-md p-4 font-mono text-xs space-y-2 border border-border mb-6">
+                                                    <p><strong class="text-ink">**Description**</strong><br>A clear description of the issue</p>
+                                                    <p><strong class="text-ink">**Steps to Reproduce**</strong><br>1. Go to...<br>2. Click on...<br>3. See error</p>
+                                                    <p><strong class="text-ink">**Expected Behavior**</strong><br>What should happen</p>
+                                                    <p><strong class="text-ink">**Actual Behavior**</strong><br>What actually happens</p>
+                                                    <p><strong class="text-ink">**Environment**</strong><br>- OS: [e.g., macOS 14.0]<br>- VS Code version: [e.g., 1.85.0]<br>- Lanes version: [e.g., v1.0.2]<br>- Node version: [e.g., v18.17.0]</p>
+                                                    <p><strong class="text-ink">**Logs**</strong><br>[Relevant error messages or console output]</p>
                                                 </div>
                                             </div>
                                         
-                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=bug_report.md" class="inline-flex items-center gap-2 bg-vscode-accent text-white px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
+                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=bug_report.md" class="inline-flex items-center gap-2 bg-accent text-white px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
                                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
                                             </svg>
@@ -3309,22 +3361,22 @@
 
                                     <!-- Suggesting Features -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Suggesting Features</h3>
-                                        <p class="text-gray-600 dark:text-gray-400 mb-4">
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Suggesting Features</h3>
+                                        <p class="text-ink-muted mb-4">
                                             Have an idea for improving Lanes? We'd love to hear it! Please provide a clear description of the problem you're trying to solve.
                                         </p>
-                                            <h4 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">Feature Request Template</h4>
-                                            <div class="text-sm text-gray-600 dark:text-gray-400 space-y-3 mb-4">
+                                            <h4 class="text-lg font-semibold text-ink mb-3">Feature Request Template</h4>
+                                            <div class="text-sm text-ink-muted space-y-3 mb-4">
                                                 <p>When requesting a feature, please include the following information:</p>
-                                                <div class="bg-white dark:bg-vscode-sidebar rounded-md p-4 font-mono text-xs space-y-2 border border-gray-200 dark:border-white/10 mb-6">
-                                                    <p><strong class="text-gray-900 dark:text-white">**Problem Description**</strong><br>Describe the problem you want to solve</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Proposed Solution**</strong><br>Describe your proposed solution (if you have one)</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Benefits**</strong><br>Explain how this would benefit other users</p>
-                                                    <p><strong class="text-gray-900 dark:text-white">**Alternatives**</strong><br>Any alternative approaches you've considered</p>
+                                                <div class="bg-surface-1 rounded-md p-4 font-mono text-xs space-y-2 border border-border mb-6">
+                                                    <p><strong class="text-ink">**Problem Description**</strong><br>Describe the problem you want to solve</p>
+                                                    <p><strong class="text-ink">**Proposed Solution**</strong><br>Describe your proposed solution (if you have one)</p>
+                                                    <p><strong class="text-ink">**Benefits**</strong><br>Explain how this would benefit other users</p>
+                                                    <p><strong class="text-ink">**Alternatives**</strong><br>Any alternative approaches you've considered</p>
                                                 </div>
                                             </div>
 
-                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=feature_request.md" class="inline-flex items-center gap-2 bg-green-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-green-700 transition-colors">
+                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=feature_request.md" class="inline-flex items-center gap-2 bg-emerald-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-emerald-700 transition-colors">
                                             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
                                             </svg>
@@ -3334,45 +3386,46 @@
 
                                     <!-- Quick Links -->
                                     <div>
-                                        <h3 class="text-2xl font-bold text-gray-900 dark:text-white mb-4">Quick Links</h3>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Quick Links</h3>
                                         <div class="grid sm:grid-cols-2 gap-4">
-                                            <a href="https://github.com/FilipeJesus/lanes/issues" class="flex items-center gap-3 bg-gray-50 dark:bg-vscode-bg rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors">
-                                                <svg class="w-6 h-6 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <a href="https://github.com/FilipeJesus/lanes/issues" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
                                                 </svg>
-                                                <span class="font-medium text-gray-900 dark:text-white">Issue Tracker</span>
+                                                <span class="font-medium text-ink">Issue Tracker</span>
                                             </a>
-                                            <a href="https://github.com/FilipeJesus/lanes/pulls" class="flex items-center gap-3 bg-gray-50 dark:bg-vscode-bg rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors">
-                                                <svg class="w-6 h-6 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <a href="https://github.com/FilipeJesus/lanes/pulls" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
                                                 </svg>
-                                                <span class="font-medium text-gray-900 dark:text-white">Pull Requests</span>
+                                                <span class="font-medium text-ink">Pull Requests</span>
                                             </a>
-                                            <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="flex items-center gap-3 bg-gray-50 dark:bg-vscode-bg rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors">
-                                                <svg class="w-6 h-6 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
                                                 </svg>
-                                                <span class="font-medium text-gray-900 dark:text-white">Contributing Guide</span>
+                                                <span class="font-medium text-ink">Contributing Guide</span>
                                             </a>
-                                            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center gap-3 bg-gray-50 dark:bg-vscode-bg rounded-lg p-4 hover:bg-gray-100 dark:hover:bg-white/5 transition-colors">
-                                                <svg class="w-6 h-6 text-gray-600 dark:text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+                                            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="currentColor" viewBox="0 0 24 24">
                                                     <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                                                 </svg>
-                                                <span class="font-medium text-gray-900 dark:text-white">GitHub Repository</span>
+                                                <span class="font-medium text-ink">GitHub Repository</span>
                                             </a>
                                         </div>
                                     </div>
 
                                     <!-- Thank You -->
-                                    <div class="bg-gradient-to-r from-vscode-accent/10 to-purple-600/10 rounded-lg p-6 text-center">
-                                        <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Thank You for Contributing!</h3>
-                                        <p class="text-gray-600 dark:text-gray-400">
+                                    <div class="bg-surface-1 border border-border rounded-lg p-6 text-center">
+                                        <h3 class="text-xl font-bold text-ink mb-2">Thank You for Contributing!</h3>
+                                        <p class="text-ink-muted">
                                             Every contribution helps make Lanes better for everyone. Whether it's reporting bugs, suggesting features, or writing code, we appreciate your support.
                                         </p>
                                     </div>
                                 </div>
                             </div>
                         </section>
+
 
                     </div>
                 </div>
@@ -3382,80 +3435,84 @@
     </main>
 
     <!-- Footer -->
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6">
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
-                <a href="https://github.com/FilipeJesus/lanes/issues" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Issues</a>
-                <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">VS Code Marketplace</a>
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="blog/index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality (desktop and mobile)
-        const themeToggle = document.getElementById('theme-toggle');
-        const themeToggleMobile = document.getElementById('theme-toggle-mobile');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-        const sunIconMobile = document.getElementById('sun-icon-mobile');
-        const moonIconMobile = document.getElementById('moon-icon-mobile');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-                sunIconMobile.classList.add('hidden');
-                moonIconMobile.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-                sunIconMobile.classList.remove('hidden');
-                moonIconMobile.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
-
-        updateIcons();
+        syncThemeIcons();
 
         function toggleTheme() {
-            if (document.documentElement.classList.contains('dark')) {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
         }
 
-        themeToggle.addEventListener('click', toggleTheme);
-        themeToggleMobile.addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-m').addEventListener('click', toggleTheme);
 
-        // Main mobile navigation toggle (hamburger menu)
-        const mainMobileNavToggle = document.getElementById('main-mobile-nav-toggle');
-        const mainMobileNav = document.getElementById('main-mobile-nav');
-        const hamburgerIcon = document.getElementById('hamburger-icon');
-        const closeIcon = document.getElementById('close-icon');
+        // --- Mobile nav drawer ---
+        const mobileNavDrawer = document.getElementById('mobile-nav-drawer');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
 
-        mainMobileNavToggle.addEventListener('click', () => {
-            mainMobileNav.classList.toggle('hidden');
-            hamburgerIcon.classList.toggle('hidden');
-            closeIcon.classList.toggle('hidden');
-        });
+        function openMobileNav() {
+            mobileNavDrawer.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNavDrawer.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
 
-        // Close main mobile nav when clicking a link
-        document.querySelectorAll('#main-mobile-nav a').forEach(link => {
-            link.addEventListener('click', () => {
-                mainMobileNav.classList.add('hidden');
-                hamburgerIcon.classList.remove('hidden');
-                closeIcon.classList.add('hidden');
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        // Close mobile nav on link click
+        mobileNavDrawer.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
             });
         });
 
-        // Section names for mobile nav display
+        // --- Section navigation ---
         const sectionNames = {
             'create-session': 'Create a New Session',
             'worktrees': 'Understanding Worktrees',
@@ -3473,14 +3530,14 @@
         };
 
         // Docs sidebar mobile navigation toggle
-        const mobileNavToggle = document.getElementById('mobile-nav-toggle');
-        const mobileNav = document.getElementById('mobile-nav');
-        const mobileNavIcon = document.getElementById('mobile-nav-icon');
-        const mobileNavCurrent = document.getElementById('mobile-nav-current');
+        const docsNavToggle = document.getElementById('mobile-nav-toggle');
+        const docsNav = document.getElementById('mobile-nav');
+        const docsNavIcon = document.getElementById('mobile-nav-icon');
+        const docsNavCurrent = document.getElementById('mobile-nav-current');
 
-        mobileNavToggle.addEventListener('click', () => {
-            mobileNav.classList.toggle('hidden');
-            mobileNavIcon.style.transform = mobileNav.classList.contains('hidden') ? 'rotate(0deg)' : 'rotate(180deg)';
+        docsNavToggle.addEventListener('click', () => {
+            docsNav.classList.toggle('hidden');
+            docsNavIcon.style.transform = docsNav.classList.contains('hidden') ? 'rotate(0deg)' : 'rotate(180deg)';
         });
 
         // Section navigation functionality
@@ -3517,13 +3574,13 @@
             });
 
             // Update mobile nav current section text
-            if (mobileNavCurrent && sectionNames[sectionId]) {
-                mobileNavCurrent.textContent = sectionNames[sectionId];
+            if (docsNavCurrent && sectionNames[sectionId]) {
+                docsNavCurrent.textContent = sectionNames[sectionId];
             }
 
-            // Close mobile nav
-            mobileNav.classList.add('hidden');
-            mobileNavIcon.style.transform = 'rotate(0deg)';
+            // Close docs mobile nav
+            docsNav.classList.add('hidden');
+            docsNavIcon.style.transform = 'rotate(0deg)';
 
             // Scroll to top of content area
             window.scrollTo({ top: 0, behavior: 'smooth' });

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,12 @@
     <title>Lanes - Parallel AI Coding in VS Code</title>
     <meta name="description" content="Manage multiple, isolated AI coding sessions — Claude Code and Codex CLI — directly inside VS Code. Free forever - uses your own subscriptions.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -13,23 +19,31 @@
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
                     },
                     fontFamily: {
-                        mono: ['SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
-                        sans: ['system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif']
-                    }
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -37,38 +51,196 @@
         }
     </script>
     <style>
-        .terminal-shadow { box-shadow: 0 10px 30px -10px rgba(0,0,0,0.5); }
-        .glow { box-shadow: 0 0 20px rgba(0, 122, 204, 0.3); }
-        @keyframes pulse-slow { 0%, 100% { opacity: 1; } 50% { opacity: 0.7; } }
-        .animate-pulse-slow { animation: pulse-slow 2s ease-in-out infinite; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Animations --- */
+        @keyframes fade-up {
+            from { opacity: 0; transform: translateY(24px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes fade-in {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+        .anim-fade-up {
+            opacity: 0;
+            animation: fade-up 0.7s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+        }
+        .anim-fade-in {
+            opacity: 0;
+            animation: fade-in 0.6s ease forwards;
+        }
+        .delay-1 { animation-delay: 0.1s; }
+        .delay-2 { animation-delay: 0.2s; }
+        .delay-3 { animation-delay: 0.3s; }
+        .delay-4 { animation-delay: 0.4s; }
+        .delay-5 { animation-delay: 0.5s; }
+        .delay-6 { animation-delay: 0.6s; }
+        .delay-7 { animation-delay: 0.7s; }
+        .delay-8 { animation-delay: 0.8s; }
+
+        /* --- Scroll reveal --- */
+        .reveal {
+            opacity: 0;
+            transform: translateY(20px);
+            transition: opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1), transform 0.6s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .reveal.visible {
+            opacity: 1;
+            transform: translateY(0);
+        }
+
+        /* --- Misc --- */
+        .terminal-chrome {
+            box-shadow:
+                0 1px 2px rgba(0,0,0,0.05),
+                0 8px 24px rgba(0,0,0,0.12),
+                0 24px 48px rgba(0,0,0,0.08);
+        }
+        .dark .terminal-chrome {
+            box-shadow:
+                0 1px 2px rgba(0,0,0,0.3),
+                0 8px 24px rgba(0,0,0,0.4),
+                0 24px 48px rgba(0,0,0,0.3);
+        }
+        .glow-ring {
+            box-shadow: 0 0 0 1px var(--accent), 0 0 24px var(--accent-dim);
+        }
+
+        /* --- Mobile nav --- */
+        .mobile-nav {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        /* Feature card hover */
+        .feature-card {
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+        }
+        .feature-card:hover {
+            transform: translateY(-2px);
+        }
+        .dark .feature-card:hover {
+            box-shadow: 0 4px 24px rgba(0,0,0,0.3);
+        }
+        .feature-card:hover {
+            box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+        }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased selection:bg-vscode-accent selection:text-white transition-colors duration-200">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav" class="mobile-nav fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Home</a>
+            <a href="#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="blog/index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Blog</a>
+            <a href="docs.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
 
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                    <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                    <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="index.html" class="text-vscode-accent font-medium transition-colors">Home</a>
-                        <a href="#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="blog/index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                        <a href="docs.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Home</a>
+                    <a href="#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="blog/index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-mobile" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
                 </div>
             </div>
@@ -76,165 +248,168 @@
     </nav>
 
     <!-- Hero Section -->
-    <main class="pt-32 pb-16 sm:pt-40 sm:pb-24 lg:pb-32 overflow-hidden">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 relative">
+    <main class="pt-28 pb-16 sm:pt-36 sm:pb-24 overflow-hidden">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
 
-            <div class="text-center max-w-3xl mx-auto mb-16">
-                <h1 class="text-4xl sm:text-6xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-6">
-                    Stop Waiting.<br>
-                    <span class="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-500">
-                        Start Parallelizing.
-                    </span>
+            <div class="text-center max-w-2xl mx-auto mb-14 sm:mb-20">
+                <div class="anim-fade-up inline-flex items-center gap-2 bg-surface-2 rounded-full px-3.5 py-1.5 mb-6 text-xs font-mono text-ink-muted">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
+                    100% free &middot; all local &middot; open source
+                </div>
+
+                <h1 class="anim-fade-up delay-1 text-4xl sm:text-5xl lg:text-6xl font-extrabold text-ink tracking-tight font-display leading-[1.1] mb-5">
+                    Stop waiting.<br>
+                    <span class="text-accent">Start parallelizing.</span>
                 </h1>
-                <p class="text-lg text-gray-600 dark:text-gray-400 mb-4 leading-relaxed">
+
+                <p class="anim-fade-up delay-2 text-base sm:text-lg text-ink-muted leading-relaxed mb-8 max-w-xl mx-auto">
                     Manage multiple, isolated AI coding sessions directly inside VS Code.
-                    Supports Claude Code and Codex CLI out of the box.
-                    No context contamination. No broken git states. Just pure flow.
+                    Claude Code and Codex CLI out of the box.
+                    No context contamination. No broken git states.
                 </p>
-                <p class="text-sm text-gray-500 mb-8">
-                    <span class="text-green-600 dark:text-green-400 font-medium">100% Free</span> &mdash; Uses your own Claude Code or Codex subscription. No hidden costs.<br>
-                    <span class="text-blue-600 dark:text-blue-400 font-medium">All Local</span> &mdash; No remote services. Everything runs and is saved on your machine.
-                </p>
-                <div class="flex flex-col sm:flex-row justify-center gap-4">
-                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="bg-gray-900 dark:bg-white text-white dark:text-gray-900 px-8 py-3 rounded-lg font-bold hover:bg-gray-800 dark:hover:bg-gray-100 transition-all flex items-center justify-center gap-2">
-                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M17.583 6.292L12 .708 6.417 6.292l5.583 5.584 5.583-5.584zm-5.584 7.416l-5.583 5.584L12 24.875l5.583-5.583-5.584-5.584zM24 11.708l-5.583 5.584-5.584-5.584 5.584-5.583L24 11.708zM5.583 6.125L0 11.708l5.583 5.584 5.584-5.584-5.584-5.583z"/></svg>
+
+                <div class="anim-fade-up delay-3 flex flex-col sm:flex-row justify-center gap-3">
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="inline-flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-black px-6 py-3 rounded-lg font-semibold text-sm hover:opacity-90 transition-opacity">
+                        <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M17.583 6.292L12 .708 6.417 6.292l5.583 5.584 5.583-5.584zm-5.584 7.416l-5.583 5.584L12 24.875l5.583-5.583-5.584-5.584zM24 11.708l-5.583 5.584-5.584-5.584 5.584-5.583L24 11.708zM5.583 6.125L0 11.708l5.583 5.584 5.584-5.584-5.584-5.583z"/></svg>
                         VS Code Marketplace
                     </a>
-                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white px-8 py-3 rounded-lg font-bold hover:bg-gray-300 dark:hover:bg-gray-700 transition-all flex items-center justify-center gap-2 border border-gray-300 dark:border-white/10">
-                        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0L1.5 6v12L12 24l10.5-6V6L12 0zm0 2.25L19.5 6.75v10.5L12 21.75l-7.5-4.5V6.75L12 2.25z"/><path d="M12 6L6 9.5v5L12 18l6-3.5v-5L12 6zm0 2.25l3.75 2.25L12 12.75 8.25 10.5 12 8.25z"/></svg>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="inline-flex items-center justify-center gap-2 border border-border bg-surface-1 px-6 py-3 rounded-lg font-semibold text-sm text-ink-muted hover:text-ink hover:border-ink-faint transition-colors">
                         Open VSX
                     </a>
-                    <a href="https://github.com/FilipeJesus/lanes" class="bg-gray-200 dark:bg-gray-800 text-gray-900 dark:text-white px-8 py-3 rounded-lg font-bold hover:bg-gray-300 dark:hover:bg-gray-700 transition-all flex items-center justify-center gap-2 border border-gray-300 dark:border-white/10">
-                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                    <a href="https://github.com/FilipeJesus/lanes" class="inline-flex items-center justify-center gap-2 border border-border bg-surface-1 px-6 py-3 rounded-lg font-semibold text-sm text-ink-muted hover:text-ink hover:border-ink-faint transition-colors">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
                         GitHub
                     </a>
                 </div>
             </div>
 
             <!-- Screenshot -->
-            <div class="relative mx-auto max-w-5xl rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar terminal-shadow overflow-hidden">
-                <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
-                    <div class="flex gap-2">
-                        <div class="w-3 h-3 rounded-full bg-red-500"></div>
-                        <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
-                        <div class="w-3 h-3 rounded-full bg-green-500"></div>
+            <div class="anim-fade-up delay-5 relative mx-auto max-w-5xl rounded-xl border border-border bg-surface-1 terminal-chrome overflow-hidden">
+                <div class="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface-2">
+                    <div class="flex gap-1.5">
+                        <div class="w-2.5 h-2.5 rounded-full bg-[#ff5f57]"></div>
+                        <div class="w-2.5 h-2.5 rounded-full bg-[#febc2e]"></div>
+                        <div class="w-2.5 h-2.5 rounded-full bg-[#28c840]"></div>
                     </div>
-                    <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">lanes — VS Code</div>
+                    <div class="ml-3 text-[11px] text-ink-faint font-mono tracking-wide">lanes &mdash; VS Code</div>
                 </div>
-                <img src="https://github.com/FilipeJesus/lanes/raw/main/media/screenshot.png" alt="Lanes Interface showing the sidebar with session management" class="w-full h-auto opacity-90">
+                <img src="https://github.com/FilipeJesus/lanes/raw/main/media/screenshot.png" alt="Lanes Interface showing the sidebar with session management" class="w-full h-auto" loading="lazy">
             </div>
         </div>
     </main>
 
     <!-- Features Section -->
-    <section id="features" class="py-24 bg-gray-100 dark:bg-vscode-sidebar border-y border-gray-200 dark:border-white/5">
+    <section id="features" class="py-20 sm:py-28 bg-surface-1 border-y border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-3xl font-bold text-gray-900 dark:text-white text-center mb-4">Everything You Need for Parallel AI Coding</h2>
-            <p class="text-gray-600 dark:text-gray-400 text-center mb-16 max-w-2xl mx-auto">Built for developers who want to run multiple AI coding agents without the chaos of conflicting file changes.</p>
+            <div class="text-center mb-14 sm:mb-20 reveal">
+                <p class="text-xs font-mono uppercase tracking-widest text-accent mb-3">Capabilities</p>
+                <h2 class="text-3xl sm:text-4xl font-bold text-ink font-display tracking-tight mb-4">Everything you need for parallel AI coding</h2>
+                <p class="text-ink-muted max-w-lg mx-auto">Built for developers who run multiple AI coding agents without the chaos of conflicting file changes.</p>
+            </div>
 
-            <div class="grid md:grid-cols-3 gap-12">
-                <!-- Feature 1: Isolation -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-blue-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-blue-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path></svg>
+            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-5">
+                <!-- Feature 1 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-blue-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-blue-500 dark:text-blue-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">True Git Isolation</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
-                        Each session runs in its own <strong class="text-gray-900 dark:text-white">Git Worktree</strong>. File changes in one lane never leak into another. Switch contexts instantly without stash/pop headaches.
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">True Git Isolation</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
+                        Each session runs in its own <strong class="text-ink font-medium">Git Worktree</strong>. File changes in one lane never leak into another. Switch contexts without stash/pop headaches.
                     </p>
                 </div>
 
-                <!-- Feature 2: Session Resume -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-purple-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-purple-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path></svg>
+                <!-- Feature 2 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-violet-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-violet-500 dark:text-violet-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Session Resume</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
-                        Closing VS Code? No problem. Lanes remembers your active sessions and resumes them exactly where you left off using <code class="bg-gray-200 dark:bg-black/30 px-1 rounded text-sm text-purple-600 dark:text-purple-300">--resume</code>.
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">Session Resume</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
+                        Closing VS Code? No problem. Lanes remembers your active sessions and resumes them exactly where you left off using <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-violet-600 dark:text-violet-300">--resume</code>.
                     </p>
                 </div>
 
-                <!-- Feature 3: Status Indicators -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-yellow-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-yellow-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path></svg>
+                <!-- Feature 3 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-amber-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-amber-500 dark:text-amber-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Real-Time Status</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
-                        See at a glance which agents are <span class="text-yellow-600 dark:text-yellow-400">waiting for input</span>, <span class="text-blue-600 dark:text-blue-400">actively working</span>, or have <span class="text-red-600 dark:text-red-400">encountered errors</span>. Auto-configured hooks keep you informed.
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">Real-Time Status</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
+                        See at a glance which agents are <span class="text-amber-600 dark:text-amber-400">waiting</span>, <span class="text-blue-600 dark:text-blue-400">working</span>, or have <span class="text-red-600 dark:text-red-400">errors</span>. Auto-configured hooks keep you informed.
                     </p>
                 </div>
 
-                <!-- Feature 4: Git Changes Viewer -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-green-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-green-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path></svg>
+                <!-- Feature 4 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-emerald-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-emerald-500 dark:text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Git Changes Viewer</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
-                        Review all changes made by an agent with a built-in diff viewer. Compare against any branch and add code review comments before merging.
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">Git Changes Viewer</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
+                        Review all changes with a built-in diff viewer. Compare against any branch and add code review comments before merging.
                     </p>
                 </div>
 
-                <!-- Feature 5: Form-Based Creation -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-pink-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-pink-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-pink-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path></svg>
+                <!-- Feature 5 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-pink-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-pink-500 dark:text-pink-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">Easy Session Setup</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
-                        Create sessions with a form: choose your agent, set a name, starting prompt, attach files, select source branch and permission mode. Previous sessions are saved for easy restart.
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">Easy Session Setup</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
+                        Create sessions with a form: choose your agent, set a name, starting prompt, attach files, select source branch and permission mode.
                     </p>
                 </div>
 
-                <!-- Feature 6: One-Click Cleanup -->
-                <div class="group">
-                    <div class="w-12 h-12 bg-red-500/10 rounded-lg flex items-center justify-center mb-6 group-hover:bg-red-500/20 transition-colors">
-                        <svg class="w-6 h-6 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path></svg>
+                <!-- Feature 6 -->
+                <div class="feature-card reveal bg-surface-0 rounded-xl border border-border p-6">
+                    <div class="w-9 h-9 rounded-lg bg-red-500/10 flex items-center justify-center mb-4">
+                        <svg class="w-4.5 h-4.5 text-red-500 dark:text-red-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 dark:text-white mb-3">One-Click Cleanup</h3>
-                    <p class="text-gray-600 dark:text-gray-400 leading-relaxed">
+                    <h3 class="text-base font-bold text-ink mb-2 font-display">One-Click Cleanup</h3>
+                    <p class="text-sm text-ink-muted leading-relaxed">
                         Done with a session? Delete the worktree and terminal with one click. Your git branch stays intact and ready to merge.
                     </p>
                 </div>
             </div>
 
-            <!-- Additional Features List -->
-            <div class="mt-16 pt-12 border-t border-gray-200 dark:border-white/10">
-                <h3 class="text-xl font-bold text-gray-900 dark:text-white text-center mb-8">And More...</h3>
-                <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Open sessions in new windows (Project Manager)</span>
+            <!-- Additional Features -->
+            <div class="mt-14 sm:mt-20 pt-10 border-t border-border reveal">
+                <p class="text-xs font-mono uppercase tracking-widest text-ink-faint text-center mb-8">And more</p>
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-x-6 gap-y-3">
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Open sessions in new windows</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Permission mode selector (acceptEdits, DontAsk, etc.)</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Permission mode selector</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Previous sessions view with saved prompts</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Previous sessions with saved prompts</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Container-ready with automatic worktree repair</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Container-ready with worktree repair</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Multi-agent support (Claude Code + Codex CLI)</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Multi-agent support</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">File attachments via drag-and-drop</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">File attachments via drag-and-drop</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Tmux terminal backend for persistent sessions</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Tmux terminal backend</span>
                     </div>
-                    <div class="flex items-start gap-3">
-                        <svg class="w-5 h-5 text-vscode-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>
-                        <span class="text-gray-600 dark:text-gray-400 text-sm">Local settings propagation to worktrees</span>
+                    <div class="flex items-start gap-2.5 py-2">
+                        <svg class="w-4 h-4 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+                        <span class="text-sm text-ink-muted">Local settings propagation</span>
                     </div>
                 </div>
             </div>
@@ -242,37 +417,66 @@
     </section>
 
     <!-- How It Works Section -->
-    <section id="how-it-works" class="py-24">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-3xl font-bold text-gray-900 dark:text-white text-center mb-16">How It Works</h2>
+    <section id="how-it-works" class="py-20 sm:py-28">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 sm:mb-20 reveal">
+                <p class="text-xs font-mono uppercase tracking-widest text-accent mb-3">Workflow</p>
+                <h2 class="text-3xl sm:text-4xl font-bold text-ink font-display tracking-tight">How it works</h2>
+            </div>
 
-            <div class="space-y-12">
-                <div class="flex gap-6">
-                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-vscode-accent flex items-center justify-center font-bold text-white">1</div>
-                    <div>
-                        <h4 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Create a Session</h4>
-                        <p class="text-gray-600 dark:text-gray-400">Open the Lanes sidebar, choose your agent (Claude Code or Codex CLI), fill in a session name (e.g., <code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">fix-login-bug</code>), your starting prompt, and optionally attach files.</p>
+            <div class="space-y-0">
+                <!-- Step 1 -->
+                <div class="reveal flex gap-5 sm:gap-7">
+                    <div class="flex flex-col items-center">
+                        <div class="w-9 h-9 rounded-full bg-accent text-white flex items-center justify-center text-sm font-bold font-mono flex-shrink-0">1</div>
+                        <div class="w-px flex-1 bg-border mt-3"></div>
+                    </div>
+                    <div class="pb-12">
+                        <h4 class="text-lg font-bold text-ink mb-2 font-display">Create a session</h4>
+                        <p class="text-sm text-ink-muted leading-relaxed">
+                            Open the Lanes sidebar, choose your agent (Claude Code or Codex CLI), fill in a session name like <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">fix-login-bug</code>, your starting prompt, and optionally attach files.
+                        </p>
                     </div>
                 </div>
-                <div class="flex gap-6">
-                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-700 flex items-center justify-center font-bold text-gray-700 dark:text-white">2</div>
-                    <div>
-                        <h4 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Automatic Isolation</h4>
-                        <p class="text-gray-600 dark:text-gray-400">Lanes creates a hidden Git worktree (<code class="text-sm bg-gray-200 dark:bg-black/30 px-1 rounded">.worktrees/fix-login-bug</code>), spawns a dedicated terminal, and launches Claude with your prompt.</p>
+
+                <!-- Step 2 -->
+                <div class="reveal flex gap-5 sm:gap-7">
+                    <div class="flex flex-col items-center">
+                        <div class="w-9 h-9 rounded-full bg-surface-2 text-ink flex items-center justify-center text-sm font-bold font-mono flex-shrink-0">2</div>
+                        <div class="w-px flex-1 bg-border mt-3"></div>
+                    </div>
+                    <div class="pb-12">
+                        <h4 class="text-lg font-bold text-ink mb-2 font-display">Automatic isolation</h4>
+                        <p class="text-sm text-ink-muted leading-relaxed">
+                            Lanes creates a hidden Git worktree (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.worktrees/fix-login-bug</code>), spawns a dedicated terminal, and launches Claude with your prompt.
+                        </p>
                     </div>
                 </div>
-                <div class="flex gap-6">
-                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-700 flex items-center justify-center font-bold text-gray-700 dark:text-white">3</div>
-                    <div>
-                        <h4 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Work in Parallel</h4>
-                        <p class="text-gray-600 dark:text-gray-400">Create as many sessions as you need. Each agent works on its own isolated copy of the codebase. No conflicts, no context contamination.</p>
+
+                <!-- Step 3 -->
+                <div class="reveal flex gap-5 sm:gap-7">
+                    <div class="flex flex-col items-center">
+                        <div class="w-9 h-9 rounded-full bg-surface-2 text-ink flex items-center justify-center text-sm font-bold font-mono flex-shrink-0">3</div>
+                        <div class="w-px flex-1 bg-border mt-3"></div>
+                    </div>
+                    <div class="pb-12">
+                        <h4 class="text-lg font-bold text-ink mb-2 font-display">Work in parallel</h4>
+                        <p class="text-sm text-ink-muted leading-relaxed">
+                            Create as many sessions as you need. Each agent works on its own isolated copy of the codebase. No conflicts, no context contamination.
+                        </p>
                     </div>
                 </div>
-                <div class="flex gap-6">
-                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-gray-300 dark:bg-gray-700 flex items-center justify-center font-bold text-gray-700 dark:text-white">4</div>
-                    <div>
-                        <h4 class="text-xl font-bold text-gray-900 dark:text-white mb-2">Review & Merge</h4>
-                        <p class="text-gray-600 dark:text-gray-400">Use the built-in Git Changes viewer to review all modifications. When satisfied, delete the session (worktree is removed, branch is preserved) and merge your changes.</p>
+
+                <!-- Step 4 -->
+                <div class="reveal flex gap-5 sm:gap-7">
+                    <div class="flex flex-col items-center">
+                        <div class="w-9 h-9 rounded-full bg-surface-2 text-ink flex items-center justify-center text-sm font-bold font-mono flex-shrink-0">4</div>
+                    </div>
+                    <div class="pb-4">
+                        <h4 class="text-lg font-bold text-ink mb-2 font-display">Review &amp; merge</h4>
+                        <p class="text-sm text-ink-muted leading-relaxed">
+                            Use the built-in Git Changes viewer to review all modifications. Delete the session when satisfied &mdash; worktree removed, branch preserved, ready to merge.
+                        </p>
                     </div>
                 </div>
             </div>
@@ -280,116 +484,135 @@
     </section>
 
     <!-- Workflow System Section -->
-    <section id="harness" class="py-24 bg-gray-100 dark:bg-vscode-sidebar border-y border-gray-200 dark:border-white/5">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-3xl font-bold text-gray-900 dark:text-white text-center mb-4">Structured Workflow System</h2>
-            <p class="text-gray-600 dark:text-gray-400 text-center mb-12 max-w-2xl mx-auto">
-                Lanes includes MCP-based workflows that guide Claude through structured phases: Plan → Implement → Test → Review.
-                Built on <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-vscode-accent hover:underline">Anthropic's research</a>
-                for long-running agent reliability.
-            </p>
-
-            <div class="bg-white dark:bg-[#1e1e1e] rounded-xl border border-gray-200 dark:border-white/10 overflow-hidden">
-                <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-black/30">
-                    <span class="text-xs text-gray-600 dark:text-gray-500 font-mono">workflow.yaml</span>
-                </div>
-                <pre class="p-4 text-sm font-mono text-gray-700 dark:text-gray-300 overflow-x-auto"><code><span class="text-blue-400">name:</span> Feature Development Workflow
-<span class="text-blue-400">description:</span> Structured workflow with plan, implement, test, review
-
-<span class="text-blue-400">agents:</span>
-    <span class="text-blue-400">coder:</span>
-        <span class="text-blue-400">description:</span> Responsible for implementing features
-    <span class="text-blue-400">test-engineer:</span>
-        <span class="text-blue-400">description:</span> Responsible for writing and executing tests
-
-<span class="text-blue-400">loops:</span>
-    <span class="text-blue-400">implement:</span>
-        - <span class="text-blue-400">id:</span> programming
-          <span class="text-blue-400">agent:</span> coder
-          <span class="text-blue-400">instructions:</span> Implement feature...
-        - <span class="text-blue-400">id:</span> testing
-          <span class="text-blue-400">agent:</span> test-engineer
-          <span class="text-blue-400">instructions:</span> Write tests...
-
-<span class="text-blue-400">steps:</span>
-  - <span class="text-blue-400">id:</span> plan
-    <span class="text-blue-400">type:</span> action
-    <span class="text-blue-400">instructions:</span> Analyze goal and break into features...
-
-  - <span class="text-blue-400">id:</span> implement
-    <span class="text-blue-400">type:</span> loop
-
-  - <span class="text-blue-400">id:</span> review
-    <span class="text-blue-400">type:</span> action
-    <span class="text-blue-400">instructions:</span> Review all changes...</code></pre>
-            </div>
-
-            <div class="mt-8 grid md:grid-cols-3 gap-6">
-                <div class="text-center">
-                    <div class="text-2xl mb-2">🎯</div>
-                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Structured Phases</h4>
-                    <p class="text-sm text-gray-600 dark:text-gray-400">Enforces plan → implement → test → review phases with clear checkpoints</p>
-                </div>
-                <div class="text-center">
-                    <div class="text-2xl mb-2">🤝</div>
-                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Agent Specialization</h4>
-                    <p class="text-sm text-gray-600 dark:text-gray-400">Dedicated agents for coding, testing, and reviewing ensure quality</p>
-                </div>
-                <div class="text-center">
-                    <div class="text-2xl mb-2">📊</div>
-                    <h4 class="font-bold text-gray-900 dark:text-white mb-1">Progress Tracking</h4>
-                    <p class="text-sm text-gray-600 dark:text-gray-400">MCP integration tracks workflow state across context windows</p>
-                </div>
-            </div>
-
-            <div class="mt-8 text-center">
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                    <a href="https://github.com/FilipeJesus/lanes/blob/main/docs/CLAUDE-HARNESS.md" class="text-vscode-accent hover:underline">Learn more in the docs</a>.
+    <section id="harness" class="py-20 sm:py-28 bg-surface-1 border-y border-border">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 reveal">
+                <p class="text-xs font-mono uppercase tracking-widest text-accent mb-3">Automation</p>
+                <h2 class="text-3xl sm:text-4xl font-bold text-ink font-display tracking-tight mb-4">Structured workflow system</h2>
+                <p class="text-sm text-ink-muted max-w-xl mx-auto leading-relaxed">
+                    MCP-based workflows that guide Claude through structured phases: Plan &rarr; Implement &rarr; Test &rarr; Review.
+                    Built on <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline">Anthropic's research</a> for long-running agent reliability.
                 </p>
+            </div>
+
+            <div class="reveal bg-surface-0 rounded-xl border border-border overflow-hidden terminal-chrome">
+                <div class="flex items-center gap-2 px-4 py-2.5 border-b border-border bg-surface-2">
+                    <div class="flex gap-1.5">
+                        <div class="w-2 h-2 rounded-full bg-[#ff5f57]"></div>
+                        <div class="w-2 h-2 rounded-full bg-[#febc2e]"></div>
+                        <div class="w-2 h-2 rounded-full bg-[#28c840]"></div>
+                    </div>
+                    <span class="ml-2 text-[11px] text-ink-faint font-mono tracking-wide">workflow.yaml</span>
+                </div>
+                <pre class="p-4 sm:p-5 text-xs sm:text-sm font-mono text-ink-muted overflow-x-auto leading-relaxed"><code><span class="text-accent">name:</span> Feature Development Workflow
+<span class="text-accent">description:</span> Structured workflow with plan, implement, test, review
+
+<span class="text-accent">agents:</span>
+    <span class="text-accent">coder:</span>
+        <span class="text-accent">description:</span> Responsible for implementing features
+    <span class="text-accent">test-engineer:</span>
+        <span class="text-accent">description:</span> Responsible for writing and executing tests
+
+<span class="text-accent">loops:</span>
+    <span class="text-accent">implement:</span>
+        - <span class="text-accent">id:</span> programming
+          <span class="text-accent">agent:</span> coder
+          <span class="text-accent">instructions:</span> Implement feature...
+        - <span class="text-accent">id:</span> testing
+          <span class="text-accent">agent:</span> test-engineer
+          <span class="text-accent">instructions:</span> Write tests...
+
+<span class="text-accent">steps:</span>
+  - <span class="text-accent">id:</span> plan
+    <span class="text-accent">type:</span> action
+    <span class="text-accent">instructions:</span> Analyze goal and break into features...
+
+  - <span class="text-accent">id:</span> implement
+    <span class="text-accent">type:</span> loop
+
+  - <span class="text-accent">id:</span> review
+    <span class="text-accent">type:</span> action
+    <span class="text-accent">instructions:</span> Review all changes...</code></pre>
+            </div>
+
+            <div class="mt-10 grid sm:grid-cols-3 gap-6 reveal">
+                <div class="text-center">
+                    <div class="w-9 h-9 rounded-lg bg-accent/10 flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
+                    </div>
+                    <h4 class="text-sm font-bold text-ink mb-1 font-display">Structured Phases</h4>
+                    <p class="text-xs text-ink-muted leading-relaxed">Plan &rarr; implement &rarr; test &rarr; review with clear checkpoints</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-9 h-9 rounded-lg bg-accent/10 flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+                    </div>
+                    <h4 class="text-sm font-bold text-ink mb-1 font-display">Agent Specialization</h4>
+                    <p class="text-xs text-ink-muted leading-relaxed">Dedicated agents for coding, testing, and reviewing</p>
+                </div>
+                <div class="text-center">
+                    <div class="w-9 h-9 rounded-lg bg-accent/10 flex items-center justify-center mx-auto mb-3">
+                        <svg class="w-4 h-4 text-accent" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"/></svg>
+                    </div>
+                    <h4 class="text-sm font-bold text-ink mb-1 font-display">Progress Tracking</h4>
+                    <p class="text-xs text-ink-muted leading-relaxed">MCP integration tracks state across context windows</p>
+                </div>
+            </div>
+
+            <div class="mt-8 text-center reveal">
+                <a href="https://github.com/FilipeJesus/lanes/blob/main/docs/CLAUDE-HARNESS.md" class="text-sm text-accent hover:underline font-medium">
+                    Learn more in the docs &rarr;
+                </a>
             </div>
         </div>
     </section>
 
     <!-- Prerequisites Section -->
-    <section class="py-24">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 class="text-3xl font-bold text-gray-900 dark:text-white text-center mb-4">Prerequisites</h2>
-            <p class="text-gray-600 dark:text-gray-400 text-center mb-12">You'll need at least one coding agent installed.</p>
+    <section class="py-20 sm:py-28">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-14 reveal">
+                <p class="text-xs font-mono uppercase tracking-widest text-accent mb-3">Setup</p>
+                <h2 class="text-3xl sm:text-4xl font-bold text-ink font-display tracking-tight mb-4">Prerequisites</h2>
+                <p class="text-ink-muted">You'll need at least one coding agent installed.</p>
+            </div>
 
-            <div class="space-y-4">
-                <div class="bg-gray-100 dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-6">
+            <div class="space-y-4 reveal">
+                <div class="bg-surface-1 rounded-xl border border-border p-5 sm:p-6">
                     <div class="flex items-start gap-4">
-                        <div class="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                            <svg class="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                        <div class="w-9 h-9 rounded-lg bg-violet-500/10 flex items-center justify-center flex-shrink-0">
+                            <svg class="w-4 h-4 text-violet-500 dark:text-violet-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                         </div>
-                        <div>
-                            <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-2">Install Claude Code</h4>
-                            <div class="bg-gray-200 dark:bg-black/30 rounded-lg p-3 font-mono text-sm mb-3 text-gray-800 dark:text-gray-300">
-                                <span class="text-green-600 dark:text-green-400">$</span> npm install -g @anthropic-ai/claude-code<br>
-                                <span class="text-green-600 dark:text-green-400">$</span> claude login
+                        <div class="min-w-0">
+                            <h4 class="text-base font-bold text-ink mb-2 font-display">Install Claude Code</h4>
+                            <div class="bg-surface-2 rounded-lg p-3 font-mono text-xs sm:text-sm mb-3 text-ink-muted overflow-x-auto">
+                                <span class="text-emerald-600 dark:text-emerald-400">$</span> npm install -g @anthropic-ai/claude-code<br>
+                                <span class="text-emerald-600 dark:text-emerald-400">$</span> claude login
                             </div>
-                            <p class="text-sm text-gray-600 dark:text-gray-400">
-                                Lanes is free. You use your own
-                                <a href="https://claude.com/claude-code" class="text-vscode-accent hover:underline">Claude Code subscription</a>
+                            <p class="text-xs sm:text-sm text-ink-muted">
+                                Lanes is free. Use your own
+                                <a href="https://claude.com/claude-code" class="text-accent hover:underline">Claude Code subscription</a>
                                 (Pro, Team, or Enterprise).
                             </p>
                         </div>
                     </div>
                 </div>
 
-                <div class="bg-gray-100 dark:bg-vscode-sidebar rounded-xl border border-gray-200 dark:border-white/10 p-6">
+                <div class="bg-surface-1 rounded-xl border border-border p-5 sm:p-6">
                     <div class="flex items-start gap-4">
-                        <div class="w-10 h-10 bg-green-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
-                            <svg class="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                        <div class="w-9 h-9 rounded-lg bg-emerald-500/10 flex items-center justify-center flex-shrink-0">
+                            <svg class="w-4 h-4 text-emerald-500 dark:text-emerald-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                         </div>
-                        <div>
-                            <h4 class="text-lg font-bold text-gray-900 dark:text-white mb-2">Install Codex CLI <span class="text-xs bg-gray-200 dark:bg-white/10 text-gray-600 dark:text-gray-400 px-2 py-0.5 rounded-full font-normal">Optional</span></h4>
-                            <div class="bg-gray-200 dark:bg-black/30 rounded-lg p-3 font-mono text-sm mb-3 text-gray-800 dark:text-gray-300">
-                                <span class="text-green-600 dark:text-green-400">$</span> npm install -g @openai/codex
+                        <div class="min-w-0">
+                            <h4 class="text-base font-bold text-ink mb-2 font-display">
+                                Install Codex CLI
+                                <span class="text-[10px] uppercase tracking-widest font-mono text-ink-faint bg-surface-2 px-2 py-0.5 rounded ml-2">Optional</span>
+                            </h4>
+                            <div class="bg-surface-2 rounded-lg p-3 font-mono text-xs sm:text-sm mb-3 text-ink-muted overflow-x-auto">
+                                <span class="text-emerald-600 dark:text-emerald-400">$</span> npm install -g @openai/codex
                             </div>
-                            <p class="text-sm text-gray-600 dark:text-gray-400">
+                            <p class="text-xs sm:text-sm text-ink-muted">
                                 Use your own
-                                <a href="https://github.com/openai/codex" class="text-vscode-accent hover:underline">OpenAI API key</a>
+                                <a href="https://github.com/openai/codex" class="text-accent hover:underline">OpenAI API key</a>
                                 to run Codex CLI sessions alongside Claude Code.
                             </p>
                         </div>
@@ -400,63 +623,107 @@
     </section>
 
     <!-- CTA Section -->
-    <section class="py-24 bg-gradient-to-b from-gray-100 dark:from-vscode-bg to-gray-200 dark:to-vscode-sidebar">
-        <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <h2 class="text-3xl font-bold text-gray-900 dark:text-white mb-4">Ready to Parallelize Your Workflow?</h2>
-            <p class="text-gray-600 dark:text-gray-400 mb-8">Install Lanes from the VS Code Marketplace and start running multiple agents today.</p>
-            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="inline-flex items-center gap-2 bg-gray-900 dark:bg-white text-white dark:text-gray-900 px-8 py-4 rounded-lg font-bold hover:bg-gray-800 dark:hover:bg-gray-100 transition-all text-lg">
-                <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M17.583 6.292L12 .708 6.417 6.292l5.583 5.584 5.583-5.584zm-5.584 7.416l-5.583 5.584L12 24.875l5.583-5.583-5.584-5.584zM24 11.708l-5.583 5.584-5.584-5.584 5.584-5.583L24 11.708zM5.583 6.125L0 11.708l5.583 5.584 5.584-5.584-5.584-5.583z"/></svg>
+    <section class="py-20 sm:py-28 border-t border-border bg-surface-1">
+        <div class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center reveal">
+            <h2 class="text-3xl sm:text-4xl font-bold text-ink font-display tracking-tight mb-4">Ready to parallelize?</h2>
+            <p class="text-ink-muted mb-8">Install Lanes from the VS Code Marketplace and start running multiple agents today.</p>
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="inline-flex items-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-black px-7 py-3.5 rounded-lg font-bold text-sm hover:opacity-90 transition-opacity">
+                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M17.583 6.292L12 .708 6.417 6.292l5.583 5.584 5.583-5.584zm-5.584 7.416l-5.583 5.584L12 24.875l5.583-5.583-5.584-5.584zM24 11.708l-5.583 5.584-5.584-5.584 5.584-5.583L24 11.708zM5.583 6.125L0 11.708l5.583 5.584 5.584-5.584-5.584-5.583z"/></svg>
                 Install Lanes
             </a>
         </div>
     </section>
 
     <!-- Footer -->
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6 flex-wrap">
-                <a href="blog/index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                <a href="docs.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Documentation</a>
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
-                <a href="https://github.com/FilipeJesus/lanes/issues" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Issues</a>
-                <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">VS Code Marketplace</a>
-                <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Open VSX</a>
-                <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Donate</a>
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="blog/index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
+        syncThemeIcons();
 
-        updateIcons();
-
-        themeToggle.addEventListener('click', () => {
-            if (document.documentElement.classList.contains('dark')) {
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav ---
+        const mobileNav = document.getElementById('mobile-nav');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNav.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNav.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        // Close mobile nav on link click
+        mobileNav.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
         });
+
+        // --- Scroll reveal ---
+        const revealElements = document.querySelectorAll('.reveal');
+        const revealObserver = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                    revealObserver.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
+
+        revealElements.forEach(el => revealObserver.observe(el));
     </script>
 </body>
 </html>

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "Blog build scripts for Lanes website",
   "scripts": {
-    "build": "node scripts/build-blog.js"
+    "build": "node scripts/build-blog.js",
+    "build:docs": "node scripts/build-docs.js"
   },
   "dependencies": {
     "dompurify": "^3.3.1",

--- a/docs/scripts/build-blog.js
+++ b/docs/scripts/build-blog.js
@@ -175,6 +175,12 @@ function generateHeader(title, currentPath = '') {
     <title>${escapeHtml(title)} - Lanes</title>
     <meta name="description" content="Manage multiple, isolated Claude Code sessions directly inside VS Code.">
     <link rel="icon" type="image/png" href="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png">
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;0,9..40,800;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
         tailwind.config = {
@@ -182,19 +188,31 @@ function generateHeader(title, currentPath = '') {
             theme: {
                 extend: {
                     colors: {
-                        vscode: {
-                            bg: '#1e1e1e',
-                            sidebar: '#252526',
-                            accent: '#007acc',
-                            text: '#cccccc'
-                        }
-                    }
+                        surface: {
+                            0: 'var(--surface-0)',
+                            1: 'var(--surface-1)',
+                            2: 'var(--surface-2)',
+                            3: 'var(--surface-3)',
+                        },
+                        accent: 'var(--accent)',
+                        'accent-dim': 'var(--accent-dim)',
+                        ink: {
+                            DEFAULT: 'var(--ink)',
+                            muted: 'var(--ink-muted)',
+                            faint: 'var(--ink-faint)',
+                        },
+                        border: 'var(--border)',
+                    },
+                    fontFamily: {
+                        display: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        body: ['"DM Sans"', 'system-ui', 'sans-serif'],
+                        mono: ['"JetBrains Mono"', 'Menlo', 'Monaco', 'Consolas', 'monospace'],
+                    },
                 }
             }
         }
     </script>
     <script>
-        // Theme toggle - check localStorage, default to dark mode
         if (localStorage.theme === 'light') {
             document.documentElement.classList.remove('dark');
         } else {
@@ -202,67 +220,156 @@ function generateHeader(title, currentPath = '') {
         }
     </script>
     <style>
-        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; }
-        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; }
-        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; }
-        .prose p { margin: 1em 0; line-height: 1.7; }
+        /* --- Theme tokens --- */
+        :root {
+            --surface-0: #f8f7f5;
+            --surface-1: #efeeeb;
+            --surface-2: #e6e4e0;
+            --surface-3: #dddbd6;
+            --accent: #0969da;
+            --accent-dim: rgba(9, 105, 218, 0.12);
+            --ink: #1c1917;
+            --ink-muted: #57534e;
+            --ink-faint: #a8a29e;
+            --border: rgba(0, 0, 0, 0.08);
+        }
+        .dark {
+            --surface-0: #121110;
+            --surface-1: #1a1918;
+            --surface-2: #242220;
+            --surface-3: #2e2c29;
+            --accent: #58a6ff;
+            --accent-dim: rgba(88, 166, 255, 0.10);
+            --ink: #e7e5e4;
+            --ink-muted: #a8a29e;
+            --ink-faint: #57534e;
+            --border: rgba(255, 255, 255, 0.06);
+        }
+
+        /* --- Grain overlay --- */
+        body::before {
+            content: '';
+            position: fixed;
+            inset: 0;
+            z-index: 9999;
+            pointer-events: none;
+            opacity: 0.025;
+            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+            background-repeat: repeat;
+            background-size: 256px 256px;
+        }
+
+        /* --- Mobile nav --- */
+        .mobile-nav {
+            transform: translateX(100%);
+            transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+        }
+        .mobile-nav.open {
+            transform: translateX(0);
+        }
+        .mobile-backdrop {
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.3s ease;
+        }
+        .mobile-backdrop.open {
+            opacity: 1;
+            pointer-events: auto;
+        }
+
+        /* --- Prose styles --- */
+        .prose h1 { font-size: 2em; font-weight: bold; margin: 0.67em 0; color: var(--ink); }
+        .prose h2 { font-size: 1.5em; font-weight: bold; margin: 0.83em 0; color: var(--ink); }
+        .prose h3 { font-size: 1.17em; font-weight: bold; margin: 1em 0; color: var(--ink); }
+        .prose p { margin: 1em 0; line-height: 1.7; color: var(--ink-muted); }
         .prose ul, .prose ol { margin: 1em 0; padding-left: 1.5em; }
         .prose ul { list-style-type: disc; }
         .prose ul ul { list-style-type: circle; }
         .prose ul ul ul { list-style-type: square; }
         .prose ol { list-style-type: decimal; }
-        .prose li { margin: 0.5em 0; }
-        .prose a { color: #007acc; text-decoration: underline; }
-        .prose a:hover { color: #005a9e; }
-        .prose code { background: rgba(0,0,0,0.08); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace; }
-        .prose pre { background: #1e1e1e; color: #d4d4d4; padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid rgba(255,255,255,0.1); }
+        .prose li { margin: 0.5em 0; color: var(--ink-muted); }
+        .prose a { color: var(--accent); text-decoration: underline; }
+        .prose a:hover { opacity: 0.8; }
+        .prose code { background: var(--surface-2); color: var(--ink-muted); padding: 0.2em 0.4em; border-radius: 3px; font-size: 0.9em; font-family: 'JetBrains Mono', Menlo, Monaco, Consolas, monospace; }
+        .prose pre { background: var(--surface-2); color: var(--ink-muted); padding: 1em; border-radius: 6px; overflow-x: auto; margin: 1em 0; border: 1px solid var(--border); }
         .prose pre code { background: transparent; padding: 0; color: inherit; }
-        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; }
-        .prose blockquote { border-left: 4px solid #007acc; padding-left: 1em; margin: 1em 0; color: #666; }
-        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid #e5e7eb; border-radius: 6px; overflow: hidden; }
-        .prose table thead { background: #f3f4f6; border-bottom: 2px solid #e5e7eb; }
-        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: #1f2937; border-right: 1px solid #e5e7eb; }
+        .prose img { max-width: 100%; border-radius: 8px; margin: 1em 0; border: 1px solid var(--border); }
+        .prose blockquote { border-left: 4px solid var(--accent); padding-left: 1em; margin: 1em 0; color: var(--ink-muted); }
+        .prose table { border-collapse: separate; border-spacing: 0; width: 100%; margin: 1em 0; font-size: 0.95em; border: 1px solid var(--border); border-radius: 6px; overflow: hidden; }
+        .prose table thead { background: var(--surface-2); border-bottom: 2px solid var(--border); }
+        .prose table th { padding: 0.75em 1em; text-align: left; font-weight: 600; color: var(--ink); border-right: 1px solid var(--border); }
         .prose table th:last-child { border-right: none; }
-        .prose table td { padding: 0.75em 1em; border-right: 1px solid #e5e7eb; border-bottom: 1px solid #e5e7eb; }
+        .prose table td { padding: 0.75em 1em; border-right: 1px solid var(--border); border-bottom: 1px solid var(--border); }
         .prose table td:last-child { border-right: none; }
         .prose table tbody tr:last-child td { border-bottom: none; }
-        .prose table tbody tr:nth-child(even) { background: #f9fafb; }
-        .prose table tbody tr:hover { background: #f3f4f6; }
-        .dark .prose table { border: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table thead { background: #2d2d2d; border-bottom: 2px solid rgba(255,255,255,0.1); }
-        .dark .prose table th { color: #f9fafb; border-right: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table td { border-right: 1px solid rgba(255,255,255,0.1); border-bottom: 1px solid rgba(255,255,255,0.1); }
-        .dark .prose table tbody tr:last-child td { border-bottom: none; }
-        .dark .prose table tbody tr:nth-child(even) { background: rgba(255,255,255,0.05); }
-        .dark .prose table tbody tr:hover { background: rgba(255,255,255,0.1); }
-        .dark .prose code { background: rgba(255,255,255,0.1); }
+        .prose table tbody tr:nth-child(even) { background: var(--surface-1); }
+        .prose table tbody tr:hover { background: var(--surface-2); }
     </style>
 </head>
-<body class="bg-gray-50 dark:bg-vscode-bg text-gray-700 dark:text-gray-300 font-sans antialiased">
+<body class="bg-surface-0 text-ink font-body antialiased selection:bg-accent selection:text-white">
+
+    <!-- Mobile nav backdrop -->
+    <div id="mobile-backdrop" class="mobile-backdrop fixed inset-0 z-40 bg-black/50 backdrop-blur-sm md:hidden"></div>
+
+    <!-- Mobile nav drawer -->
+    <div id="mobile-nav" class="mobile-nav fixed top-0 right-0 bottom-0 w-72 z-50 bg-surface-1 border-l border-border p-6 flex flex-col md:hidden">
+        <div class="flex items-center justify-between mb-8">
+            <span class="text-lg font-semibold text-ink">Menu</span>
+            <button id="mobile-nav-close" class="p-2 -mr-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Close menu">
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <nav class="flex flex-col gap-1">
+            <a href="../index.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Home</a>
+            <a href="../index.html#features" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Features</a>
+            <a href="../index.html#how-it-works" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">How it Works</a>
+            <a href="index.html" class="px-3 py-2.5 rounded-lg text-accent font-medium">Blog</a>
+            <a href="../docs.html" class="px-3 py-2.5 rounded-lg text-ink-muted hover:text-ink hover:bg-surface-2 transition-colors">Docs</a>
+        </nav>
+        <div class="mt-auto pt-6 border-t border-border flex flex-col gap-3">
+            <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="flex items-center justify-center gap-2 bg-ink text-surface-0 dark:bg-white dark:text-surface-0 px-4 py-2.5 rounded-lg font-semibold text-sm">
+                Install from Marketplace
+            </a>
+            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center justify-center gap-2 border border-border px-4 py-2.5 rounded-lg font-medium text-sm text-ink-muted hover:text-ink transition-colors">
+                <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                View on GitHub
+            </a>
+        </div>
+    </div>
+
     <!-- Navigation -->
-    <nav class="fixed w-full z-50 bg-white/90 dark:bg-vscode-bg/90 backdrop-blur-sm border-b border-gray-200 dark:border-white/10">
+    <nav class="fixed w-full z-30 bg-surface-0/80 backdrop-blur-md border-b border-border">
         <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex items-center justify-between h-16">
-                <div class="flex items-center gap-2">
-                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-8 h-8">
-                    <span class="text-xl font-bold text-gray-900 dark:text-white tracking-tight">Lanes</span>
-                    <span class="text-xs bg-green-500/20 text-green-600 dark:text-green-400 px-2 py-0.5 rounded-full font-medium">Free Forever</span>
-                    <span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-0.5 rounded-full font-medium">All Local</span>
+            <div class="flex items-center justify-between h-14">
+                <div class="flex items-center gap-2.5">
+                    <img src="https://github.com/FilipeJesus/lanes/raw/main/media/lanes-default-64px.png" alt="Lanes Logo" class="w-7 h-7">
+                    <span class="text-lg font-bold text-ink tracking-tight font-display">Lanes</span>
+                    <span class="hidden sm:inline text-[10px] uppercase tracking-widest font-mono font-medium text-emerald-600 dark:text-emerald-400 bg-emerald-500/10 px-2 py-0.5 rounded">Free</span>
                 </div>
-                <div class="hidden md:flex items-center">
-                    <div class="ml-10 flex items-baseline space-x-8">
-                        <a href="../index.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                        <a href="../index.html#features" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Features</a>
-                        <a href="../index.html#how-it-works" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">How it Works</a>
-                        <a href="index.html" class="${currentPath === 'blog' ? 'text-vscode-accent font-medium' : 'text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white'} transition-colors">Blog</a>
-                        <a href="../docs.html" class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                        <a href="https://github.com/FilipeJesus/lanes" class="bg-vscode-accent hover:bg-blue-600 text-white px-4 py-2 rounded-md font-medium transition-all">
-                            View on GitHub
-                        </a>
-                    </div>
-                    <button id="theme-toggle" class="ml-6 p-2 rounded-lg bg-gray-200 dark:bg-white/10 hover:bg-gray-300 dark:hover:bg-white/20 transition-colors" aria-label="Toggle theme">
-                        <svg id="sun-icon" class="w-5 h-5 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path></svg>
-                        <svg id="moon-icon" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path></svg>
+                <div class="hidden md:flex items-center gap-1">
+                    <a href="../index.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Home</a>
+                    <a href="../index.html#features" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Features</a>
+                    <a href="../index.html#how-it-works" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">How it Works</a>
+                    <a href="index.html" class="px-3 py-1.5 rounded-md text-sm font-medium text-accent">Blog</a>
+                    <a href="../docs.html" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors">Docs</a>
+                    <span class="w-px h-5 bg-border mx-2"></span>
+                    <a href="https://github.com/FilipeJesus/lanes" class="px-3 py-1.5 rounded-md text-sm text-ink-muted hover:text-ink transition-colors flex items-center gap-1.5">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+                        GitHub
+                    </a>
+                    <button id="theme-toggle" class="ml-1 p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                </div>
+                <!-- Mobile: theme toggle + hamburger -->
+                <div class="flex items-center gap-1 md:hidden">
+                    <button id="theme-toggle-mobile" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Toggle theme">
+                        <svg id="sun-icon-m" class="w-4 h-4 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/></svg>
+                        <svg id="moon-icon-m" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/></svg>
+                    </button>
+                    <button id="mobile-nav-open" class="p-2 rounded-lg hover:bg-surface-2 transition-colors" aria-label="Open menu">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
                     </button>
                 </div>
             </div>
@@ -278,47 +385,83 @@ function generateHeader(title, currentPath = '') {
  */
 function generateFooter() {
   return `    </main>
-    <footer class="border-t border-gray-200 dark:border-white/10 py-12 bg-gray-100 dark:bg-vscode-sidebar">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <p class="text-gray-500 mb-4">
-                <span class="text-green-600 dark:text-green-400">Free &amp; Open Source</span> under MIT License. Built by <a href="https://github.com/FilipeJesus" class="text-blue-600 dark:text-blue-400 hover:underline">FilipeJesus</a>.
-            </p>
-            <div class="flex justify-center gap-6 flex-wrap">
-                <a href="../index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Home</a>
-                <a href="index.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Blog</a>
-                <a href="../docs.html" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">Docs</a>
-                <a href="https://github.com/FilipeJesus/lanes" class="text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors">GitHub</a>
+
+    <!-- Footer -->
+    <footer class="border-t border-border py-10 bg-surface-0">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex flex-col sm:flex-row items-center justify-between gap-4">
+                <p class="text-xs text-ink-faint text-center sm:text-left">
+                    <span class="text-emerald-600 dark:text-emerald-400">Free &amp; Open Source</span> under MIT License.
+                    Built by <a href="https://github.com/FilipeJesus" class="text-accent hover:underline">FilipeJesus</a>.
+                </p>
+                <div class="flex items-center gap-5 flex-wrap justify-center">
+                    <a href="../index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Home</a>
+                    <a href="index.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Blog</a>
+                    <a href="../docs.html" class="text-xs text-ink-faint hover:text-ink transition-colors">Docs</a>
+                    <a href="https://github.com/FilipeJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">GitHub</a>
+                    <a href="https://github.com/FilipeJesus/lanes/issues" class="text-xs text-ink-faint hover:text-ink transition-colors">Issues</a>
+                    <a href="https://marketplace.visualstudio.com/items?itemName=FilipeMarquesJesus.lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Marketplace</a>
+                    <a href="https://open-vsx.org/extension/FilipeMarquesJesus/lanes" class="text-xs text-ink-faint hover:text-ink transition-colors">Open VSX</a>
+                    <a href="https://www.paypal.com/donate/?business=JEYBHRR3E4PEU&no_recurring=0&item_name=Loving+Lanes?+I+am+too%21+Thank+you+so+much+for+supporting+it%27s+development.&currency_code=GBP" class="text-xs text-ink-faint hover:text-ink transition-colors">Donate</a>
+                </div>
             </div>
         </div>
     </footer>
 
     <script>
-        // Theme toggle functionality
-        const themeToggle = document.getElementById('theme-toggle');
-        const sunIcon = document.getElementById('sun-icon');
-        const moonIcon = document.getElementById('moon-icon');
-
-        function updateIcons() {
-            if (document.documentElement.classList.contains('dark')) {
-                sunIcon.classList.add('hidden');
-                moonIcon.classList.remove('hidden');
-            } else {
-                sunIcon.classList.remove('hidden');
-                moonIcon.classList.add('hidden');
-            }
+        // --- Theme toggle ---
+        function syncThemeIcons() {
+            const isDark = document.documentElement.classList.contains('dark');
+            ['', '-m'].forEach(suffix => {
+                const sun = document.getElementById('sun-icon' + suffix);
+                const moon = document.getElementById('moon-icon' + suffix);
+                if (!sun || !moon) return;
+                sun.classList.toggle('hidden', isDark);
+                moon.classList.toggle('hidden', !isDark);
+            });
         }
+        syncThemeIcons();
 
-        updateIcons();
-
-        themeToggle.addEventListener('click', () => {
-            if (document.documentElement.classList.contains('dark')) {
+        function toggleTheme() {
+            const isDark = document.documentElement.classList.contains('dark');
+            if (isDark) {
                 document.documentElement.classList.remove('dark');
                 localStorage.theme = 'light';
             } else {
                 document.documentElement.classList.add('dark');
                 localStorage.theme = 'dark';
             }
-            updateIcons();
+            syncThemeIcons();
+        }
+
+        document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+        document.getElementById('theme-toggle-mobile').addEventListener('click', toggleTheme);
+
+        // --- Mobile nav ---
+        const mobileNav = document.getElementById('mobile-nav');
+        const mobileBackdrop = document.getElementById('mobile-backdrop');
+
+        function openMobileNav() {
+            mobileNav.classList.add('open');
+            mobileBackdrop.classList.add('open');
+            document.body.style.overflow = 'hidden';
+        }
+        function closeMobileNav() {
+            mobileNav.classList.remove('open');
+            mobileBackdrop.classList.remove('open');
+            document.body.style.overflow = '';
+        }
+
+        document.getElementById('mobile-nav-open').addEventListener('click', openMobileNav);
+        document.getElementById('mobile-nav-close').addEventListener('click', closeMobileNav);
+        mobileBackdrop.addEventListener('click', closeMobileNav);
+
+        mobileNav.querySelectorAll('a').forEach(a => {
+            a.addEventListener('click', () => {
+                if (a.getAttribute('href').startsWith('#')) {
+                    closeMobileNav();
+                }
+            });
         });
     </script>
 </body>
@@ -334,26 +477,24 @@ function generateBlogIndex(posts) {
   const tags = getAllTags(posts);
 
   const tagButtons = tags.map(tag =>
-    `        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-      tag === 'all' ? 'bg-vscode-accent text-white' : 'bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-700'
-    }" data-tag="${escapeHtml(tag)}">${escapeHtml(tag)}</button>`
+    `        <button class="tag-btn px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-surface-2 text-ink-muted hover:bg-surface-3" data-tag="${escapeHtml(tag)}">${escapeHtml(tag)}</button>`
   ).join('\n');
 
   const postCards = posts.map(post => `
-        <article class="bg-white dark:bg-[#1e1e1e] rounded-xl border border-gray-200 dark:border-white/10 p-6 hover:border-vscode-accent/50 transition-colors">
+        <article class="bg-surface-0 rounded-xl border border-border p-6 hover:border-accent/40 transition-colors">
           <div class="flex flex-wrap gap-2 mb-3">
-            ${post.tags.map(tag => `<span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">${escapeHtml(tag)}</span>`).join('')}
+            ${post.tags.map(tag => `<span class="tag-text text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">${escapeHtml(tag)}</span>`).join('')}
           </div>
-          <h2 class="text-2xl font-bold text-gray-900 dark:text-white mb-3">
-            <a href="${escapeHtml(post.slug)}.html" class="hover:text-vscode-accent transition-colors">${escapeHtml(post.title)}</a>
+          <h2 class="text-2xl font-bold text-ink mb-3 font-display">
+            <a href="${escapeHtml(post.slug)}.html" class="hover:text-accent transition-colors">${escapeHtml(post.title)}</a>
           </h2>
-          <p class="text-gray-600 dark:text-gray-400 mb-4 line-clamp-2">${escapeHtml(post.excerpt)}</p>
-          <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+          <p class="text-ink-muted mb-4 line-clamp-2">${escapeHtml(post.excerpt)}</p>
+          <div class="flex items-center gap-4 text-sm text-ink-faint">
             <span>${formatDate(post.date)}</span>
             <span>&middot;</span>
             <span>${escapeHtml(post.readingTime)}</span>
           </div>
-          <a href="${escapeHtml(post.slug)}.html" class="inline-flex items-center gap-2 text-vscode-accent hover:underline font-medium mt-4">
+          <a href="${escapeHtml(post.slug)}.html" class="inline-flex items-center gap-2 text-accent hover:underline font-medium mt-4">
             Read more
             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
           </a>
@@ -363,16 +504,16 @@ function generateBlogIndex(posts) {
   return `${generateHeader('Blog', 'blog')}
     <div class="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
       <div class="text-center mb-12">
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-ink tracking-tight font-display mb-4">
           Lanes Blog
         </h1>
-        <p class="text-lg text-gray-600 dark:text-gray-400">
+        <p class="text-lg text-ink-muted">
           Projects, tutorials, and updates from the Lanes community
         </p>
       </div>
 
       <div class="flex gap-2 mb-8 flex-wrap justify-center">
-        <button class="tag-btn active px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-vscode-accent text-white" data-tag="all">All Posts</button>
+        <button class="tag-btn active px-4 py-2 rounded-lg text-sm font-medium transition-colors bg-accent text-white" data-tag="all">All Posts</button>
 ${tagButtons}
       </div>
 
@@ -389,7 +530,7 @@ ${postCards}
         // Store original order
         const postsData = Array.from(allPosts).map(article => ({
           element: article,
-          tags: Array.from(article.querySelectorAll('.text-blue-600')).map(el => el.textContent.toLowerCase())
+          tags: Array.from(article.querySelectorAll('.tag-text')).map(el => el.textContent.toLowerCase())
         }));
 
         tagBtns.forEach(btn => {
@@ -398,11 +539,11 @@ ${postCards}
 
             // Update active button
             tagBtns.forEach(b => {
-              b.classList.remove('bg-vscode-accent', 'text-white');
-              b.classList.add('bg-gray-200', 'dark:bg-gray-800', 'text-gray-700', 'dark:text-gray-300');
+              b.classList.remove('bg-accent', 'text-white');
+              b.classList.add('bg-surface-2', 'text-ink-muted');
             });
-            btn.classList.remove('bg-gray-200', 'dark:bg-gray-800', 'text-gray-700', 'dark:text-gray-300');
-            btn.classList.add('bg-vscode-accent', 'text-white');
+            btn.classList.remove('bg-surface-2', 'text-ink-muted');
+            btn.classList.add('bg-accent', 'text-white');
 
             // Filter posts
             postsContainer.innerHTML = '';
@@ -430,14 +571,14 @@ function wrapCodeBlocks(html) {
     (match, lang, code) => {
       // Strip curly braces from language name if present (e.g., {bash} -> bash)
       const cleanLang = lang.replace(/[{}]/g, '');
-      return `<div class="relative my-4 rounded-xl border border-gray-200 dark:border-white/10 bg-gray-100 dark:bg-vscode-sidebar overflow-hidden">
-        <div class="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-white/10 bg-gray-200 dark:bg-[#1e1e1e]">
+      return `<div class="relative my-4 rounded-xl border border-border bg-surface-1 overflow-hidden">
+        <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
           <div class="flex gap-2">
             <div class="w-3 h-3 rounded-full bg-red-500"></div>
             <div class="w-3 h-3 rounded-full bg-yellow-500"></div>
             <div class="w-3 h-3 rounded-full bg-green-500"></div>
           </div>
-          <div class="ml-4 text-xs text-gray-600 dark:text-gray-500 font-mono">${escapeHtml(cleanLang)}</div>
+          <div class="ml-4 text-xs text-ink-faint font-mono">${escapeHtml(cleanLang)}</div>
         </div>
         <pre style="margin: 0; border-top-left-radius: 0; border-top-right-radius: 0;"><code class="language-${escapeHtml(lang)}">${code}</code></pre>
       </div>`;
@@ -458,13 +599,13 @@ function generatePostPage(post, allPosts) {
     .slice(0, 3);
 
   const relatedPostsHtml = relatedPosts.length > 0 ? `
-      <div class="border-t border-gray-200 dark:border-white/10 pt-8 mt-8">
-        <h3 class="text-lg font-bold text-gray-900 dark:text-white mb-4">Related Posts</h3>
+      <div class="border-t border-border pt-8 mt-8">
+        <h3 class="text-lg font-bold text-ink mb-4 font-display">Related Posts</h3>
         <div class="grid gap-4">
           ${relatedPosts.map(p => `
-            <a href="${escapeHtml(p.slug)}.html" class="block p-4 rounded-lg bg-gray-100 dark:bg-white/5 hover:bg-gray-200 dark:hover:bg-white/10 transition-colors">
-              <h4 class="font-medium text-gray-900 dark:text-white">${escapeHtml(p.title)}</h4>
-              <p class="text-sm text-gray-600 dark:text-gray-400 mt-1">${escapeHtml(p.excerpt)}</p>
+            <a href="${escapeHtml(p.slug)}.html" class="block p-4 rounded-lg bg-surface-1 hover:bg-surface-2 transition-colors border border-border">
+              <h4 class="font-medium text-ink">${escapeHtml(p.title)}</h4>
+              <p class="text-sm text-ink-muted mt-1">${escapeHtml(p.excerpt)}</p>
             </a>
           `).join('')}
         </div>
@@ -473,24 +614,24 @@ function generatePostPage(post, allPosts) {
   return `${generateHeader(post.title, 'blog')}
     <article class="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
       <nav class="mb-8 text-sm">
-        <a href="index.html" class="text-vscode-accent hover:underline">&larr; Back to Blog</a>
+        <a href="index.html" class="text-accent hover:underline">&larr; Back to Blog</a>
       </nav>
 
       <header class="mb-8">
         <div class="flex flex-wrap gap-2 mb-4">
-          ${post.tags.map(tag => `<span class="text-xs bg-blue-500/20 text-blue-600 dark:text-blue-400 px-2 py-1 rounded-full">${escapeHtml(tag)}</span>`).join('')}
+          ${post.tags.map(tag => `<span class="text-xs bg-accent/15 text-accent px-2 py-1 rounded-full">${escapeHtml(tag)}</span>`).join('')}
         </div>
-        <h1 class="text-4xl sm:text-5xl font-extrabold text-gray-900 dark:text-white tracking-tight mb-4">
+        <h1 class="text-4xl sm:text-5xl font-extrabold text-ink tracking-tight font-display mb-4">
           ${escapeHtml(post.title)}
         </h1>
-        <div class="flex items-center gap-4 text-sm text-gray-500 dark:text-gray-500">
+        <div class="flex items-center gap-4 text-sm text-ink-faint">
           <span>${formatDate(post.date)}</span>
           <span>&middot;</span>
           <span>${escapeHtml(post.readingTime)}</span>
         </div>
       </header>
 
-      <div class="prose dark:prose-invert max-w-none">
+      <div class="prose max-w-none">
         ${wrapCodeBlocks(post.html)}
       </div>
 

--- a/docs/scripts/build-docs.js
+++ b/docs/scripts/build-docs.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Assembles docs/docs.html from docs/docs-shell.html + docs/sections/*.html
+ *
+ * The shell file contains a <!-- SECTIONS --> placeholder.
+ * Each section file in docs/sections/ is inserted in order at that marker.
+ *
+ * Usage: node scripts/build-docs.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const docsDir = path.resolve(__dirname, '..');
+const shellPath = path.join(docsDir, 'docs-shell.html');
+const sectionsDir = path.join(docsDir, 'sections');
+const outputPath = path.join(docsDir, 'docs.html');
+
+// Section order (matches sidebar)
+const sectionOrder = [
+    'create-session',
+    'worktrees',
+    'permission-modes',
+    'git-review',
+    'multi-agent',
+    'file-attachments',
+    'tmux-terminal',
+    'local-settings',
+    'workflows-intro',
+    'workflow-structure',
+    'creating-workflow',
+    'lanes-mcp',
+    'contributing',
+];
+
+// Read the shell
+const shell = fs.readFileSync(shellPath, 'utf8');
+
+// Read and concatenate sections
+const sectionsHtml = sectionOrder.map(id => {
+    const filePath = path.join(sectionsDir, `${id}.html`);
+    if (!fs.existsSync(filePath)) {
+        console.error(`Missing section file: ${filePath}`);
+        process.exit(1);
+    }
+    return fs.readFileSync(filePath, 'utf8');
+}).join('\n');
+
+// Replace the placeholder
+if (!shell.includes('<!-- SECTIONS -->')) {
+    console.error('Shell file missing <!-- SECTIONS --> placeholder');
+    process.exit(1);
+}
+
+const output = shell.replace('<!-- SECTIONS -->', sectionsHtml);
+fs.writeFileSync(outputPath, output, 'utf8');
+
+const lineCount = output.split('\n').length;
+console.log(`Built docs.html (${lineCount} lines) from ${sectionOrder.length} sections`);

--- a/docs/sections/contributing.html
+++ b/docs/sections/contributing.html
@@ -1,0 +1,115 @@
+                        <section id="contributing" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <h2 class="text-3xl font-bold text-ink mb-6">Contributing to Lanes</h2>
+                                <p class="text-ink-muted mb-8">
+                                    Lanes is an open-source project, and we welcome contributions from the community. Whether you want to report a bug, suggest a feature, or contribute code, here's how to get involved.
+                                </p>
+
+                                <!-- Development Guidelines -->
+                                <div>
+                                    <h3 class="text-2xl font-bold text-ink mb-4">Development Guidelines</h3>
+                                    <p class="text-ink-muted mb-6">
+                                        Interested in contributing code? Check out our comprehensive contribution guide for development setup, coding standards, and the pull request process.
+                                    </p>
+                                    <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="inline-flex items-center gap-2 bg-violet-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-violet-700 transition-colors mb-6">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+                                        </svg>
+                                        View Contributing Guidelines
+                                    </a>
+                                </div>
+
+                                <div class="space-y-8">
+                                    <!-- Reporting Issues -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Reporting Issues</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Found a bug? Please report it through our issue tracker with as much detail as possible.
+                                        </p>
+                                            <h4 class="text-lg font-semibold text-ink mb-3">Issue Template</h4>
+                                            <div class="text-sm text-ink-muted space-y-3 mb-3">
+                                                <p>When reporting a bug, please include the following information:</p>
+                                                <div class="bg-surface-1 rounded-md p-4 font-mono text-xs space-y-2 border border-border mb-6">
+                                                    <p><strong class="text-ink">**Description**</strong><br>A clear description of the issue</p>
+                                                    <p><strong class="text-ink">**Steps to Reproduce**</strong><br>1. Go to...<br>2. Click on...<br>3. See error</p>
+                                                    <p><strong class="text-ink">**Expected Behavior**</strong><br>What should happen</p>
+                                                    <p><strong class="text-ink">**Actual Behavior**</strong><br>What actually happens</p>
+                                                    <p><strong class="text-ink">**Environment**</strong><br>- OS: [e.g., macOS 14.0]<br>- VS Code version: [e.g., 1.85.0]<br>- Lanes version: [e.g., v1.0.2]<br>- Node version: [e.g., v18.17.0]</p>
+                                                    <p><strong class="text-ink">**Logs**</strong><br>[Relevant error messages or console output]</p>
+                                                </div>
+                                            </div>
+                                        
+                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=bug_report.md" class="inline-flex items-center gap-2 bg-accent text-white px-6 py-3 rounded-lg font-medium hover:opacity-90 transition-opacity">
+                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+                                            </svg>
+                                            Report a Bug
+                                        </a>
+                                    </div>
+
+                                    <!-- Suggesting Features -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Suggesting Features</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Have an idea for improving Lanes? We'd love to hear it! Please provide a clear description of the problem you're trying to solve.
+                                        </p>
+                                            <h4 class="text-lg font-semibold text-ink mb-3">Feature Request Template</h4>
+                                            <div class="text-sm text-ink-muted space-y-3 mb-4">
+                                                <p>When requesting a feature, please include the following information:</p>
+                                                <div class="bg-surface-1 rounded-md p-4 font-mono text-xs space-y-2 border border-border mb-6">
+                                                    <p><strong class="text-ink">**Problem Description**</strong><br>Describe the problem you want to solve</p>
+                                                    <p><strong class="text-ink">**Proposed Solution**</strong><br>Describe your proposed solution (if you have one)</p>
+                                                    <p><strong class="text-ink">**Benefits**</strong><br>Explain how this would benefit other users</p>
+                                                    <p><strong class="text-ink">**Alternatives**</strong><br>Any alternative approaches you've considered</p>
+                                                </div>
+                                            </div>
+
+                                        <a href="https://github.com/FilipeJesus/lanes/issues/new?template=feature_request.md" class="inline-flex items-center gap-2 bg-emerald-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-emerald-700 transition-colors">
+                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                            </svg>
+                                            Request a Feature
+                                        </a>
+                                    </div>
+
+                                    <!-- Quick Links -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Quick Links</h3>
+                                        <div class="grid sm:grid-cols-2 gap-4">
+                                            <a href="https://github.com/FilipeJesus/lanes/issues" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+                                                </svg>
+                                                <span class="font-medium text-ink">Issue Tracker</span>
+                                            </a>
+                                            <a href="https://github.com/FilipeJesus/lanes/pulls" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"></path>
+                                                </svg>
+                                                <span class="font-medium text-ink">Pull Requests</span>
+                                            </a>
+                                            <a href="https://github.com/FilipeJesus/lanes/blob/main/CONTRIBUTING.md" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                                                </svg>
+                                                <span class="font-medium text-ink">Contributing Guide</span>
+                                            </a>
+                                            <a href="https://github.com/FilipeJesus/lanes" class="flex items-center gap-3 bg-surface-1 rounded-lg p-4 hover:bg-surface-2 transition-colors">
+                                                <svg class="w-6 h-6 text-ink-muted" fill="currentColor" viewBox="0 0 24 24">
+                                                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+                                                </svg>
+                                                <span class="font-medium text-ink">GitHub Repository</span>
+                                            </a>
+                                        </div>
+                                    </div>
+
+                                    <!-- Thank You -->
+                                    <div class="bg-surface-1 border border-border rounded-lg p-6 text-center">
+                                        <h3 class="text-xl font-bold text-ink mb-2">Thank You for Contributing!</h3>
+                                        <p class="text-ink-muted">
+                                            Every contribution helps make Lanes better for everyone. Whether it's reporting bugs, suggesting features, or writing code, we appreciate your support.
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/create-session.html
+++ b/docs/sections/create-session.html
@@ -1,0 +1,355 @@
+                        <section id="create-session" class="doc-section mb-16 scroll-mt-24">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Create a New Session</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Creating a new session in Lanes is straightforward. Each session is isolated and runs in its own Git worktree, giving Claude Code a clean workspace to work in without affecting your main codebase.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- Step 1: Prerequisites -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Before You Start</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Make sure you have:
+                                        </p>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li>Opened a folder or workspace in VS Code</li>
+                                            <li>A Git repository initialized (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">git init</code> if needed)</li>
+                                            <li>Claude Code installed globally (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">npm install -g @anthropic-ai/claude-code</code>)</li>
+                                            <li>Logged into Claude (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">claude login</code>)</li>
+                                            <li><code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">jq</code> installed for status tracking (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">brew install jq</code> on macOS or <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">apt install jq</code> on Linux)</li>
+                                            <li><em>Optional:</em> Codex CLI installed (<code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">npm install -g @openai/codex</code>) for OpenAI agent support</li>
+                                        </ul>
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 mt-3">
+                                            <p class="text-xs text-amber-600 dark:text-amber-400">
+                                                <strong>Note:</strong> Lanes currently supports macOS and Linux. Windows is not yet supported (WSL may work).
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Step 2: Open Lanes Sidebar -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 1: Open the Lanes Sidebar</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Click the Lanes icon in the VS Code activity bar (the vertical bar on the far left) to open the Lanes panel. You'll see the session creation form at the top.
+                                        </p>
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4 mt-3">
+                                            <div class="flex gap-2">
+                                                <svg class="w-5 h-5 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-accent font-medium">Tip</p>
+                                                    <p class="text-sm text-accent mt-1">
+                                                        Can't find the Lanes icon? Use the command palette (<kbd class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">Cmd+Shift+P</kbd>) and search for "Lanes: Create Session".
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Step 3: Fill in Session Details -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 2: Fill in the Session Form</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The form has several fields to configure your session. Here's what each one does:
+                                        </p>
+
+                                        <div class="space-y-6">
+                                            <!-- Agent Selection -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">1</span>
+                                                    Agent Selection
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    Choose which AI coding agent to use for this session. Click the agent logo to switch between available agents.
+                                                </p>
+                                                <div class="space-y-2 text-sm">
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">Claude Code</code>
+                                                        <span class="text-ink-muted">Anthropic's coding agent — uses hooks for status tracking</span>
+                                                    </div>
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">Codex CLI</code>
+                                                        <span class="text-ink-muted">OpenAI's coding agent — uses polling for session ID capture</span>
+                                                    </div>
+                                                </div>
+                                                <div class="bg-accent-dim border border-accent/20 rounded-lg p-3 mt-3">
+                                                    <p class="text-xs text-accent">
+                                                        <strong>Tip:</strong> Set a default agent with the <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">lanes.defaultAgent</code> setting to skip this step.
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            <!-- Session Name -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">2</span>
+                                                    Session Name <span class="text-red-500 ml-1">*</span>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    A unique identifier for your session. This becomes the Git branch name, so use descriptive, Git-safe names.
+                                                </p>
+                                                <div class="bg-surface-2 rounded-lg p-3 font-mono text-sm text-ink-muted mb-2">
+                                                    <span class="text-green-600 dark:text-green-400">✓ Good:</span> fix-login-bug, add-dark-mode, refactor-api-client<br>
+                                                    <span class="text-red-600 dark:text-red-400">✗ Bad:</span> my session, task#123, testing!!!
+                                                </div>
+                                                <p class="text-xs text-ink-faint italic">
+                                                    Allowed characters: letters, numbers, hyphens, underscores, dots, and slashes
+                                                </p>
+                                            </div>
+
+                                            <!-- Source Branch -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">3</span>
+                                                    Source Branch (optional)
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    The branch to create the worktree from. If left empty, Lanes uses your current HEAD.
+                                                </p>
+                                                <div class="bg-surface-2 rounded-lg p-3 text-sm text-ink-muted">
+                                                    <strong>Example:</strong> Enter <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">main</code> to always start from main, or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">develop</code> for your development branch.
+                                                </div>
+                                                <div class="bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded p-3 mt-3">
+                                                    <p class="text-xs text-amber-600 dark:text-amber-400">
+                                                        <strong>Note:</strong> The source branch must already exist. Lanes will create a new branch (with the session name) from this branch.
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            <!-- Starting Prompt -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">4</span>
+                                                    Starting Prompt (optional)
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    The initial task description sent to Claude Code when the session starts. Be specific about what you want Claude to do.
+                                                </p>
+                                                <div class="bg-surface-2 rounded-lg p-3 font-mono text-xs text-ink-muted mb-2">
+                                                    Example: "Fix the authentication bug where users get logged out after 5 minutes. The issue seems to be in the token refresh logic in src/auth/TokenManager.ts"
+                                                </div>
+                                                <p class="text-xs text-ink-faint italic">
+                                                    Leave empty if you want to start with a blank session and provide instructions manually.
+                                                </p>
+                                            </div>
+
+                                            <!-- File Attachments -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">5</span>
+                                                    File Attachments (optional)
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    Drag-and-drop or click to attach files to your session. File contents are included with the starting prompt, giving the agent additional context.
+                                                </p>
+                                                <div class="bg-surface-2 rounded-lg p-3 text-sm text-ink-muted mb-2">
+                                                    <strong>Use cases:</strong> Design specs, API schemas, screenshots, reference implementations, or any file the agent should read before starting.
+                                                </div>
+                                                <p class="text-xs text-ink-faint italic">
+                                                    A progress indicator shows upload status for each file.
+                                                </p>
+                                            </div>
+
+                                            <!-- Permission Mode -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center text-xs font-bold">6</span>
+                                                    Permission Mode
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Controls what Claude Code can do without asking for permission. Choose based on your trust level and workflow:
+                                                </p>
+                                                <div class="space-y-2 text-sm">
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">default</code>
+                                                        <span class="text-ink-muted">Standard behavior - asks for permission on sensitive operations</span>
+                                                    </div>
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">acceptEdits</code>
+                                                        <span class="text-ink-muted">Auto-accepts file edits (recommended for most workflows)</span>
+                                                    </div>
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">dontAsk</code>
+                                                        <span class="text-ink-muted">Auto-deny tools unless explicitly allowed by an allow rule</span>
+                                                    </div>
+                                                    <div class="flex gap-2">
+                                                        <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">bypassPermissions</code>
+                                                        <span class="text-ink-muted">Runs all commands automatically (use with caution)</span>
+                                                    </div>
+                                                </div>
+                                                <div class="bg-accent-dim border border-accent/20 rounded-lg p-3 mt-3">
+                                                    <p class="text-xs text-accent">
+                                                        <strong>Recommendation:</strong> Start with <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">default</code> or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">acceptEdits</code> until you're comfortable with how Claude works.
+                                                    </p>
+                                                </div>
+                                            </div>
+
+                                            <!-- Workflow Template -->
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <span class="w-6 h-6 bg-surface-3 text-ink rounded-full flex items-center justify-center text-xs font-bold">7</span>
+                                                    Workflow Template (optional)
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    Choose a structured workflow to guide Claude through your task. Workflows define clear phases like plan, implement, test, and review.
+                                                </p>
+                                                <div class="space-y-2 text-sm mb-3">
+                                                    <div class="flex gap-2 items-start">
+                                                        <span class="text-ink-faint flex-shrink-0">•</span>
+                                                        <div>
+                                                            <strong class="text-ink">None (ad-hoc mode):</strong>
+                                                            <span class="text-ink-muted"> Freeform session - Claude works without a predefined structure</span>
+                                                        </div>
+                                                    </div>
+                                                    <div class="flex gap-2 items-start">
+                                                        <span class="text-ink-faint flex-shrink-0">•</span>
+                                                        <div>
+                                                            <strong class="text-ink">Custom Workflows:</strong>
+                                                            <span class="text-ink-muted"> Your own workflows from <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/workflows/</code></span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <p class="text-xs text-ink-faint italic">
+                                                    Click the refresh button (↻) to reload the workflow list if you just added new workflow files.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Step 4: Create the Session -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Step 3: Click "Create Session"</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Once you've filled in the required fields, click the <strong>Create Session</strong> button. Lanes will:
+                                        </p>
+                                        <div class="space-y-3">
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">1</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Create a new Git worktree</p>
+                                                    <p class="text-sm text-ink-muted">Located at <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.worktrees/[session-name]</code> - a complete, isolated copy of your repository</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">2</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Create a new branch</p>
+                                                    <p class="text-sm text-ink-muted">Named after your session, branched from the source branch (or current HEAD)</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">3</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Open a dedicated terminal</p>
+                                                    <p class="text-sm text-ink-muted">Each session gets its own terminal window in VS Code</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">4</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Launch the selected agent</p>
+                                                    <p class="text-sm text-ink-muted">With your starting prompt, file attachments (if any), and selected permission mode</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-6 h-6 bg-emerald-500 text-white rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">5</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Initialize workflow (if selected)</p>
+                                                    <p class="text-sm text-ink-muted">Sets up the MCP server and prepares the workflow state</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- What Happens Next -->
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">What Happens Next?</h3>
+                                        <div class="space-y-3 text-ink-muted">
+                                            <p>
+                                                <strong>Terminal Opens:</strong> You'll see a new terminal window appear with Claude Code running. The terminal title shows your session name.
+                                            </p>
+                                            <p>
+                                                <strong>Session Appears in Sidebar:</strong> Your new session shows up in the "Active Sessions" list in the Lanes sidebar with a real-time status indicator.
+                                            </p>
+                                            <p>
+                                                <strong>Claude Starts Working:</strong> If you provided a starting prompt, Claude immediately begins working on your task. Otherwise, it waits for your instructions.
+                                            </p>
+                                            <p>
+                                                <strong>Isolated Environment:</strong> All changes Claude makes are contained in the worktree. Your main working directory remains untouched.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Tips and Best Practices -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Tips for Success</h3>
+                                        <div class="space-y-3">
+                                            <div class="flex gap-3 items-start">
+                                                <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-ink font-medium">Use descriptive session names</p>
+                                                    <p class="text-sm text-ink-muted">Names like <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">fix-user-logout-bug</code> are more helpful than <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">session1</code></p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-ink font-medium">Be specific in your prompts</p>
+                                                    <p class="text-sm text-ink-muted">Include file paths, expected behavior, and any relevant context</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-ink font-medium">Start with a clean working directory</p>
+                                                    <p class="text-sm text-ink-muted">Commit or stash changes in your main branch before creating sessions</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-ink font-medium">Use workflows for complex tasks</p>
+                                                    <p class="text-sm text-ink-muted">Features with multiple files, testing requirements, or documentation needs benefit from structured workflows</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <svg class="w-5 h-5 text-green-600 dark:text-green-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-ink font-medium">One task per session</p>
+                                                    <p class="text-sm text-ink-muted">Keep sessions focused on a single goal - create multiple sessions for multiple tasks</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Common Issues -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Troubleshooting Common Issues</h3>
+                                        <div class="space-y-3">
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Session name already exists"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">A session with this name is already active, or a branch with this name exists. Choose a different name or delete the existing session first.</p>
+                                            </div>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Not a git repository"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Run <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">git init</code> in your project folder to initialize a Git repository.</p>
+                                            </div>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Claude Code not found"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Install Claude Code globally: <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">npm install -g @anthropic-ai/claude-code</code></p>
+                                            </div>
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <p class="text-sm font-bold text-red-600 dark:text-red-400 mb-1">Error: "Codex CLI not found"</p>
+                                                <p class="text-sm text-red-600 dark:text-red-400">Install Codex CLI globally: <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">npm install -g @openai/codex</code>. Make sure you have an OpenAI API key configured.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/creating-workflow.html
+++ b/docs/sections/creating-workflow.html
@@ -1,0 +1,496 @@
+                        <section id="creating-workflow" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Creating a Workflow</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Learn how to create custom workflows for your projects, with a complete annotated example and best practices.
+                                </p>
+
+                                <div class="space-y-10">
+                                    <!-- Creating Custom Workflows -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Step-by-Step Guide</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Custom workflows let you define project-specific development processes. They appear in the "Custom" section of the workflow dropdown.
+                                        </p>
+                                        <ol class="space-y-4 mb-6">
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Define corresponding agents (if needed)</h5>
+                                                    <p class="text-sm text-ink-muted mb-2">
+                                                        First thing you will want to do is make sure you have already created all the agents you want to use in your workflow ahead of time. This is because agent names in your workflow must match either inline definitions or external agent files.
+                                                    </p>
+                                                    <div class="bg-surface-2 rounded-lg p-2 font-mono text-sm text-ink-muted mb-2">
+                                                        mkdir -p .claude/agents<br>
+                                                        # Create .claude/agents/my-agent.md
+                                                    </div>
+                                                    <p class="text-xs text-ink-faint">
+                                                        Note: Inline agent definitions in the workflow file take precedence over external files.
+                                                    </p>
+                                                </div>
+                                            </li>
+
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Start creating a workflow document</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Open the Lanes sidebar → Open the "Workflow" window → Press the '+' icon.
+                                                    </p>
+                                                </div>
+                                            </li>
+
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Start creating a workflow document</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        If you like, choose a template to start from (feature, bugfix, refactor, or default). This will create a new YAML file in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/workflows/</code>.
+                                                    </p>
+                                                </div>
+                                            </li>
+
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">4</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Write your workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Edit your the template document, you can use the examples below or use the Workflow Structure page for guidance.
+                                                    </p>
+                                                </div>
+                                            </li>
+
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">5</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Validate your workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        The lanes extension comes with the 'Validate Workflow' command which you cna find in your command palette. This will check your workflow for common errors and help ensure it is correctly formatted.
+                                                    </p>
+                                                </div>
+                                            </li>
+
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">6</span>
+                                                <div class="flex-1">
+                                                    <h5 class="font-semibold text-ink mb-1">Use the new Workflow</h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        The workflow should now appear in the workflow dropdown in the Lanes New Session window. You might need to use the refresh button. Select it to start using your custom workflow for new worktrees.
+                                                    </p>
+                                                </div>
+                                            </li>
+                                        </ol>
+
+                                    </div>
+
+                                    <!-- Simple Workflow Example -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Simple Workflow Example</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            For straightforward tasks, you can create a workflow with just steps—no agents or loops required. The main Claude agent handles all steps directly:
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">simple-workflow.yaml</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-gray-500"># A minimal workflow - just name, description, and steps</span>
+<span class="text-purple-400">name:</span> simple-task
+<span class="text-purple-400">description:</span> Execute a straightforward task
+
+<span class="text-purple-400">steps:</span>
+  - <span class="text-green-400">id:</span> analyze
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Analyze the codebase and identify what needs to be done.
+
+  - <span class="text-green-400">id:</span> implement
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Implement the required changes.
+      Ensure all tests pass.
+
+  - <span class="text-green-400">id:</span> verify
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Run tests and verify the implementation.
+      Update documentation if needed.</code></pre>
+                                        </div>
+
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4 mb-4">
+                                            <p class="text-sm text-accent">
+                                                <strong>Tip:</strong> Simple workflows are great for quick prototypes, single-developer tasks, or when you don't need specialized phases.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Context and Artefacts Example -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Context Management and Artefact Tracking</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            For larger features, you can use <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> to give Claude a fresh context window between planning and implementation. Combine this with <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">artefacts: true</code> to preserve important work across the reset:
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">context-aware-workflow.yaml</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">name:</span> feature-with-context-reset
+<span class="text-purple-400">description:</span> Large feature development with context management
+
+<span class="text-purple-400">steps:</span>
+  - <span class="text-green-400">id:</span> brainstorming
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      Use brainstorming skill to explore the problem space.
+
+  - <span class="text-green-400">id:</span> writing-plans
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">artefacts:</span> <span class="text-blue-400">true</span>  <span class="text-gray-500"># Track created plan files</span>
+    <span class="text-green-400">instructions:</span> |
+      Create detailed implementation plans.
+      Use "/writing-plans" skill from superpower to start.
+
+  - <span class="text-green-400">id:</span> implementation
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">context:</span> <span class="text-blue-400">clear</span>  <span class="text-gray-500"># Fresh context for implementation</span>
+    <span class="text-green-400">instructions:</span> |
+      Implement the features based on the plans.
+      Use "/subagent-driven-development" skill to start.
+      <span class="text-gray-500"># Artefacts from previous step are available here</span></code></pre>
+                                        </div>
+
+                                        <div class="grid md:grid-cols-2 gap-4 mb-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">Why use context: clear?</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Large features can exhaust Claude's context window. Clearing between planning and implementation gives the orchestrator a fresh start while the saved plans guide implementation.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">Why use artefacts: true?</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    When context is cleared, downstream steps need to know what files were created. Artefact tracking makes these files visible to subsequent steps.
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <div class="bg-red-500/10 border border-red-500/20 p-4">
+                                            <p class="text-sm text-red-600 dark:text-red-400">
+                                                <strong>Important:</strong> Only use <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> when you're confident your workflow saves plans in artefacts. Without saved plans, the implementation step won't have the necessary context.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Complete Annotated Example -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Complete Annotated Example (with Agents and Loops)</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            For complex workflows that need specialized agents and iteration over tasks, here's a complete template with detailed annotations:
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">my-custom-workflow.yaml</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto" style="max-height: 600px;"><code><span class="text-gray-500"># ==============================================================================</span>
+<span class="text-gray-500"># WORKFLOW TEMPLATE: Custom Feature Development</span>
+<span class="text-gray-500"># ==============================================================================</span>
+
+<span class="text-gray-500"># Required: Unique name for this workflow</span>
+<span class="text-purple-400">name:</span> custom-dev-workflow
+
+<span class="text-gray-500"># Required: Description shown in workflow selector</span>
+<span class="text-purple-400">description:</span> Custom workflow for our team's feature development process
+
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-gray-500"># AGENTS: Define specialized roles with tool permissions</span>
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-purple-400">agents:</span>
+  <span class="text-gray-500"># Planning agent - can read code but not modify it</span>
+  <span class="text-blue-400">planner:</span>
+    <span class="text-green-400">description:</span> Analyzes requirements and breaks down work
+
+  <span class="text-gray-500"># Implementation agent - can write code but not commit</span>
+  <span class="text-blue-400">coder:</span>
+    <span class="text-green-400">description:</span> Implements features according to plan
+
+  <span class="text-gray-500"># Test agent - can run tests and fix test code</span>
+  <span class="text-blue-400">tester:</span>
+    <span class="text-green-400">description:</span> Runs tests and fixes failures
+
+  <span class="text-gray-500"># Review agent - read-only, provides feedback</span>
+  <span class="text-blue-400">reviewer:</span>
+    <span class="text-green-400">description:</span> Reviews code quality and security
+
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-gray-500"># LOOPS: Reusable sub-workflows that iterate over tasks</span>
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-purple-400">loops:</span>
+  <span class="text-gray-500"># This loop executes for each task in the task list</span>
+  <span class="text-blue-400">build_feature:</span>
+    <span class="text-gray-500"># Sub-step 1: Implement the feature</span>
+    - <span class="text-green-400">id:</span> code
+      <span class="text-green-400">agent:</span> coder
+      <span class="text-green-400">instructions:</span> |
+        Implement: {task.title}
+
+        Steps:
+        1. Read relevant files to understand context
+        2. Plan your implementation approach
+        3. Write the code
+        4. Verify it compiles without errors
+
+        Do NOT run tests - that's handled in the next step.
+
+    <span class="text-gray-500"># Sub-step 2: Test the implementation</span>
+    - <span class="text-green-400">id:</span> test
+      <span class="text-green-400">agent:</span> tester
+      <span class="text-green-400">instructions:</span> |
+        Test the implementation of: {task.title}
+
+        1. Run the full test suite
+        2. Identify any failing tests
+        3. Fix test failures
+        4. Ensure all tests pass
+        5. Report test results
+      <span class="text-green-400">on_fail:</span> retry  <span class="text-gray-500"># Retry if tests fail</span>
+
+    <span class="text-gray-500"># Sub-step 3: Review the code</span>
+    - <span class="text-green-400">id:</span> review
+      <span class="text-green-400">agent:</span> reviewer
+      <span class="text-green-400">instructions:</span> |
+        Review the implementation of: {task.title}
+
+        Check for:
+        1. Security vulnerabilities
+        2. Proper error handling
+        3. Code quality and maintainability
+        4. Adherence to project patterns
+        5. Edge cases and potential bugs
+
+        Provide specific feedback on any issues found.
+
+    <span class="text-gray-500"># Sub-step 4: Address review feedback (no agent = main Claude)</span>
+    - <span class="text-green-400">id:</span> fix_issues
+      <span class="text-green-400">instructions:</span> |
+        Review feedback for: {task.title}
+
+        1. Read the reviewer's feedback
+        2. If there are critical issues, fix them
+        3. If there are minor suggestions, note them for future work
+        4. Mark the task as complete
+
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-gray-500"># STEPS: Main workflow sequence (executed in order)</span>
+<span class="text-gray-500"># ==============================================================================</span>
+<span class="text-purple-400">steps:</span>
+  <span class="text-gray-500"># Step 1: ACTION type - single operation by planner agent</span>
+  - <span class="text-green-400">id:</span> analyze
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> planner
+    <span class="text-green-400">instructions:</span> |
+      Analyze the user's goal and break it into discrete tasks.
+
+      Consider:
+      1. What features or changes are needed?
+      2. What are the dependencies between tasks?
+      3. What is the optimal implementation order?
+
+      Document your analysis clearly.
+
+  <span class="text-gray-500"># Step 2: ACTION type - planner defines the task list</span>
+  - <span class="text-green-400">id:</span> create_tasks
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> planner
+    <span class="text-green-400">instructions:</span> |
+      Create a task list based on your analysis.
+
+      For each task, define:
+      - id: unique-identifier (e.g., 'add-login', 'fix-validation')
+      - title: Clear, concise title (e.g., 'Add login form')
+      - description: Detailed requirements
+
+      Call workflow_set_tasks('build_feature', tasks) when ready.
+
+  <span class="text-gray-500"># Step 3: LOOP type - references the 'build_feature' loop above</span>
+  <span class="text-gray-500"># This will execute all sub-steps for each task</span>
+  - <span class="text-green-400">id:</span> build_feature
+    <span class="text-green-400">type:</span> loop
+
+  <span class="text-gray-500"># Step 4: ACTION type - final review of all changes</span>
+  - <span class="text-green-400">id:</span> final_review
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> reviewer
+    <span class="text-green-400">instructions:</span> |
+      Review the complete implementation.
+
+      Check:
+      1. Consistency across all changes
+      2. Integration between features
+      3. Overall code quality
+      4. Any missed requirements from the original goal
+
+      Provide a summary of the implementation quality.
+
+  <span class="text-gray-500"># Step 5: ACTION type - finalize and prepare for commit</span>
+  - <span class="text-green-400">id:</span> finalize
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">instructions:</span> |
+      <span class="text-gray-500"># No agent specified - main Claude handles this</span>
+      Finalize the implementation.
+
+      1. Review the final review feedback
+      2. Address any critical issues
+      3. Run final tests
+      4. Prepare a summary of what was accomplished
+      5. The workflow will complete and you can commit</code></pre>
+                                        </div>
+                                    </div>
+
+                                    <!-- Best Practices -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Best Practices for Custom Workflows</h3>
+
+                                        <div class="space-y-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Keep Agent Roles Focused</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Each agent should have a single, clear responsibility. Don't create "super agents" that can do everything.
+                                                    Focused agents enforce separation of concerns and prevent mistakes.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use Clear, Specific Instructions</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Instructions should be explicit and actionable. Include numbered steps, expected outputs, and what NOT to do.
+                                                    Remember that different Claude instances will execute these instructions across context windows.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use on_fail Strategically</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">retry</code> - For test failures or transient issues<br>
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">skip</code> - For optional steps that might fail<br>
+                                                    • <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">abort</code> (default) - For critical steps that must succeed
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Use Task Variables</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Always reference <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">{task.id}</code> and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">{task.title}</code>
+                                                    in loop instructions. This provides context across different tasks and helps Claude understand what it's working on.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Test Your Workflow</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Before rolling out a custom workflow to your team, test it on a real task. Verify that:
+                                                    • Each step produces the expected output
+                                                    • Agents execute their roles correctly
+                                                    • The workflow completes successfully
+                                                    • The final result matches expectations
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-green-900 dark:text-green-200 mb-2">Version Control Your Workflows</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    Commit your <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.lanes/workflows/</code> directory to git.
+                                                    This ensures your team uses consistent workflows and you can track changes over time.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Validation and Debugging -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Validation and Debugging</h3>
+
+                                        <p class="text-ink-muted mb-4">
+                                            Lanes validates workflow templates when they're loaded. Common validation errors:
+                                        </p>
+
+                                        <div class="space-y-3">
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Agent 'X' references unknown agent 'Y'</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    A step references an agent that isn't defined. Check:
+                                                </p>
+                                                <ul class="text-sm text-ink-muted list-disc list-inside ml-4">
+                                                    <li>Is the agent name spelled correctly?</li>
+                                                    <li>Is the agent defined in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">agents:</code> section?</li>
+                                                    <li>Does a matching file exist in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.claude/agents/</code>?</li>
+                                                </ul>
+                                            </div>
+
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Loop step 'X' references unknown loop definition</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    A <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">type: loop</code> step's <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">id</code>
+                                                    doesn't match any loop in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">loops:</code> section.
+                                                    The loop step ID must exactly match a loop name.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                                                <h5 class="font-bold text-red-600 dark:text-red-400 mb-2 font-mono text-sm">Invalid YAML syntax</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    YAML parsing failed. Common issues:
+                                                </p>
+                                                <ul class="text-sm text-ink-muted list-disc list-inside ml-4">
+                                                    <li>Incorrect indentation (YAML uses 2 spaces, not tabs)</li>
+                                                    <li>Missing colons after keys</li>
+                                                    <li>Unquoted strings with special characters</li>
+                                                    <li>Inconsistent list formatting</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Next Steps -->
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Next Steps</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Now that you understand workflow templates, you might want to:
+                                        </p>
+                                        <ul class="space-y-2 text-sm text-ink-muted">
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="#lanes-mcp" class="text-accent hover:underline">Learn about the Lanes MCP Server</a> - Understanding how workflows communicate with Claude
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <span>Study the built-in workflows in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">workflows/</code> for real-world examples</span>
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <span>Create a custom workflow for your team's specific development process</span>
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline" target="_blank">Read Anthropic's research</a> on effective harnesses for long-running agents
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/file-attachments.html
+++ b/docs/sections/file-attachments.html
@@ -1,0 +1,65 @@
+                        <section id="file-attachments" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">File Attachments</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Attach files to your session to give the agent additional context before it starts working. Files are read and their contents are included with the starting prompt.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- How to Attach -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">How to Attach Files</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            In the session creation form, you can attach files in two ways:
+                                        </p>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Click to browse:</strong> Click the attachment area to open a file picker</li>
+                                        </ul>
+                                    </div>
+
+                                    <!-- Upload Progress -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Upload Progress</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Each attached file shows an upload progress indicator. Once uploaded, file contents are processed and ready to be included with your prompt.
+                                        </p>
+                                    </div>
+
+                                    <!-- How Contents Are Included -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">How Contents Are Included</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            When you create the session, file contents are appended to the starting prompt. The agent receives the full text of each file along with the filename, giving it immediate access to the context it needs.
+                                        </p>
+                                    </div>
+
+                                    <!-- Use Cases -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Common Use Cases</h3>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Design Specifications</h4>
+                                                <p class="text-xs text-ink-muted">Attach design docs or mockup descriptions so the agent understands the target UI/UX.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">API Schemas</h4>
+                                                <p class="text-xs text-ink-muted">Include OpenAPI specs or GraphQL schemas for API integration tasks.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Reference Code</h4>
+                                                <p class="text-xs text-ink-muted">Attach example implementations or patterns you want the agent to follow.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Bug Reports</h4>
+                                                <p class="text-xs text-ink-muted">Include error logs, stack traces, or issue descriptions for debugging sessions.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/git-review.html
+++ b/docs/sections/git-review.html
@@ -1,0 +1,176 @@
+                        <section id="git-review" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Reviewing Changes</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Lanes includes a built-in code review tool that lets you view changes, add comments, and generate review feedback for your coding agents.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- Opening the Diff Viewer -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Opening the Git Changes Viewer</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            To review changes made in a session:
+                                        </p>
+                                        <ol class="space-y-3 mb-4">
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted">Click the <strong class="text-ink">"Show Git Changes"</strong> button in the session's action bar (the diff icon)</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted">A new panel opens showing all file changes between your session branch and the comparison branch</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted">This can be slow when there are many changes.</p>
+                                                </div>
+                                            </li>
+                                        </ol>
+                                    </div>
+
+                                    <!-- Understanding the Diff View -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Understanding the Diff View</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The diff viewer shows changes in a unified diff format:
+                                        </p>
+                                        <div class="space-y-4">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Comparison Branch</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    By default, changes are compared against <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">main</code> or <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">master</code>.
+                                                    You can change this using the branch selector dropdown at the top of the diff panel.
+                                                </p>
+                                            </div>
+                                            <div class="grid md:grid-cols-2 gap-4">
+                                                <div class="bg-green-50 dark:bg-green-900/20 border-l-4 border-green-500 p-4">
+                                                    <h5 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                        <span class="text-green-600 dark:text-green-400">+</span> Added Lines
+                                                    </h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Lines highlighted in green are new additions to the codebase.
+                                                    </p>
+                                                </div>
+                                                <div class="bg-red-50 dark:bg-red-900/20 border-l-4 border-red-500 p-4">
+                                                    <h5 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                        <span class="text-red-600 dark:text-red-400">-</span> Removed Lines
+                                                    </h5>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Lines highlighted in red have been deleted from the original.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Adding Review Comments -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Adding Review Comments</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            You can add comments to specific lines in the diff to provide feedback:
+                                        </p>
+                                        <ol class="space-y-3 mb-4">
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted"><strong class="text-ink">Click on any line</strong> in the diff view to select it</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted"><strong class="text-ink">Type your comment</strong> in the input field that appears</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted"><strong class="text-ink">Press Enter</strong> to save the comment</p>
+                                                </div>
+                                            </li>
+                                        </ol>
+                                        <p class="text-ink-muted mb-4">
+                                            Comments are displayed inline with the code, making it easy to track your feedback as you review.
+                                        </p>
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-amber-600 dark:text-amber-400">
+                                                <strong>Note:</strong> Comments are stored locally in the diff viewer session. They are not persisted to git or any external system.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Submitting Review -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Submitting Your Review</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Once you've added all your comments, you can generate a formatted review to share with your coding agent:
+                                        </p>
+                                        <ol class="space-y-3 mb-6">
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">1</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted">Click the <strong class="text-ink">"Submit Review"</strong> button at the top of the diff panel</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">2</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted">The review is <strong class="text-ink">automatically copied to your clipboard</strong> in a structured markdown format</p>
+                                                </div>
+                                            </li>
+                                            <li class="flex gap-3">
+                                                <span class="flex-shrink-0 w-7 h-7 bg-accent text-white rounded-full flex items-center justify-center font-bold text-sm">3</span>
+                                                <div class="flex-1">
+                                                    <p class="text-ink-muted"><strong class="text-ink">Paste</strong> the review into your coding agent's terminal or chat</p>
+                                                </div>
+                                            </li>
+                                        </ol>
+
+                                        <h4 class="text-lg font-semibold text-ink mb-3">Clipboard Format</h4>
+                                        <p class="text-ink-muted mb-4">
+                                            The generated review follows a structured markdown format that's easy for AI agents to parse:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Example: Clipboard Output</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-600 dark:text-purple-400"># Code Review Comments</span>
+
+<span class="text-blue-600 dark:text-blue-400">## docs/docs.html</span>
+
+<span class="text-ink-muted">**Line 38** (added):</span>
+```
++    &lt;/script&gt;
+```
+<span class="text-green-600 dark:text-green-400">&gt; Is this really a script tag? It seems misplaced.</span>
+
+<span class="text-ink-muted">**Line 142** (added):</span>
+```
++    const user = await getUser();
+```
+<span class="text-green-600 dark:text-green-400">&gt; Consider adding error handling for the getUser() call.</span>
+
+<span class="text-blue-600 dark:text-blue-400">## src/utils/helper.ts</span>
+
+<span class="text-ink-muted">**Line 25** (removed):</span>
+```
+-    // TODO: Remove this hack
+```
+<span class="text-green-600 dark:text-green-400">&gt; Good cleanup! But make sure the hack was actually fixed, not just the comment removed.</span></code></pre>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/lanes-mcp.html
+++ b/docs/sections/lanes-mcp.html
@@ -1,0 +1,645 @@
+                        <section id="lanes-mcp" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Lanes MCP</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    The Lanes Model Context Protocol (MCP) server enables workflows to maintain state, track progress, and coordinate between agents across context windows. This technical explains how the MCP integration works under the hood.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- What is MCP? -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">What is MCP?</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The <strong class="text-ink">Model Context Protocol (MCP)</strong> is Anthropic's open protocol that enables AI assistants to securely connect to data sources and tools. It provides a standardized way to extend Claude with custom capabilities while maintaining security and control.
+                                        </p>
+                                        <p class="text-ink-muted mb-4">
+                                            The Lanes MCP server is a specialized MCP implementation that gives Claude fine-grained control over workflow execution:
+                                        </p>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Workflow State Management:</strong> Tracks current position in workflow, step outputs, and task progress</li>
+                                            <li><strong class="text-ink">Session Management:</strong> Allows Claude to request creation of new Lanes sessions programmatically</li>
+                                            <li><strong class="text-ink">Context Preservation:</strong> Maintains history across steps so agents can reference earlier work</li>
+                                        </ul>
+                                        <div class="mt-4 bg-accent-dim border border-accent/20 rounded-lg p-4">
+                                            <p class="text-sm text-accent">
+                                                <strong>Learn more:</strong> Visit <a href="https://modelcontextprotocol.io/" class="underline hover:text-blue-700 dark:hover:text-blue-400" target="_blank">modelcontextprotocol.io</a> for the official MCP specification.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Architecture -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Architecture</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            When you start a workflow session, Lanes automatically spins up an MCP server process that communicates with Claude via stdio:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-6 mb-4">
+                                            <pre class="text-sm font-mono text-ink-muted overflow-x-auto"><code>┌─────────────────────────────────────────────────────────┐
+│                    VS Code Extension                    │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Start Workflow Session                          │  │
+│  └──────────────────┬───────────────────────────────┘  │
+│                     │                                   │
+│                     ▼                                   │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Spawn MCP Server Process                        │  │
+│  │  node server.js --worktree <path> --workflow-path│  │
+│  └──────────────────┬───────────────────────────────┘  │
+│                     │                                   │
+│                     ▼                                   │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Generate .claude/mcp.json config                │  │
+│  └──────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+                      │
+                      ▼ stdio transport
+┌─────────────────────────────────────────────────────────┐
+│                   MCP Server Process                    │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Workflow State Machine                          │  │
+│  │  - Current step/sub-step                         │  │
+│  │  - Task iteration                                │  │
+│  │  - Step outputs history                          │  │
+│  └──────────────────────────────────────────────────┘  │
+│                     │                                   │
+│                     ▼                                   │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  Tool Handlers                                   │  │
+│  │  - workflow_start                                │  │
+│  │  - workflow_set_tasks                            │  │
+│  │  - workflow_status                               │  │
+│  │  - workflow_advance                              │  │
+│  │  - workflow_context                              │  │
+│  │  - session_create                                │  │
+│  │  - session_clear                                 │  │
+│  └──────────────────────────────────────────────────┘  │
+│                     │                                   │
+│                     ▼                                   │
+│  ┌──────────────────────────────────────────────────┐  │
+│  │  File System Persistence                         │  │
+│  │  - workflow-state.json (state)                   │  │
+│  └──────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
+                      │
+                      ▼ MCP protocol
+┌─────────────────────────────────────────────────────────┐
+│                    Claude Code                          │
+│                                                         │
+│  Calls MCP tools to navigate workflow steps             │
+└─────────────────────────────────────────────────────────┘</code></pre>
+                                        </div>
+                                        <p class="text-ink-muted">
+                                            The MCP server runs in the background for the lifetime of the session. Claude can call the MCP tools at any time to query or update workflow state.
+                                        </p>
+                                    </div>
+
+                                    <!-- MCP Tools -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">MCP Tools Reference</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The Lanes MCP server exposes six tools that Claude uses to control workflow execution:
+                                        </p>
+
+                                        <!-- Tool: workflow_start -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_start</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Initialize the workflow and return the first step instructions. If the workflow was previously started, returns the current status (enables resume).
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <div class="mb-2">
+                                                            <span class="text-blue-600 dark:text-blue-400">summary</span>
+                                                            <span class="text-gray-500">?: string</span>
+                                                            <span class="text-ink-muted ml-2">// Optional brief summary (max 10 words)</span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "status": "active",
+  "step": {
+    "id": "plan",
+    "type": "action",
+    "agent": "orchestrator",
+    "instructions": "Analyze the goal and break it into..."
+  },
+  "progress": {
+    "currentStepIndex": 0,
+    "totalSteps": 5,
+    "stepsCompleted": 0
+  },
+  "summary": "Add user authentication"
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-purple-600 dark:text-purple-400">workflow_start</span>(<span class="text-green-600 dark:text-green-400">"Add user authentication"</span>)
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: workflow_set_tasks -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_set_tasks</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Associate tasks with a loop step. Each task will be iterated through the loop's sub-steps.</code>.
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <div class="mb-2">
+                                                            <span class="text-blue-600 dark:text-blue-400">loop_id</span>
+                                                            <span class="text-gray-500">: string</span>
+                                                            <span class="text-ink-muted ml-2">// Loop step ID to associate tasks with</span>
+                                                        </div>
+                                                        <div>
+                                                            <span class="text-blue-600 dark:text-blue-400">tasks</span>
+                                                            <span class="text-gray-500">: Task[]</span>
+                                                            <span class="text-ink-muted ml-2">// Array of task objects</span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Task Object:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
+  "id": string,            // Unique identifier
+  "title": string,         // Human-readable title
+  "description"?: string   // Optional detailed description
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
+  "success": true,
+  "tasksSet": 3
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
+  {
+    <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"login-form"</span>,
+    <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Create login form"</span>,
+    <span class="text-blue-600 dark:text-blue-400">description</span>: <span class="text-green-600 dark:text-green-400">"Build login form with email and password"</span>
+  },
+  {
+    <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"auth-api"</span>,
+    <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Implement auth API"</span>,
+    <span class="text-blue-600 dark:text-blue-400">description</span>: <span class="text-green-600 dark:text-green-400">"Create API endpoint for authentication"</span>
+  }
+])</pre>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: workflow_status -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_status</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Get current workflow position with full context. Returns the current step, sub-step (if in a loop), agent, instructions, and progress.
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns (in loop):</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "status": "active",
+  "step": {
+    "id": "feature_development",
+    "type": "loop",
+    "subStep": {
+      "id": "implement",
+      "agent": "implementer",
+      "instructions": "Implement: Create login form..."
+    }
+  },
+  "task": {
+    "id": "login-form",
+    "title": "Create login form",
+    "index": 0,
+    "total": 2
+  },
+  "progress": {
+    "currentStepIndex": 2,
+    "totalSteps": 5,
+    "stepsCompleted": 1
+  }
+}</pre>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: workflow_advance -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_advance</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Complete the current step/sub-step and advance to the next. When a task completes (all sub-steps done), automatically updates <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> to mark the task as <code class="text-xs">passes: true</code>.
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <div>
+                                                            <span class="text-blue-600 dark:text-blue-400">output</span>
+                                                            <span class="text-gray-500">: string</span>
+                                                            <span class="text-ink-muted ml-2">// Summary of what was accomplished</span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "status": "active",
+  "step": {
+    "id": "feature_development",
+    "type": "loop",
+    "subStep": {
+      "id": "test",
+      "agent": "tester",
+      "instructions": "Run tests for: Create login form..."
+    }
+  },
+  "task": {
+    "id": "login-form",
+    "title": "Create login form",
+    "index": 0,
+    "total": 2
+  },
+  "progress": { ... }
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-purple-600 dark:text-purple-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Implemented login form with email and password fields"</span>)
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: workflow_context -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">workflow_context</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Get outputs from previous steps. Returns a record keyed by step path (e.g., <code class="text-xs">"plan"</code> or <code class="text-xs">"feature_development.login-form.implement"</code>).
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "plan": "Analyzed requirements. Identified 2 tasks: login-form, auth-api",
+  "define_tasks": "Created task list with 2 tasks",
+  "feature_development.login-form.implement": "Implemented login form with...",
+  "feature_development.login-form.test": "All tests passing",
+  "feature_development.login-form.review": "Code looks good, no issues"
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <p class="text-xs text-ink-muted mt-3">
+                                                    This enables agents to reference earlier work and build upon previous decisions.
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: session_create -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">session_create</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Request creation of a new Lanes session. Writes a config file to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.lanes/pending-sessions/</code> that the VS Code extension monitors and processes.
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <div class="mb-2">
+                                                            <span class="text-blue-600 dark:text-blue-400">name</span>
+                                                            <span class="text-gray-500">: string</span>
+                                                            <span class="text-ink-muted ml-2">// Session name (sanitized for git)</span>
+                                                        </div>
+                                                        <div class="mb-2">
+                                                            <span class="text-blue-600 dark:text-blue-400">sourceBranch</span>
+                                                            <span class="text-gray-500">: string</span>
+                                                            <span class="text-ink-muted ml-2">// Branch to create worktree from</span>
+                                                        </div>
+                                                        <div class="mb-2">
+                                                            <span class="text-blue-600 dark:text-blue-400">prompt</span>
+                                                            <span class="text-gray-500">?: string</span>
+                                                            <span class="text-ink-muted ml-2">// Optional starting prompt</span>
+                                                        </div>
+                                                        <div>
+                                                            <span class="text-blue-600 dark:text-blue-400">workflow</span>
+                                                            <span class="text-gray-500">?: string</span>
+                                                            <span class="text-ink-muted ml-2">// Workflow template (feature, bugfix, etc.)</span>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
+  "success": true,
+  "configPath": ".lanes/pending-sessions/fix-auth-bug-1736454321.json"
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div>
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">session_create</span>(
+  <span class="text-green-600 dark:text-green-400">"fix-auth-bug"</span>,
+  <span class="text-green-600 dark:text-green-400">"main"</span>,
+  <span class="text-green-600 dark:text-green-400">"Fix authentication timeout issue"</span>,
+  <span class="text-green-600 dark:text-green-400">"bugfix"</span>
+)</pre>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Tool: session_clear -->
+                                        <div class="mb-6">
+                                            <div class="bg-surface-2 rounded-lg p-5">
+                                                <h4 class="text-lg font-bold text-ink mb-3">
+                                                    <code class="text-base bg-surface-2 px-2 py-1 rounded font-mono text-ink-muted">session_clear</code>
+                                                </h4>
+                                                <p class="text-sm text-ink-muted mb-3">
+                                                    Clear the Claude session's context window. This gives the agent a fresh start while preserving the workflow state. Useful when transitioning between planning and implementation phases for large features.
+                                                </p>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Parameters:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+                                                        <span class="text-ink-muted">None</span>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Returns:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono">
+<pre class="text-ink-muted">{
+  "success": true,
+  "message": "Session context cleared"
+}</pre>
+                                                    </div>
+                                                </div>
+                                                <div class="mb-3">
+                                                    <p class="text-xs font-semibold text-ink-muted mb-2">Example Usage:</p>
+                                                    <div class="bg-surface-1 rounded-lg p-3 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-purple-600 dark:text-purple-400">session_clear</span>()</pre>
+                                                    </div>
+                                                </div>
+                                                <p class="text-xs text-ink-muted mt-3">
+                                                    <strong>Note:</strong> This is typically called automatically by Lanes when a workflow step has <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> set. You can also call it manually if needed.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Workflow State Persistence -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Workflow State Persistence</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The MCP server persists workflow state to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> in the worktree root after every state change. This enables:
+                                        </p>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4 mb-4">
+                                            <li><strong class="text-ink">Resume capability:</strong> If Claude crashes or loses context, calling <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow_start</code> again restores to the current position</li>
+                                            <li><strong class="text-ink">Context preservation:</strong> All step outputs are stored and accessible via <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow_context</code></li>
+                                            <li><strong class="text-ink">Progress tracking:</strong> Current step, task progress, and completion status are persisted</li>
+                                        </ul>
+                                        <div class="mb-4">
+                                            <p class="text-xs font-semibold text-ink-muted mb-2">Example workflow-state.json:</p>
+                                            <div class="bg-surface-2 rounded-lg p-4 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "status": "active",
+  "currentStepIndex": 2,
+  "currentSubStepIndex": 1,
+  "currentTaskIndex": 0,
+  "stepOutputs": {
+    "plan": "Analyzed requirements...",
+    "define_tasks": "Created task list...",
+    "feature_development.login-form.implement": "Implemented login form..."
+  },
+  "loopTasks": {
+    "feature_development": [
+      {
+        "id": "login-form",
+        "title": "Create login form",
+        "description": "Build login form with email and password",
+        "status": "in_progress"
+      },
+      {
+        "id": "auth-api",
+        "title": "Implement auth API",
+        "description": "Create API endpoint for authentication",
+        "status": "pending"
+      }
+    ]
+  },
+  "summary": "Add user authentication"
+}</pre>
+                                            </div>
+                                        </div>
+                                        <div class="bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-amber-600 dark:text-amber-400">
+                                                <strong>Important:</strong> The workflow state file is automatically managed by the MCP server. Do not manually edit this file.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Example Usage Flow -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Example Usage Flow</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Here's how Claude uses the MCP tools to execute a typical workflow:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-6">
+                                            <div class="space-y-4 text-sm font-mono">
+                                                <div>
+                                                    <div class="text-purple-600 dark:text-purple-400 mb-1">// 1. Start the workflow</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
+                                                        <span class="text-blue-600 dark:text-blue-400">workflow_start</span>(<span class="text-green-600 dark:text-green-400">"Add user authentication"</span>)
+                                                    </div>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Step 1: plan" with instructions</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="border-l-2 border-blue-500 pl-4">
+                                                    <div class="text-purple-600 dark:text-purple-400 mb-1">// 2. Claude reads code and plans the work</div>
+                                                    <div class="text-ink-muted mb-2">Analyzes codebase, identifies 2 tasks needed...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
+                                                        <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Analyzed requirements. Need 2 tasks: login form and auth API"</span>)
+                                                    </div>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Step 2: define_tasks" with instructions</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="border-l-2 border-green-500 pl-4">
+                                                    <div class="text-purple-600 dark:text-purple-400 mb-1">// 3. Define the task list</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2 overflow-x-auto">
+<pre class="text-ink-muted"><span class="text-ink-muted">Claude calls: </span><span class="text-blue-600 dark:text-blue-400">workflow_set_tasks</span>(<span class="text-green-600 dark:text-green-400">"feature_development"</span>, [
+  { <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"login-form"</span>, <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Create login form"</span>, ... },
+  { <span class="text-blue-600 dark:text-blue-400">id</span>: <span class="text-green-600 dark:text-green-400">"auth-api"</span>, <span class="text-blue-600 dark:text-blue-400">title</span>: <span class="text-green-600 dark:text-green-400">"Implement auth API"</span>, ... }
+])</pre>
+                                                    </div>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: implement login-form" with instructions</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="border-l-2 border-yellow-500 pl-4">
+                                                    <div class="text-purple-600 dark:text-purple-400 mb-1">// 4. Implement the first task</div>
+                                                    <div class="text-ink-muted mb-2">Claude writes the login form code...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
+                                                        <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"Implemented login form with email and password fields"</span>)
+                                                    </div>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: test login-form" with instructions</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="border-l-2 border-red-500 pl-4">
+                                                    <div class="text-purple-600 dark:text-purple-400 mb-1">// 5. Run tests</div>
+                                                    <div class="text-ink-muted mb-2">Claude runs test suite, fixes any failures...</div>
+                                                    <div class="bg-surface-1 rounded-lg p-3 mb-2">
+                                                        <span class="text-ink-muted">Claude calls: </span>
+                                                        <span class="text-blue-600 dark:text-blue-400">workflow_advance</span>(<span class="text-green-600 dark:text-green-400">"All tests pass"</span>)
+                                                    </div>
+                                                    <div class="bg-surface-1 rounded-lg p-3">
+                                                        <span class="text-ink-muted">Returns: </span>
+                                                        <span class="text-ink-muted">"Task 1/2: review login-form" with instructions</span>
+                                                    </div>
+                                                </div>
+
+                                                <div class="text-ink-muted text-center py-2">
+                                                    ... and so on through all tasks and steps ...
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- MCP Configuration -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">MCP Configuration</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            The Lanes MCP server is automatically configured when you create a workflow session. The VS Code extension:
+                                        </p>
+                                        <ol class="list-decimal list-inside text-ink-muted space-y-2 ml-4 mb-4">
+                                            <li>Spawns the MCP server process with the workflow path and worktree path</li>
+                                            <li>Generates a <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/mcp.json</code> config file in the worktree</li>
+                                            <li>Passes the config to Claude Code via the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">--mcp-config</code> flag</li>
+                                        </ol>
+                                        <div class="mb-4">
+                                            <p class="text-xs font-semibold text-ink-muted mb-2">Generated .claude/mcp.json:</p>
+                                            <div class="bg-surface-2 rounded-lg p-4 text-xs font-mono overflow-x-auto">
+<pre class="text-ink-muted">{
+  "mcpServers": {
+    "lanes-workflow": {
+      "command": "node",
+      "args": [
+        "/path/to/lanes/dist/mcp/server.js",
+        "--worktree", "/path/to/worktree",
+        "--workflow-path", "/path/to/workflow.yaml"
+      ]
+    }
+  }
+}</pre>
+                                            </div>
+                                        </div>
+                                        <p class="text-ink-muted">
+                                            The MCP server runs in the background for the lifetime of the session. It's automatically stopped when the session is closed.
+                                        </p>
+                                    </div>
+
+                                    <!-- Next Steps -->
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Next Steps</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Now that you understand the Lanes MCP server, you might want to:
+                                        </p>
+                                        <ul class="space-y-2 text-sm text-ink-muted">
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <span>Explore the MCP server source code in <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">src/mcp/</code></span>
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="#workflow-templates" class="text-accent hover:underline">Review the Workflow Templates documentation</a> to understand how workflows are structured
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="https://modelcontextprotocol.io/" class="text-accent hover:underline" target="_blank">Read the MCP specification</a> to understand the protocol
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <span>Try creating a workflow session and observe the MCP tools in action</span>
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/local-settings.html
+++ b/docs/sections/local-settings.html
@@ -1,0 +1,71 @@
+                        <section id="local-settings" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Local Settings Propagation</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Lanes can automatically propagate your <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/settings.local.json</code> file from your base repository to each worktree. This ensures your local Claude Code configuration is available in all sessions.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- Configuration -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Configuration</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Add to your VS Code settings:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-4">
+                                            <span class="text-blue-600 dark:text-blue-400">"lanes.localSettingsPropagation"</span>: <span class="text-green-600 dark:text-green-400">"copy"</span>
+                                        </div>
+                                        <div class="space-y-2 text-sm">
+                                            <div class="flex gap-2">
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">copy</code>
+                                                <span class="text-ink-muted">Default — copies the settings file to each worktree. Works on all platforms.</span>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">symlink</code>
+                                                <span class="text-ink-muted">Creates a symbolic link. More efficient but may require developer mode on Windows.</span>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">disabled</code>
+                                                <span class="text-ink-muted">Does not propagate settings to worktrees.</span>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- How It Works -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">How It Works</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            When you create a new session (worktree), Lanes checks if <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">.claude/settings.local.json</code> exists in your base repository. If it does and propagation is enabled, the file is copied or symlinked to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">&lt;worktree&gt;/.claude/settings.local.json</code>.
+                                        </p>
+                                    </div>
+
+                                    <!-- Use Cases -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Common Use Cases</h3>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Environment Variables</h4>
+                                                <p class="text-xs text-ink-muted">Set custom <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">ANTHROPIC_DEFAULT_HAIKU_MODEL</code> for all sessions.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Model Settings</h4>
+                                                <p class="text-xs text-ink-muted">Configure default models or permission modes across all worktrees.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">Custom Hooks</h4>
+                                                <p class="text-xs text-ink-muted">Define hooks that apply to all sessions automatically.</p>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-1 text-sm">API Keys</h4>
+                                                <p class="text-xs text-ink-muted">Propagate API key configurations so agents in every worktree can access required services.</p>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/multi-agent.html
+++ b/docs/sections/multi-agent.html
@@ -1,0 +1,98 @@
+                        <section id="multi-agent" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Multi-Agent Support</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Lanes supports multiple AI coding agents. Choose the best agent for each task, or mix agents across sessions.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- Supported Agents -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Supported Agents</h3>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Claude Code</h4>
+                                                <p class="text-sm text-ink-muted mb-2">Anthropic's coding agent with deep code understanding and multi-file editing capabilities.</p>
+                                                <ul class="text-xs text-ink-faint space-y-1">
+                                                    <li>&#x2022; Status tracking via hooks</li>
+                                                    <li>&#x2022; Permission modes (default, acceptEdits, bypassPermissions)</li>
+                                                    <li>&#x2022; MCP workflow support built-in</li>
+                                                    <li>&#x2022; Session resume with <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">--resume</code></li>
+                                                </ul>
+                                            </div>
+                                            <div class="bg-surface-1 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2">Codex CLI</h4>
+                                                <p class="text-sm text-ink-muted mb-2">OpenAI's command-line coding agent for code generation and editing tasks.</p>
+                                                <ul class="text-xs text-ink-faint space-y-1">
+                                                    <li>&#x2022; Status tracking via polling</li>
+                                                    <li>&#x2022; TOML-based configuration</li>
+                                                    <li>&#x2022; MCP workflow support via config overrides</li>
+                                                    <li>&#x2022; Hookless session ID capture</li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- How to Select -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Selecting an Agent</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            In the session creation form, click the agent logo at the top to cycle between available agents. The selected agent's logo is displayed inline, and the form adjusts available options accordingly.
+                                        </p>
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4">
+                                            <p class="text-sm text-accent">
+                                                <strong>Default agent:</strong> Set <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">lanes.defaultAgent</code> in VS Code settings to <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">"claude-code"</code> or <code class="bg-surface-2 px-1.5 py-0.5 rounded font-mono">"codex"</code> to pre-select your preferred agent.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Differences Between Agents -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Differences Between Agents</h3>
+                                        <div class="overflow-x-auto">
+                                            <table class="w-full text-sm">
+                                                <thead>
+                                                    <tr class="border-b border-border">
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Feature</th>
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Claude Code</th>
+                                                        <th class="text-left py-2 px-3 font-bold text-ink">Codex CLI</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody class="text-ink-muted">
+                                                    <tr class="border-b border-border">
+                                                        <td class="py-2 px-3">Status tracking</td>
+                                                        <td class="py-2 px-3">Hook-based (real-time)</td>
+                                                        <td class="py-2 px-3">Polling-based</td>
+                                                    </tr>
+                                                    <tr class="border-b border-border">
+                                                        <td class="py-2 px-3">Session ID capture</td>
+                                                        <td class="py-2 px-3">Via hooks</td>
+                                                        <td class="py-2 px-3">Via polling</td>
+                                                    </tr>
+                                                    <tr class="border-b border-border">
+                                                        <td class="py-2 px-3">Configuration format</td>
+                                                        <td class="py-2 px-3">JSON</td>
+                                                        <td class="py-2 px-3">TOML</td>
+                                                    </tr>
+                                                    <tr class="border-b border-border">
+                                                        <td class="py-2 px-3">MCP workflows</td>
+                                                        <td class="py-2 px-3">Native support</td>
+                                                        <td class="py-2 px-3">Via config overrides</td>
+                                                    </tr>
+                                                    <tr>
+                                                        <td class="py-2 px-3">Permission modes</td>
+                                                        <td class="py-2 px-3">Full support</td>
+                                                        <td class="py-2 px-3">Agent-specific modes</td>
+                                                    </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/permission-modes.html
+++ b/docs/sections/permission-modes.html
@@ -1,0 +1,82 @@
+                        <section id="permission-modes" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Permission Modes</h2>
+                                </div>
+
+                                <div class="mb-8">
+                                    <p class="text-ink-muted mb-4">
+                                        Permission modes control how Claude Code interacts with your files and executes commands. Each mode offers a different balance between automation and control, allowing you to choose the level of oversight that matches your workflow and security requirements.
+                                    </p>
+                                    <p class="text-ink-muted">
+                                        When creating a new session, you can select the permission mode from the dropdown in the session form. The mode you choose will apply to Claude's entire session in that worktree.
+                                    </p>
+                                </div>
+
+                                <!-- Quick Comparison Table -->
+                                <div class="mb-8 overflow-x-auto">
+                                    <h3 class="text-xl font-bold text-ink mb-4">Quick Comparison</h3>
+                                    <table class="w-full text-sm border-collapse">
+                                        <thead>
+                                            <tr class="bg-surface-2">
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Mode</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">File Edits</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Commands</th>
+                                                <th class="text-left p-3 font-semibold text-ink border-b border-border">Best For</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody class="text-ink-muted">
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">default</td>
+                                                <td class="p-3">Ask first</td>
+                                                <td class="p-3">Ask first unless allowed by an allow rule</td>
+                                                <td class="p-3">Standard interactive workflow</td>
+                                            </tr>
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">acceptEdits</td>
+                                                <td class="p-3">Auto-approve</td>
+                                                <td class="p-3">Ask first unless allowed by an allow rule</td>
+                                                <td class="p-3">Fast coding, careful with commands</td>
+                                            </tr>
+                                            <tr class="border-b border-border">
+                                                <td class="p-3 font-medium text-ink">dontAsk</td>
+                                                <td class="p-3">Auto-approve</td>
+                                                <td class="p-3">Auto-deny unless allowed by an allow rule</td>
+                                                <td class="p-3">Auto-deny tools unless explicitly allowed by an allow rule</td>
+                                            </tr>
+                                            <tr>
+                                                <td class="p-3 font-medium text-red-600 dark:text-red-400">bypassPermissions</td>
+                                                <td class="p-3">Auto-approve</td>
+                                                <td class="p-3">Auto-approve</td>
+                                                <td class="p-3">Testing/debugging only</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+
+                                <!-- How to Select -->
+                                <div class="mt-8 bg-surface-2 rounded-lg p-6">
+                                    <h3 class="text-xl font-bold text-ink mb-4">How to Select a Permission Mode</h3>
+                                    <div class="space-y-4">
+                                        <div>
+                                            <h4 class="font-semibold text-ink mb-2">When Creating a Session</h4>
+                                            <ol class="list-decimal list-inside text-ink-muted space-y-2 ml-4">
+                                                <li>Open the Lanes sidebar in VS Code</li>
+                                                <li>Fill out the session form with your session name and prompt</li>
+                                                <li>Select your desired permission mode from the "Permission Mode" dropdown</li>
+                                                <li>Click "Create Session"</li>
+                                            </ol>
+                                        </div>
+                                        <div>
+                                            <p class="text-sm text-ink-muted">
+                                                The permission mode is set when the session is created and applies to Claude's entire session in that worktree. Choose carefully based on your task and trust level.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+
+                            </div>
+                        </section>

--- a/docs/sections/tmux-terminal.html
+++ b/docs/sections/tmux-terminal.html
@@ -1,0 +1,66 @@
+                        <section id="tmux-terminal" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Tmux Terminal</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Lanes can use tmux as an alternative terminal backend instead of VS Code's built-in terminals. Tmux sessions persist independently of VS Code, making them more resilient to window reloads and crashes.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- Benefits -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Benefits</h3>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4">
+                                            <li><strong class="text-ink">Persistence:</strong> Sessions survive VS Code restarts and window reloads</li>
+                                            <li><strong class="text-ink">Resilience:</strong> Agent continues running even if VS Code crashes</li>
+                                            <li><strong class="text-ink">Scrollback:</strong> Full terminal history preserved in tmux</li>
+                                        </ul>
+                                    </div>
+
+                                    <!-- Configuration -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Configuration</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Set the terminal mode in VS Code settings:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-3">
+                                            <span class="text-blue-600 dark:text-blue-400">"lanes.terminalMode"</span>: <span class="text-green-600 dark:text-green-400">"tmux"</span>
+                                        </div>
+                                        <div class="space-y-2 text-sm">
+                                            <div class="flex gap-2">
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">vscode</code>
+                                                <span class="text-ink-muted">Default — uses VS Code's built-in terminal</span>
+                                            </div>
+                                            <div class="flex gap-2">
+                                                <code class="bg-surface-2 px-2 py-0.5 rounded text-xs font-mono text-ink-muted flex-shrink-0">tmux</code>
+                                                <span class="text-ink-muted">Uses tmux for persistent terminal sessions</span>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Prerequisites -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Prerequisites</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            Tmux must be installed on your system:
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted">
+                                            <span class="text-green-600 dark:text-green-400">$</span> brew install tmux <span class="text-gray-500"># macOS</span><br>
+                                            <span class="text-green-600 dark:text-green-400">$</span> sudo apt-get install tmux <span class="text-gray-500"># Ubuntu/Debian</span>
+                                        </div>
+                                    </div>
+
+                                    <!-- Per-Session Mode -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Per-Session Persistence</h3>
+                                        <p class="text-ink-muted mb-3">
+                                            The terminal mode is stored per session, so each session remembers whether it was created with VS Code or tmux terminals. Changing the global setting only affects new sessions.
+                                        </p>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/workflow-structure.html
+++ b/docs/sections/workflow-structure.html
@@ -1,0 +1,350 @@
+                        <section id="workflow-structure" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Workflow Structure</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    This section covers the YAML structure of workflow templates, including how to define agents, create loops, and configure steps.
+                                </p>
+
+                                <div class="space-y-10">
+                                    <!-- YAML Structure Overview -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">YAML Structure Overview</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Workflow templates are YAML files. Simple workflows only need <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">name</code>, <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">description</code>, and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">steps</code>. The <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">agents</code> and <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">loops</code> sections are optional for more complex workflows:
+                                        </p>
+
+                                        <div class="space-y-4">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">name</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> Yes<br>
+                                                    <strong>Purpose:</strong> Identifies the workflow. Must be unique within your project.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">description</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> Yes<br>
+                                                    <strong>Purpose:</strong> Human-readable description shown in the workflow selector.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">agents</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> object<br>
+                                                    <strong>Required:</strong> No (optional)<br>
+                                                    <strong>Purpose:</strong> Defines specialized agents with tool permissions and restrictions. Only needed for complex workflows requiring sub-agents.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">loops</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> object<br>
+                                                    <strong>Required:</strong> No (optional)<br>
+                                                    <strong>Purpose:</strong> Reusable sub-workflows that iterate over tasks. Only needed for workflows that process multiple items.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 font-mono text-sm">steps</h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> array<br>
+                                                    <strong>Required:</strong> Yes (must have at least one step)<br>
+                                                    <strong>Purpose:</strong> The main workflow sequence, executed in order.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Agents Definition -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Agents Definition</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Agents are specialized roles that execute workflow steps. Each agent has specific capabilities and restrictions.
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Agent Configuration</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">agents:</span>
+  <span class="text-blue-400">orchestrator:</span>
+    <span class="text-green-400">description:</span> Plans work and coordinates sub-agents
+
+  <span class="text-blue-400">implementer:</span>
+    <span class="text-green-400">description:</span> Writes code to implement features
+    </code></pre>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- Steps -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Steps (Main Workflow Sequence)</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Steps define the main workflow sequence. They are executed in order from top to bottom.
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Main Steps</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">steps:</span>
+  - <span class="text-green-400">id:</span> plan
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> orchestrator
+    <span class="text-green-400">instructions:</span> |
+      Analyze the goal and break it into discrete tasks.
+
+      Consider:
+      1. What are the individual features or changes needed?
+      2. What are the dependencies between tasks?
+      3. What is the optimal order of implementation?
+
+  - <span class="text-green-400">id:</span> define_tasks
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> orchestrator
+    <span class="text-green-400">instructions:</span> |
+      Call workflow_set_tasks('feature_development', tasks) with:
+      - id: unique identifier
+      - title: concise title
+      - description: detailed description
+
+  - <span class="text-green-400">id:</span> feature_development
+    <span class="text-green-400">type:</span> loop
+    <span class="text-gray-500"># References the loop defined above</span>
+
+  - <span class="text-green-400">id:</span> final_review
+    <span class="text-green-400">type:</span> action
+    <span class="text-green-400">agent:</span> reviewer
+    <span class="text-green-400">instructions:</span> |
+      Review the implementation as a whole...</code></pre>
+                                        </div>
+
+                                        <h4 class="text-lg font-semibold text-ink mb-3">Step Fields</h4>
+                                        <div class="space-y-3">
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">id</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> Yes<br>
+                                                    Unique identifier for this step. For loop steps, must match a loop name.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">type</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> Yes<br>
+                                                    <strong>Valid values:</strong> action, loop, ralph
+
+                                        <div class="grid md:grid-cols-3 gap-4 mb-4">
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">action</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    A single operation performed by an agent. Used for planning, reviewing, or any one-off task.
+                                                </p>
+                                                <p class="text-xs text-ink-faint">
+                                                    <strong>Required fields:</strong> id, type, instructions<br>
+                                                    <strong>Optional fields:</strong> agent
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">loop</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    Iterates over a list of tasks, executing the loop's sub-steps for each task.
+                                                </p>
+                                                <p class="text-xs text-ink-faint">
+                                                    <strong>Required fields:</strong> id, type<br>
+                                                    <strong>Note:</strong> The id must match a loop name defined in the <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">loops:</code> section
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-accent p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">ralph</h5>
+                                                <p class="text-sm text-ink-muted mb-2">
+                                                    Repeats the same task n times for iterative refinement. Claude works on the task multiple times to improve quality.
+                                                </p>
+                                                <p class="text-xs text-ink-faint">
+                                                    <strong>Required fields:</strong> id, type, instructions, n<br>
+                                                    <strong>Optional fields:</strong> agent
+                                                </p>
+                                            </div>
+                                        </div>
+
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">agent</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> No (for action steps)<br>
+                                                    <strong>Not applicable:</strong> For loop steps (agents are specified in loop sub-steps)<br>
+                                                    Name of the agent to execute this step. When omitted, the main Claude agent handles that step directly instead of delegating to a specialized sub-agent.
+                                                This is useful for simpler workflows or steps that don't require specialized capabilities.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-2 rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">instructions</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> Yes (for action and ralph steps)<br>
+                                                    <strong>Not applicable:</strong> For loop steps (instructions are in loop sub-steps)<br>
+                                                    Instructions for what to do in this step.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-accent p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">n</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> integer<br>
+                                                    <strong>Required:</strong> Yes (for ralph steps only)<br>
+                                                    <strong>Valid values:</strong> Positive integer (1 or greater)<br>
+                                                    Number of times to repeat the step. Each iteration stores its output with a unique key (e.g., <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">step-id.1</code>, <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">step-id.2</code>).
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-violet-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">on_fail</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> No<br>
+                                                    <strong>Valid values:</strong> retry, skip, abort<br>
+                                                    <strong>Default:</strong> abort<br>
+                                                    Action to take if this step fails.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-emerald-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">context</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> string<br>
+                                                    <strong>Required:</strong> No<br>
+                                                    <strong>Valid values:</strong> clear<br>
+                                                    <strong>Default:</strong> (no change)<br>
+                                                    When set to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">clear</code>, Lanes will clear the Claude session context when this step begins. This gives the orchestrator a fresh context window for larger development loops. Use this only if you are confident your workflow saves plans in artefacts that can be reloaded.
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border-l-4 border-amber-500 p-4">
+                                                <h5 class="font-bold text-ink mb-1 font-mono text-sm">artefacts</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    <strong>Type:</strong> boolean<br>
+                                                    <strong>Required:</strong> No<br>
+                                                    <strong>Valid values:</strong> true, false<br>
+                                                    <strong>Default:</strong> false<br>
+                                                    When set to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">true</code>, Lanes introduces a hook that tracks all files created during this step. Downstream steps are made aware of these artefacts and can read them to gain context. This is especially useful when combined with <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">context: clear</code> to preserve important work across context resets.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Loops and Sub-steps -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Loops and Sub-steps</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Loops are reusable sub-workflows that execute a sequence of steps for each task in a list.
+                                            They enable structured iteration over features, fixes, or refactors.
+                                        </p>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden mb-4">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Loop Definition</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-purple-400">loops:</span>
+  <span class="text-blue-400">feature_development:</span>
+    - <span class="text-green-400">id:</span> implement
+      <span class="text-green-400">agent:</span> implementer
+      <span class="text-green-400">instructions:</span> |
+        Implement: {task.title}
+
+        1. Read relevant files to understand context
+        2. Plan the implementation approach
+        3. Write the code
+        4. Verify it compiles
+
+    - <span class="text-green-400">id:</span> test
+      <span class="text-green-400">agent:</span> tester
+      <span class="text-green-400">instructions:</span> |
+        Run tests for: {task.title}
+
+        1. Run the existing test suite
+        2. Identify any failing tests
+        3. Fix any test failures
+        4. Ensure all tests pass
+      <span class="text-green-400">on_fail:</span> retry
+
+    - <span class="text-green-400">id:</span> review
+      <span class="text-green-400">agent:</span> reviewer
+      <span class="text-green-400">instructions:</span> |
+        Review implementation of: {task.title}
+
+        Check for:
+        1. Security vulnerabilities
+        2. Proper error handling
+        3. Code quality and patterns
+
+    - <span class="text-green-400">id:</span> resolution
+      <span class="text-green-400">instructions:</span> |
+        <span class="text-gray-500"># No agent specified - main Claude handles this</span>
+        Address any issues from the review of: {task.title}</code></pre>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- Task Variables -->
+                                    <div>
+                                        <h3 class="text-2xl font-bold text-ink mb-4">Task Variables</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Within loop sub-step instructions, you can reference task properties using curly brace syntax:
+                                        </p>
+
+                                        <div class="grid md:grid-cols-3 gap-4 mb-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">{task.id}</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    The unique identifier for the current task (e.g., "add-login-form").
+                                                </p>
+                                            </div>
+
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h5 class="font-bold text-ink mb-2 font-mono text-sm">{task.title}</h5>
+                                                <p class="text-sm text-ink-muted">
+                                                    The concise title of the current task (e.g., "Login form UI").
+                                                </p>
+                                            </div>
+
+                                        </div>
+
+                                        <div class="bg-surface-2 rounded-lg overflow-hidden">
+                                            <div class="flex items-center gap-2 px-4 py-2 border-b border-border bg-surface-2">
+                                                <span class="text-xs text-ink-faint font-mono">Example: Using Task Variables</span>
+                                            </div>
+                                            <pre class="p-4 text-sm font-mono text-ink-muted overflow-x-auto"><code><span class="text-green-400">instructions:</span> |
+  Implement: {task.title}
+
+  Task ID for reference: {task.id}
+
+  1. Read relevant files
+  2. Implement the feature
+  3. Verify it works</code></pre>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/workflows-intro.html
+++ b/docs/sections/workflows-intro.html
@@ -1,0 +1,339 @@
+                        <section id="workflows-intro" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Introduction to Workflows</h2>
+                                </div>
+
+                                <p class="text-ink-muted mb-8 text-lg">
+                                    Workflows are structured development processes that guide Claude through proven phases like planning, implementation, testing, and review. Built on research from <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline">Anthropic's long-running agent harnesses</a>, they bring consistency and quality to complex development tasks.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- What are Workflows? -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-4">What are Workflows?</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            A workflow is like a development playbook that Claude follows step-by-step. Each workflow defines:
+                                        </p>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path>
+                                                    </svg>
+                                                    Phases
+                                                </h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    The sequence of steps (plan, implement, test, review) that ensure thorough development
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                                                    </svg>
+                                                    Specialized Agents
+                                                </h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    Different "roles" for Claude with specific tools and restrictions (orchestrator, implementer, tester, reviewer)
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
+                                                    </svg>
+                                                    Repeatable Loops
+                                                </h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    Patterns that repeat for each task (implement → test → review → resolve)
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <h4 class="font-bold text-ink mb-2 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                    </svg>
+                                                    Progress Tracking
+                                                </h4>
+                                                <p class="text-sm text-ink-muted">
+                                                    Automatic state persistence so Claude can resume work across context windows
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- Why Use Workflows? -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-4">Why Use Workflows?</h3>
+                                        <div class="space-y-4">
+                                            <div class="flex items-start gap-3">
+                                                <div class="w-8 h-8 bg-accent/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                    <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+                                                    </svg>
+                                                </div>
+                                                <div>
+                                                    <h4 class="font-bold text-ink mb-1">Consistent Structure</h4>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Every task follows the same proven pattern: plan before coding, test after implementation, review before completion. This prevents common mistakes like coding without a plan or skipping tests.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div class="flex items-start gap-3">
+                                                <div class="w-8 h-8 bg-violet-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                    <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                                                    </svg>
+                                                </div>
+                                                <div>
+                                                    <h4 class="font-bold text-ink mb-1">Higher Quality</h4>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Specialized agents bring focused expertise to each phase. The reviewer agent only reads code (can't edit), ensuring objective feedback. The tester focuses solely on test quality.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div class="flex items-start gap-3">
+                                                <div class="w-8 h-8 bg-emerald-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                    <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                                                    </svg>
+                                                </div>
+                                                <div>
+                                                    <h4 class="font-bold text-ink mb-1">Built-in Checkpoints</h4>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Workflows prevent Claude from jumping ahead or getting sidetracked. Each phase must complete before moving to the next, ensuring nothing is skipped.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                            <div class="flex items-start gap-3">
+                                                <div class="w-8 h-8 bg-amber-500/10 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5">
+                                                    <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                    </svg>
+                                                </div>
+                                                <div>
+                                                    <h4 class="font-bold text-ink mb-1">Seamless Context Continuity</h4>
+                                                    <p class="text-sm text-ink-muted">
+                                                        Workflow state is saved to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> after each step. If Claude runs out of context or the session ends, you can resume exactly where you left off.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                                                        <!-- Built-in Workflow Types -->
+                                                                        <div>
+                                                                            <h3 class="text-xl font-bold text-ink mb-4">Built-in Workflow Types</h3>
+                                                                            <p class="text-ink-muted mb-4">
+                                                                                Lanes includes four workflow templates out of the box. Each is optimized for a specific type of development work:
+                                                                            </p>
+                                                                            <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-accent/10 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-blue-600 dark:text-blue-400 font-bold text-sm">FT</span>
+                                                                                    </div>
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Feature Dev</h4>
+                                                                                    <p class="text-xs text-ink-muted">
+                                                                                        New features with tests and review.
+                                                                                    </p>
+                                                                                </div>
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-red-500/10 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-red-600 dark:text-red-400 font-bold text-sm">BF</span>
+                                                                                    </div>
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Bug Fix</h4>
+                                                                                    <p class="text-xs text-ink-muted">
+                                                                                        Investigate and fix bugs safely.
+                                                                                    </p>
+                                                                                </div>
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-violet-500/10 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-purple-600 dark:text-purple-400 font-bold text-sm">RF</span>
+                                                                                    </div>
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Refactor</h4>
+                                                                                    <p class="text-xs text-ink-muted">
+                                                                                        Improve code quality safely.
+                                                                                    </p>
+                                                                                </div>
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-surface-2 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-ink-muted font-bold text-sm">DF</span>
+                                                                                    </div>
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Default</h4>
+                                                                                    <p class="text-xs text-ink-muted">
+                                                                                        General-purpose tasks.
+                                                                                    </p>
+                                                                                </div>
+                                                                                <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                                                    <div class="w-10 h-10 bg-emerald-500/10 rounded-lg flex items-center justify-center mb-3">
+                                                                                        <span class="text-green-600 dark:text-green-400 font-bold text-sm">CW</span>
+                                                                                    </div>
+                                                                                    <h4 class="font-bold text-ink mb-2 text-sm">Custom</h4>
+                                                                                    <p class="text-xs text-ink-muted">
+                                                                                        Your own workflows.
+                                                                                    </p>
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+
+
+                                    <!-- Starting a Workflow -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-4">How to Start a Workflow Session</h3>
+                                        <div class="bg-surface-1 rounded-lg p-6 border border-border">
+                                            <div class="space-y-4">
+                                                <div class="flex items-start gap-3">
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">1</div>
+                                                    <div>
+                                                        <p class="text-ink-muted">
+                                                            <strong>Click "New Session"</strong> in the Lanes sidebar
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                                <div class="flex items-start gap-3">
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">3</div>
+                                                    <div>
+                                                        <p class="text-ink-muted">
+                                                            <strong>Enter a branch name</strong> (e.g., "feat-user-auth" or "fix-login-bug")
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                                <div class="flex items-start gap-3">
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">4</div>
+                                                    <div>
+                                                        <p class="text-ink-muted">
+                                                            <strong>Describe your goal</strong> to Claude (e.g., "Add user authentication with email and password")
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                                <div class="flex items-start gap-3">
+                                                    <div class="flex-shrink-0 w-6 h-6 bg-accent text-white rounded-full flex items-center justify-center font-bold text-xs">2</div>
+                                                    <div>
+                                                        <p class="text-ink-muted">
+                                                            <strong>Choose a workflow type</strong> from the dropdown (If you have not created a custom workflow you will need to. You can learn how in the Creating Workflows section.)
+                                                        </p>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="mt-4 pt-4 border-t border-border">
+                                                <p class="text-sm text-ink-muted">
+                                                    Claude will automatically follow the workflow phases, creating a <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono text-ink-muted">workflow-state.json</code> file to track progress and saving workflow state after each step.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- When to Use Workflows -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-4">When to Use Workflows vs. Ad-Hoc Sessions</h3>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-5">
+                                                <h4 class="font-bold text-ink mb-3 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                    </svg>
+                                                    Use Workflows For:
+                                                </h4>
+                                                <ul class="space-y-2 text-sm text-ink-muted">
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>New features with multiple components</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>Complex bug fixes requiring investigation</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>Large refactors touching multiple files</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>Work that needs thorough testing and review</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>Tasks that may span multiple sessions</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-green-600 dark:text-green-400 mt-0.5">•</span>
+                                                        <span>Team projects needing consistent process</span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-5">
+                                                <h4 class="font-bold text-ink mb-3 flex items-center gap-2">
+                                                    <svg class="w-5 h-5 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
+                                                    </svg>
+                                                    Use Ad-Hoc Sessions For:
+                                                </h4>
+                                                <ul class="space-y-2 text-sm text-ink-muted">
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>Quick fixes (typos, small tweaks)</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>Exploratory coding or prototyping</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>One-off scripts or utilities</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>Documentation updates</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>Code review or analysis (no changes)</span>
+                                                    </li>
+                                                    <li class="flex items-start gap-2">
+                                                        <span class="text-blue-600 dark:text-blue-400 mt-0.5">•</span>
+                                                        <span>When you want full manual control</span>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        </div>
+                                        <div class="mt-4 bg-amber-500/10 border border-amber-500/20 rounded-lg p-4">
+                                            <p class="text-sm text-ink-muted">
+                                                <strong class="text-amber-600 dark:text-amber-400">Tip:</strong> Start with a workflow for quality work. You can always switch to ad-hoc if the structure feels unnecessary. Workflows add minimal overhead but provide significant benefits for anything beyond trivial changes.
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <!-- Next Steps -->
+                                    <div class="bg-surface-1 border border-border rounded-xl p-6">
+                                        <h3 class="text-xl font-bold text-ink mb-3">Want to Learn More?</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            This introduction covered the basics of workflows. For deeper understanding:
+                                        </p>
+                                        <ul class="space-y-2 text-sm text-ink-muted">
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="#workflow-templates" class="text-accent hover:underline">Workflow Templates</a> - Learn YAML syntax and create custom workflows
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="#lanes-mcp" class="text-accent hover:underline">Lanes MCP</a> - Understand how workflows use Model Context Protocol
+                                            </li>
+                                            <li class="flex items-center gap-2">
+                                                <svg class="w-4 h-4 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                                                </svg>
+                                                <a href="https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents" class="text-accent hover:underline" target="_blank">Anthropic's Research Paper</a> - The science behind workflow harnesses
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </section>

--- a/docs/sections/worktrees.html
+++ b/docs/sections/worktrees.html
@@ -1,0 +1,137 @@
+                        <section id="worktrees" class="doc-section mb-16 scroll-mt-24 hidden">
+                            <div class="bg-surface-0 rounded-xl border border-border p-6 sm:p-8">
+                                <div class="flex items-center gap-4 mb-6">
+                                    <div class="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center">
+                                        <svg class="w-6 h-6 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path></svg>
+                                    </div>
+                                    <h2 class="text-3xl font-bold text-ink">Understanding Worktrees</h2>
+                                </div>
+                                <p class="text-ink-muted mb-6">
+                                    Git worktrees are the foundation of Lanes' isolation strategy. They allow you to have multiple working directories attached to the same repository, enabling you to work on multiple tasks simultaneously without conflicts.
+                                </p>
+
+                                <div class="space-y-8">
+                                    <!-- What are Git Worktrees? -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">What are Git Worktrees?</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            Imagine you're working on a feature in your project, but suddenly need to fix a critical bug. Normally, you'd have to:
+                                        </p>
+                                        <ul class="list-disc list-inside text-ink-muted space-y-2 ml-4 mb-4">
+                                            <li>Stash or commit your incomplete work</li>
+                                            <li>Switch branches</li>
+                                            <li>Fix the bug</li>
+                                            <li>Switch back</li>
+                                            <li>Restore your work-in-progress</li>
+                                        </ul>
+                                        <p class="text-ink-muted mb-4">
+                                            <strong class="text-ink">Git worktrees solve this problem.</strong> They let you check out multiple branches simultaneously, each in its own separate directory. Think of it as having multiple copies of your project, each on a different branch, but all sharing the same Git database.
+                                        </p>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted mb-4">
+                                            <span class="text-ink-faint"># Your repository structure with Lanes</span><br>
+                                            my-project/<br>
+                                            ├── .git/                <span class="text-ink-faint"># Shared git database (history, commits, refs)</span><br>
+                                            ├── src/                 <span class="text-ink-faint"># Your main working directory</span><br>
+                                            ├── package.json<br>
+                                            └── .worktrees/          <span class="text-ink-faint"># Lanes stores worktrees here</span><br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;├── fix-login-bug/   <span class="text-ink-faint"># Claude working on bug fix</span><br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;├── src/<br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;│&nbsp;&nbsp;&nbsp;└── package.json<br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;└── add-dark-mode/   <span class="text-ink-faint"># Claude working on new feature</span><br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;├── src/<br>
+                                            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;└── package.json
+                                        </div>
+                                        <div class="bg-accent-dim border border-accent/20 rounded-lg p-4">
+                                            <div class="flex gap-2">
+                                                <svg class="w-5 h-5 text-accent flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                <div>
+                                                    <p class="text-sm text-accent font-medium">Key Insight</p>
+                                                    <p class="text-sm text-accent mt-1">
+                                                        Each worktree is a complete working directory with its own files, but they all share the same <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.git</code> database. This means commits made in one worktree are immediately visible in all others, but the working files remain isolated.
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <!-- How Lanes Uses Worktrees -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">How Lanes Uses Worktrees</h3>
+                                        <p class="text-ink-muted mb-4">
+                                            When you create a new Lanes session, here's what happens under the hood:
+                                        </p>
+                                        <div class="space-y-3 mb-4">
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">1</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Creates a new branch</p>
+                                                    <p class="text-sm text-ink-muted">Named after your session (e.g., <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">fix-login-bug</code>), branched from your source branch</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">2</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Creates a worktree directory</p>
+                                                    <p class="text-sm text-ink-muted">Located at <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">.worktrees/fix-login-bug/</code> with a full checkout of your project</p>
+                                                </div>
+                                            </div>
+                                            <div class="flex gap-3 items-start">
+                                                <div class="w-8 h-8 bg-accent text-white rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 mt-0.5">3</div>
+                                                <div>
+                                                    <p class="text-ink font-medium">Launches Claude Code</p>
+                                                    <p class="text-sm text-ink-muted">Claude works exclusively in the worktree directory, completely isolated from your main workspace</p>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="bg-surface-2 rounded-lg p-4 font-mono text-sm text-ink-muted">
+                                            <span class="text-ink-faint"># Git command that Lanes runs (simplified):</span><br>
+                                            git worktree add .worktrees/fix-login-bug -b fix-login-bug
+                                        </div>
+                                    </div>
+
+                                    <!-- Benefits of Isolation -->
+                                    <div>
+                                        <h3 class="text-xl font-bold text-ink mb-3">Benefits of Complete Isolation</h3>
+                                        <div class="grid md:grid-cols-2 gap-4">
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <svg class="w-5 h-5 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                    <h4 class="font-bold text-ink">No File Conflicts</h4>
+                                                </div>
+                                                <p class="text-sm text-ink-muted">
+                                                    Changes in one session never affect files in another. You can run multiple Claude sessions simultaneously without any interference.
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <svg class="w-5 h-5 text-accent" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+                                                    <h4 class="font-bold text-ink">Clean Starting State</h4>
+                                                </div>
+                                                <p class="text-sm text-ink-muted">
+                                                    Each session starts fresh from your source branch. No leftover files or uncommitted changes from previous work.
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <svg class="w-5 h-5 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+                                                    <h4 class="font-bold text-ink">No Context Switching</h4>
+                                                </div>
+                                                <p class="text-sm text-ink-muted">
+                                                    Say goodbye to <code class="text-xs bg-surface-2 px-1.5 py-0.5 rounded font-mono">git stash</code>. Your main workspace stays exactly as you left it while Claude works elsewhere.
+                                                </p>
+                                            </div>
+                                            <div class="bg-surface-1 border border-border rounded-lg p-4">
+                                                <div class="flex items-center gap-2 mb-2">
+                                                    <svg class="w-5 h-5 text-orange-600 dark:text-orange-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"></path></svg>
+                                                    <h4 class="font-bold text-ink">Parallel Workflows</h4>
+                                                </div>
+                                                <p class="text-sm text-ink-muted">
+                                                    Run multiple agents on different tasks at the same time. One fixing bugs, another implementing features.
+                                                </p>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                </div>
+                            </div>
+                        </section>


### PR DESCRIPTION
## Summary
- Applies the Terminal Noir design system (from `index.html`) to all documentation and blog pages
- Splits monolithic `docs.html` into `docs-shell.html` + 13 section files with a `build-docs.js` build script for maintainability
- Updates `build-blog.js` templates so new blog posts automatically inherit the Terminal Noir theme
- Adds CSS custom property tokens, DM Sans + JetBrains Mono fonts, grain texture overlay, mobile slide-in drawer nav, and consistent component styling across all pages

## Test plan
- [x] Open `docs/index.html` in browser — verify Terminal Noir styling in light and dark mode
- [x] Open `docs/docs.html` — verify all 13 sections render correctly, sidebar nav works, mobile drawer works
- [x] Open `docs/blog/index.html` — verify tag filtering, article cards, and theme toggle
- [x] Open both blog post pages — verify code blocks, prose styling, and navigation
- [x] Run `node docs/scripts/build-docs.js` — verify docs.html rebuilds from sections
- [x] Run `node docs/scripts/build-blog.js` — verify blog pages rebuild with Terminal Noir theme
- [x] Test mobile responsive layout on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)