### PR TITLE
chore: add docs rebuild step to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -18,4 +18,12 @@ else
     npm run test || exit 1
 fi
 
+# Rebuild docs.html if any docs source files changed
+DOCS_CHANGED=$(git diff --cached --name-only -- 'docs/docs-shell.html' 'docs/sections/' | head -1)
+if [ -n "$DOCS_CHANGED" ]; then
+    echo "📄 Rebuilding docs.html..."
+    npm run build:docs --prefix docs || exit 1
+    git add docs/docs.html
+fi
+
 echo "✅ All checks passed!"


### PR DESCRIPTION
## Summary
- Add automatic docs.html rebuild to the pre-commit hook when docs source files are changed

## Changes
- Updated `.husky/pre-commit` to detect staged changes in `docs/docs-shell.html` or `docs/sections/`
- When docs source files are staged, runs `npm run build:docs` and stages the rebuilt `docs/docs.html`

## Testing
- All 739 tests passing
- Lint passes
- Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)