### PR TITLE
feat: show VS Code notification alongside chime on session status change

### DIFF
--- a/src/AgentSessionProvider.ts
+++ b/src/AgentSessionProvider.ts
@@ -446,7 +446,17 @@ export class SessionItem extends vscode.TreeItem {
         }
         const previousIcon = previousIconState.get(this.worktreePath);
         if (iconId === 'bell' && previousIcon !== 'bell') {
-            if (chimeEnabled) { void vscode.commands.executeCommand('lanes.playChime'); }
+            if (chimeEnabled) {
+                void vscode.commands.executeCommand('lanes.playChime');
+                void vscode.window.showInformationMessage(
+                    `Session '${this.label}' is waiting for your input`,
+                    'Open Session'
+                ).then(selection => {
+                    if (selection === 'Open Session') {
+                        void vscode.commands.executeCommand('lanes.openSession', this);
+                    }
+                });
+            }
         }
         previousIconState.set(this.worktreePath, iconId);
         if (iconId === 'bell') { return new vscode.ThemeIcon('bell', new vscode.ThemeColor('charts.yellow')); }


### PR DESCRIPTION
## Summary
When chime is enabled for a session, a VS Code notification is now displayed alongside the audio chime when a session transitions to `waiting_for_user` status.

## Changes
- Added `vscode.window.showInformationMessage()` call in `AgentSessionProvider.ts` alongside the existing `lanes.playChime` command
- Notification shows "Session 'X' is waiting for your input" with an "Open Session" action button
- Uses the same trigger conditions as the audio chime (transition to `waiting_for_user` with chime enabled)

## Testing
- All 784 tests pass, 0 failing
- `npm run lint && npm test` passes cleanly
- Pre-commit hooks pass (compile, lint, test)

## Checklist
- [x] Code follows project standards
- [x] Tests are passing
- [x] No breaking changes
- [x] Commit history is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)