### PR TITLE
feat: add multi-project discovery with global daemon registry and dis…

### DIFF
--- a/.lanes/phase-3-plan.md
+++ b/.lanes/phase-3-plan.md
@@ -1,0 +1,72 @@
+# Phase 3: Multi-Project Discovery — Implementation Plan
+
+## Goal
+Enable a remote UI to discover all running project daemons via:
+1. A global registry at `~/.lanes/daemons.json`
+2. A `GET /api/v1/discovery` endpoint returning project metadata
+
+## Current State
+- All daemon state is repo-scoped (`<workspaceRoot>/.lanes/`)
+- No global `~/.lanes/` directory or registry exists
+- No `os.homedir()` usage in daemon code
+- `server.ts` writes PID/port/token on start, deletes on shutdown
+- Router uses custom `matchRoute()` pattern matching — no framework
+
+## Task Breakdown
+
+### Task 1: Create daemon registry module
+**Files**: `src/daemon/registry.ts`, `src/daemon/index.ts`, `src/test/daemon/registry.test.ts`
+
+Create `src/daemon/registry.ts`:
+- `DaemonRegistryEntry` type: `{ workspaceRoot, port, pid, token, startedAt, projectName }`
+- `getRegistryPath()` — returns `~/.lanes/daemons.json` using `os.homedir()`
+- `registerDaemon(entry: DaemonRegistryEntry)` — reads registry, upserts by workspaceRoot, writes atomically
+- `deregisterDaemon(workspaceRoot: string)` — reads registry, removes entry, writes back
+- `listRegisteredDaemons()` — reads registry, returns all entries
+- `cleanStaleEntries()` — removes entries whose PID is dead (using `process.kill(pid, 0)`)
+- Handle concurrent writes: read-modify-write with temp file + rename for atomicity
+- Create `~/.lanes/` directory if it doesn't exist (with `recursive: true`)
+
+Update `src/daemon/index.ts` to export new types and functions.
+
+Write tests in `src/test/daemon/registry.test.ts` covering:
+- Register, deregister, list operations
+- Stale entry cleanup
+- Concurrent daemon handling (upsert by workspaceRoot)
+- Missing directory/file creation
+- Edge cases (empty registry, non-existent file)
+
+### Task 2: Integrate registry + add discovery endpoint
+**Files**: `src/daemon/server.ts`, `src/daemon/router.ts`, `src/test/daemon/router.test.ts`
+
+In `server.ts`:
+- After writing PID/port/token, call `registerDaemon()` with entry data
+- Get `projectName` from `path.basename(workspaceRoot)`
+- Get token from the generated token (already in scope)
+- In `shutdown()`, call `deregisterDaemon(workspaceRoot)` before deleting local files
+
+In `router.ts`:
+- Add `GET /api/v1/discovery` route (requires auth)
+- Returns: `{ projectName, gitRemote, sessionCount, uptime, workspaceRoot, port }`
+- `projectName`: from `path.basename(workspaceRoot)` or config
+- `gitRemote`: run `git remote get-url origin` (gracefully handle no remote)
+- `sessionCount`: call `handlerService.handleSessionList()` and count
+- `uptime`: calculate from server start time (store `startedAt` in router context or pass as param)
+- `port`: from the server's listening address
+
+Add tests in `src/test/daemon/router.test.ts`:
+- Discovery endpoint returns correct shape
+- Discovery endpoint requires auth
+- Handles missing git remote gracefully
+
+## Dependencies
+- Task 2 depends on Task 1 (imports registry types)
+- Both tasks should be done in sequence
+
+## Key Decisions
+- Registry path: `~/.lanes/daemons.json` (per plan)
+- Atomic writes via temp file + `fs.rename` to prevent corruption
+- Stale cleanup uses `process.kill(pid, 0)` — same pattern as `isDaemonRunning()`
+- Discovery endpoint is per-daemon (returns THIS daemon's info), not an aggregator
+- `projectName` defaults to `path.basename(workspaceRoot)` — simple and predictable
+- Token is stored in registry entries so the remote UI can authenticate without reading local files

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -24,3 +24,11 @@ export { DaemonNotificationEmitter } from './notifications';
 export type { FileWatchOptions } from './fileWatcher';
 export { DaemonFileWatchManager } from './fileWatcher';
 export { createRouter } from './router';
+export type { DaemonRegistryEntry } from './registry';
+export {
+    getRegistryPath,
+    registerDaemon,
+    deregisterDaemon,
+    listRegisteredDaemons,
+    cleanStaleEntries,
+} from './registry';

--- a/src/daemon/registry.ts
+++ b/src/daemon/registry.ts
@@ -1,0 +1,162 @@
+/**
+ * Daemon Registry - Global registry of running daemon instances
+ *
+ * Maintains a JSON registry at `~/.lanes/daemons.json` that tracks all running
+ * daemon instances across workspaces. This allows tools (CLI, IDE plugins) to
+ * discover daemons without knowing each workspace path in advance.
+ *
+ * The registry is written atomically (write to temp + rename) to prevent
+ * corruption from concurrent access.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single entry in the global daemon registry.
+ */
+export type DaemonRegistryEntry = {
+    /** Absolute path to the workspace root this daemon serves. */
+    workspaceRoot: string;
+    /** Port number the daemon is listening on. */
+    port: number;
+    /** OS process ID of the daemon process. */
+    pid: number;
+    /** Bearer token for authenticating requests to this daemon. */
+    token: string;
+    /** ISO-8601 timestamp of when the daemon was started. */
+    startedAt: string;
+    /** Human-readable project name (typically the workspace directory name). */
+    projectName: string;
+};
+
+// ---------------------------------------------------------------------------
+// Registry path
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the absolute path to the global registry file: `~/.lanes/daemons.json`.
+ */
+export function getRegistryPath(): string {
+    return path.join(os.homedir(), '.lanes', 'daemons.json');
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Ensure the `~/.lanes/` directory exists.
+ */
+async function ensureRegistryDir(): Promise<void> {
+    const registryDir = path.join(os.homedir(), '.lanes');
+    await fs.mkdir(registryDir, { recursive: true });
+}
+
+/**
+ * Read the current registry from disk.
+ * Returns an empty array if the file does not exist or is malformed.
+ */
+async function readRegistry(): Promise<DaemonRegistryEntry[]> {
+    const registryPath = getRegistryPath();
+    try {
+        const content = await fs.readFile(registryPath, 'utf-8');
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed)) {
+            return parsed as DaemonRegistryEntry[];
+        }
+        return [];
+    } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+            return [];
+        }
+        if (err instanceof SyntaxError) {
+            // Malformed JSON — start fresh
+            return [];
+        }
+        // Permission errors, disk failures, etc. — propagate
+        throw err;
+    }
+}
+
+/**
+ * Write entries to the registry atomically using a temp file + rename.
+ * This prevents corruption if the process is interrupted mid-write.
+ */
+async function writeRegistry(entries: DaemonRegistryEntry[]): Promise<void> {
+    await ensureRegistryDir();
+    const registryPath = getRegistryPath();
+    const tempPath = `${registryPath}.tmp`;
+
+    await fs.writeFile(tempPath, JSON.stringify(entries, null, 2), { encoding: 'utf-8', mode: 0o600 });
+    await fs.rename(tempPath, registryPath);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register (or update) a daemon entry in the global registry.
+ * If an entry with the same `workspaceRoot` already exists, it is replaced.
+ *
+ * Note: The read-modify-write cycle is not concurrency-safe across processes.
+ * If two daemons register simultaneously, one entry may be lost. In practice
+ * this is rare since daemon starts are user-initiated and sequential.
+ */
+export async function registerDaemon(entry: DaemonRegistryEntry): Promise<void> {
+    const existing = await readRegistry();
+    const filtered = existing.filter((e) => e.workspaceRoot !== entry.workspaceRoot);
+    filtered.push(entry);
+    await writeRegistry(filtered);
+}
+
+/**
+ * Remove the daemon entry for the given workspace root from the global registry.
+ * Does nothing if no entry for that workspace exists.
+ */
+export async function deregisterDaemon(workspaceRoot: string): Promise<void> {
+    const existing = await readRegistry();
+    const filtered = existing.filter((e) => e.workspaceRoot !== workspaceRoot);
+    if (filtered.length !== existing.length) {
+        await writeRegistry(filtered);
+    }
+}
+
+/**
+ * Return all entries currently in the global registry (no liveness check).
+ */
+export async function listRegisteredDaemons(): Promise<DaemonRegistryEntry[]> {
+    return readRegistry();
+}
+
+/**
+ * Remove registry entries whose daemon process is no longer alive.
+ * Uses `process.kill(pid, 0)` to test liveness without sending a real signal.
+ * Returns the remaining live entries.
+ */
+export async function cleanStaleEntries(): Promise<DaemonRegistryEntry[]> {
+    const existing = await readRegistry();
+
+    const liveEntries = existing.filter((entry) => {
+        try {
+            // Signal 0 checks process existence without sending a real signal
+            process.kill(entry.pid, 0);
+            return true;
+        } catch {
+            // ESRCH: no such process — entry is stale
+            return false;
+        }
+    });
+
+    if (liveEntries.length !== existing.length) {
+        await writeRegistry(liveEntries);
+    }
+
+    return liveEntries;
+}

--- a/src/daemon/router.ts
+++ b/src/daemon/router.ts
@@ -12,9 +12,11 @@
  */
 
 import * as http from 'http';
+import * as path from 'path';
 import { SessionHandlerService, JsonRpcHandlerError } from '../core/services/SessionHandlerService';
 import { DaemonNotificationEmitter } from './notifications';
 import { validateAuthHeader } from './auth';
+import { execGit } from '../core/gitService';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -192,12 +194,14 @@ function matchRoute(pattern: string, pathname: string): RouteMatch | null {
  * @param handlerService  The protocol-agnostic session handler service.
  * @param notificationEmitter  The SSE notification emitter.
  * @param authToken  The Bearer token clients must supply for authentication.
+ * @param context  Additional server context used by the discovery endpoint.
  * @returns An HTTP request handler function suitable for `http.createServer()`.
  */
 export function createRouter(
     handlerService: SessionHandlerService,
     notificationEmitter: DaemonNotificationEmitter,
-    authToken: string
+    authToken: string,
+    context: { workspaceRoot: string; startedAt: string; port: number }
 ): (req: http.IncomingMessage, res: http.ServerResponse) => void {
     return async function router(
         req: http.IncomingMessage,
@@ -233,6 +237,35 @@ export function createRouter(
         }
 
         try {
+            // ---------------------------------------------------------------
+            // Discovery
+            // ---------------------------------------------------------------
+
+            // GET /api/v1/discovery
+            if (method === 'GET' && pathname === '/api/v1/discovery') {
+                let gitRemote: string | null = null;
+                try {
+                    gitRemote = (await execGit(['remote', 'get-url', 'origin'], context.workspaceRoot)).trim();
+                } catch {
+                    gitRemote = null;
+                }
+
+                const sessionsResult = await handlerService.handleSessionList({}) as { sessions?: unknown[] };
+                const sessionCount = Array.isArray(sessionsResult.sessions) ? sessionsResult.sessions.length : 0;
+
+                const uptime = Math.floor((Date.now() - new Date(context.startedAt).getTime()) / 1000);
+
+                sendJson(res, 200, {
+                    projectName: path.basename(context.workspaceRoot),
+                    gitRemote,
+                    sessionCount,
+                    uptime,
+                    workspaceRoot: context.workspaceRoot,
+                    port: context.port,
+                });
+                return;
+            }
+
             // ---------------------------------------------------------------
             // SSE events stream
             // ---------------------------------------------------------------

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -18,6 +18,7 @@ import { DaemonNotificationEmitter } from './notifications';
 import { DaemonFileWatchManager } from './fileWatcher';
 import { generateToken, writeTokenFile } from './auth';
 import { createRouter } from './router';
+import { registerDaemon, deregisterDaemon, DaemonRegistryEntry } from './registry';
 import { SessionHandlerService } from '../core/services/SessionHandlerService';
 import { getWorktreesFolder } from '../core/session/SessionDataService';
 import { IHandlerContext } from '../core/interfaces/IHandlerContext';
@@ -133,11 +134,20 @@ async function main(): Promise<void> {
     const authToken = generateToken();
     await writeTokenFile(workspaceRoot, authToken);
 
-    // 7. Create router and HTTP server
-    const requestHandler = createRouter(handlerService, notificationEmitter, authToken);
+    // 7. Record startup time for use in the discovery endpoint
+    const startedAt = new Date().toISOString();
+
+    // 8. Create router and HTTP server (context filled in after actualPort is known)
+    // We create a mutable context object so we can back-fill the port after binding.
+    const routerContext: { workspaceRoot: string; startedAt: string; port: number } = {
+        workspaceRoot,
+        startedAt,
+        port: 0, // will be updated after listen()
+    };
+    const requestHandler = createRouter(handlerService, notificationEmitter, authToken, routerContext);
     const server = http.createServer(requestHandler);
 
-    // 8. Start listening on 127.0.0.1 only
+    // 9. Start listening on 127.0.0.1 only
     await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
         server.listen(port, '127.0.0.1', () => {
@@ -148,9 +158,23 @@ async function main(): Promise<void> {
     const address = server.address();
     const actualPort = typeof address === 'object' && address !== null ? address.port : port;
 
-    // 9. Write PID, port, and log startup info
+    // Back-fill the actual port into the router context (used by /api/v1/discovery)
+    routerContext.port = actualPort;
+
+    // 10. Write PID, port, and log startup info
     await writeLanesFile(workspaceRoot, 'daemon.pid', String(process.pid));
     await writeLanesFile(workspaceRoot, 'daemon.port', String(actualPort));
+
+    // 11. Register this daemon in the global registry (~/.lanes/daemons.json)
+    const registryEntry: DaemonRegistryEntry = {
+        workspaceRoot,
+        port: actualPort,
+        pid: process.pid,
+        token: authToken,
+        startedAt,
+        projectName: path.basename(workspaceRoot),
+    };
+    await registerDaemon(registryEntry);
 
     process.stderr.write(
         `[Daemon] Started. pid=${process.pid} port=${actualPort} workspace=${workspaceRoot}\n`
@@ -189,6 +213,13 @@ async function main(): Promise<void> {
 
         // Dispose file watchers
         fileWatchManager.dispose();
+
+        // Remove this daemon from the global registry (best-effort)
+        try {
+            await deregisterDaemon(workspaceRoot);
+        } catch (err) {
+            process.stderr.write(`[Daemon] Warning: failed to deregister from global registry: ${(err as Error).message}\n`);
+        }
 
         // Remove PID, port, and token files
         await removeLanesFile(workspaceRoot, 'daemon.pid');

--- a/src/test/daemon/index.test.ts
+++ b/src/test/daemon/index.test.ts
@@ -98,4 +98,39 @@ suite('daemon index', () => {
             'DaemonFileWatchManager should be exported as a class/constructor'
         );
     });
+
+    test('Given an import from src/daemon/index, then getRegistryPath is exported', () => {
+        assert.ok(
+            typeof daemonIndex.getRegistryPath === 'function',
+            'getRegistryPath should be exported as a function'
+        );
+    });
+
+    test('Given an import from src/daemon/index, then registerDaemon is exported', () => {
+        assert.ok(
+            typeof daemonIndex.registerDaemon === 'function',
+            'registerDaemon should be exported as a function'
+        );
+    });
+
+    test('Given an import from src/daemon/index, then deregisterDaemon is exported', () => {
+        assert.ok(
+            typeof daemonIndex.deregisterDaemon === 'function',
+            'deregisterDaemon should be exported as a function'
+        );
+    });
+
+    test('Given an import from src/daemon/index, then listRegisteredDaemons is exported', () => {
+        assert.ok(
+            typeof daemonIndex.listRegisteredDaemons === 'function',
+            'listRegisteredDaemons should be exported as a function'
+        );
+    });
+
+    test('Given an import from src/daemon/index, then cleanStaleEntries is exported', () => {
+        assert.ok(
+            typeof daemonIndex.cleanStaleEntries === 'function',
+            'cleanStaleEntries should be exported as a function'
+        );
+    });
 });

--- a/src/test/daemon/registry.test.ts
+++ b/src/test/daemon/registry.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Tests for daemon registry module.
+ *
+ * Covers:
+ *  - getRegistryPath() returns path relative to os.homedir()
+ *  - registerDaemon() adds an entry to the registry
+ *  - registerDaemon() replaces an existing entry for the same workspaceRoot (upsert)
+ *  - deregisterDaemon() removes the entry for a given workspaceRoot
+ *  - deregisterDaemon() is a no-op when the entry does not exist
+ *  - listRegisteredDaemons() returns all entries (empty when no file)
+ *  - listRegisteredDaemons() returns all entries after multiple registrations
+ *  - cleanStaleEntries() removes entries whose PID is no longer alive
+ *  - cleanStaleEntries() keeps entries whose PID is alive
+ *  - cleanStaleEntries() handles an empty registry without throwing
+ *  - Registry file and directory are created automatically
+ *  - Malformed JSON in registry returns empty array (graceful degradation)
+ *
+ * The HOME environment variable is overridden in each test to point to a temp
+ * directory, so os.homedir() resolves to a temp path and the real ~/.lanes is
+ * never touched.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import sinon from 'sinon';
+import {
+    getRegistryPath,
+    registerDaemon,
+    deregisterDaemon,
+    listRegisteredDaemons,
+    cleanStaleEntries,
+} from '../../daemon/registry';
+import type { DaemonRegistryEntry } from '../../daemon/registry';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal valid registry entry for testing. */
+function makeEntry(overrides: Partial<DaemonRegistryEntry> = {}): DaemonRegistryEntry {
+    return {
+        workspaceRoot: '/tmp/test-workspace',
+        port: 3000,
+        pid: process.pid,
+        token: 'abc123',
+        startedAt: new Date().toISOString(),
+        projectName: 'test-project',
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Suite: daemon registry
+// ---------------------------------------------------------------------------
+
+suite('daemon registry', () => {
+    let tempDir: string;
+    let originalHome: string | undefined;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-daemon-registry-test-'));
+        // Override HOME so that os.homedir() points to our temp directory.
+        // On Linux/macOS os.homedir() reads from process.env.HOME.
+        originalHome = process.env.HOME;
+        process.env.HOME = tempDir;
+    });
+
+    teardown(() => {
+        sinon.restore();
+        // Restore the original HOME
+        if (originalHome !== undefined) {
+            process.env.HOME = originalHome;
+        } else {
+            delete process.env.HOME;
+        }
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-get-path
+    // -------------------------------------------------------------------------
+
+    test('Given HOME is set to tempDir, when getRegistryPath() is called, then it returns <tempDir>/.lanes/daemons.json', () => {
+        const result = getRegistryPath();
+
+        const expected = path.join(tempDir, '.lanes', 'daemons.json');
+        assert.strictEqual(result, expected, `Expected registry path to be ${expected}`);
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-list-empty
+    // -------------------------------------------------------------------------
+
+    test('Given no registry file exists, when listRegisteredDaemons() is called, then it returns an empty array', async () => {
+        const result = await listRegisteredDaemons();
+
+        assert.ok(Array.isArray(result), 'listRegisteredDaemons should return an array');
+        assert.strictEqual(result.length, 0, 'Should return empty array when no registry file exists');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-register
+    // -------------------------------------------------------------------------
+
+    test('Given no existing registry, when registerDaemon() is called, then the entry appears in listRegisteredDaemons()', async () => {
+        // Arrange
+        const entry = makeEntry({ workspaceRoot: '/workspace/alpha', projectName: 'alpha' });
+
+        // Act
+        await registerDaemon(entry);
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 1, 'Registry should contain exactly one entry');
+        assert.strictEqual(result[0].workspaceRoot, entry.workspaceRoot);
+        assert.strictEqual(result[0].projectName, entry.projectName);
+        assert.strictEqual(result[0].port, entry.port);
+        assert.strictEqual(result[0].pid, entry.pid);
+        assert.strictEqual(result[0].token, entry.token);
+    });
+
+    test('Given no existing registry, when registerDaemon() is called, then ~/.lanes/daemons.json is created on disk', async () => {
+        // Arrange
+        const entry = makeEntry({ workspaceRoot: '/workspace/beta' });
+        const expectedPath = path.join(tempDir, '.lanes', 'daemons.json');
+
+        // Act
+        await registerDaemon(entry);
+
+        // Assert
+        assert.ok(fs.existsSync(expectedPath), 'daemons.json should be created after registerDaemon()');
+    });
+
+    test('Given no existing registry, when registerDaemon() is called, then the ~/.lanes directory is created automatically', async () => {
+        // Arrange: ensure .lanes directory does not exist yet
+        const lanesDir = path.join(tempDir, '.lanes');
+        assert.ok(!fs.existsSync(lanesDir), 'Precondition: .lanes dir should not exist');
+
+        // Act
+        await registerDaemon(makeEntry());
+
+        // Assert
+        assert.ok(fs.existsSync(lanesDir), '.lanes directory should be created by registerDaemon()');
+    });
+
+    test('Given two different workspaceRoots, when both are registered, then listRegisteredDaemons() returns two entries', async () => {
+        // Arrange
+        const entry1 = makeEntry({ workspaceRoot: '/workspace/project-one', port: 3001 });
+        const entry2 = makeEntry({ workspaceRoot: '/workspace/project-two', port: 3002 });
+
+        // Act
+        await registerDaemon(entry1);
+        await registerDaemon(entry2);
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 2, 'Registry should contain two entries');
+        const roots = result.map((e) => e.workspaceRoot);
+        assert.ok(roots.includes(entry1.workspaceRoot), 'Entry 1 should be present');
+        assert.ok(roots.includes(entry2.workspaceRoot), 'Entry 2 should be present');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-upsert (concurrent daemon handling)
+    // -------------------------------------------------------------------------
+
+    test('Given an existing entry for a workspaceRoot, when registerDaemon() is called again with the same root, then it is replaced (upsert)', async () => {
+        // Arrange: register an initial entry
+        const initial = makeEntry({ workspaceRoot: '/workspace/upsert', port: 3000, pid: 1001 });
+        await registerDaemon(initial);
+
+        // Act: re-register with updated port and pid
+        const updated = makeEntry({ workspaceRoot: '/workspace/upsert', port: 4000, pid: 2002 });
+        await registerDaemon(updated);
+        const result = await listRegisteredDaemons();
+
+        // Assert: only one entry should exist with the updated values
+        assert.strictEqual(result.length, 1, 'Upsert should not create a duplicate; only one entry should remain');
+        assert.strictEqual(result[0].port, 4000, 'Port should be updated to 4000');
+        assert.strictEqual(result[0].pid, 2002, 'PID should be updated to 2002');
+    });
+
+    test('Given an existing entry for workspaceRoot A, when a different workspaceRoot B is registered, then A is not replaced', async () => {
+        // Arrange
+        const entryA = makeEntry({ workspaceRoot: '/workspace/a', port: 3001 });
+        const entryB = makeEntry({ workspaceRoot: '/workspace/b', port: 3002 });
+        await registerDaemon(entryA);
+
+        // Act
+        await registerDaemon(entryB);
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 2, 'Both entries should be present');
+        const portA = result.find((e) => e.workspaceRoot === '/workspace/a')?.port;
+        assert.strictEqual(portA, 3001, 'Entry A port should remain unchanged');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-deregister
+    // -------------------------------------------------------------------------
+
+    test('Given a registered entry, when deregisterDaemon() is called with that workspaceRoot, then listRegisteredDaemons() returns an empty array', async () => {
+        // Arrange
+        const entry = makeEntry({ workspaceRoot: '/workspace/to-remove' });
+        await registerDaemon(entry);
+
+        // Act
+        await deregisterDaemon('/workspace/to-remove');
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 0, 'Registry should be empty after deregistration');
+    });
+
+    test('Given two registered entries, when deregisterDaemon() is called for one, then the other remains', async () => {
+        // Arrange
+        const entryA = makeEntry({ workspaceRoot: '/workspace/keep', port: 3001 });
+        const entryB = makeEntry({ workspaceRoot: '/workspace/remove', port: 3002 });
+        await registerDaemon(entryA);
+        await registerDaemon(entryB);
+
+        // Act
+        await deregisterDaemon('/workspace/remove');
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 1, 'One entry should remain');
+        assert.strictEqual(result[0].workspaceRoot, '/workspace/keep', 'Remaining entry should be the one that was kept');
+    });
+
+    test('Given an empty registry, when deregisterDaemon() is called, then it does not throw', async () => {
+        // Act & Assert: should not throw even though no entry exists
+        await deregisterDaemon('/workspace/nonexistent');
+    });
+
+    test('Given no registry file, when deregisterDaemon() is called, then it does not throw', async () => {
+        // The registry file does not exist at all — no .lanes directory
+        await deregisterDaemon('/workspace/ghost');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-clean-stale
+    // -------------------------------------------------------------------------
+
+    test('Given an entry with the current process PID, when cleanStaleEntries() is called, then the entry is kept', async () => {
+        // Arrange: use the current process PID — guaranteed to be alive
+        const entry = makeEntry({ workspaceRoot: '/workspace/alive', pid: process.pid });
+        await registerDaemon(entry);
+
+        // Act
+        const live = await cleanStaleEntries();
+
+        // Assert
+        assert.strictEqual(live.length, 1, 'Live entry should be kept');
+        assert.strictEqual(live[0].workspaceRoot, '/workspace/alive');
+    });
+
+    test('Given an entry with a dead PID, when cleanStaleEntries() is called, then the entry is removed', async () => {
+        // Arrange: stub process.kill to throw ESRCH for all PIDs (simulating a dead process)
+        const fakePid = 999999999;
+        const killStub = sinon.stub(process, 'kill').throws(
+            Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' })
+        );
+
+        const entry = makeEntry({ workspaceRoot: '/workspace/dead', pid: fakePid });
+        await registerDaemon(entry);
+
+        // Act
+        const live = await cleanStaleEntries();
+
+        // Assert
+        killStub.restore();
+        assert.strictEqual(live.length, 0, 'Stale entry should be removed');
+    });
+
+    test('Given one live entry and one stale entry, when cleanStaleEntries() is called, then only the live entry is returned', async () => {
+        // Arrange: register both entries before stubbing process.kill
+        const liveEntry = makeEntry({ workspaceRoot: '/workspace/live', pid: process.pid, port: 3001 });
+        const fakePid = 888888888;
+        const staleEntry = makeEntry({ workspaceRoot: '/workspace/stale', pid: fakePid, port: 3002 });
+
+        await registerDaemon(liveEntry);
+        await registerDaemon(staleEntry);
+
+        // Stub process.kill: throw ESRCH only for the fake PID, pass for the real PID
+        const killStub = sinon.stub(process, 'kill').callsFake((pid: number | NodeJS.Signals, _signal?: string | number) => {
+            if (pid === fakePid) {
+                throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' });
+            }
+            // Let process.pid through — it is alive (no throw means alive)
+            return true;
+        });
+
+        // Act
+        const live = await cleanStaleEntries();
+
+        // Assert
+        killStub.restore();
+        assert.strictEqual(live.length, 1, 'Only the live entry should remain');
+        assert.strictEqual(live[0].workspaceRoot, '/workspace/live', 'Remaining entry should be the live one');
+    });
+
+    test('Given an empty registry, when cleanStaleEntries() is called, then it returns an empty array without throwing', async () => {
+        // Act
+        const result = await cleanStaleEntries();
+
+        // Assert
+        assert.ok(Array.isArray(result), 'cleanStaleEntries should return an array');
+        assert.strictEqual(result.length, 0, 'Empty registry should yield empty result');
+    });
+
+    test('Given all entries are alive, when cleanStaleEntries() is called, then the registry file is not rewritten', async () => {
+        // Arrange: register a live entry
+        const entry = makeEntry({ workspaceRoot: '/workspace/all-live', pid: process.pid });
+        await registerDaemon(entry);
+
+        const registryPath = getRegistryPath();
+        const statBefore = fs.statSync(registryPath);
+
+        // Small delay to ensure mtime would differ if written
+        await new Promise<void>((resolve) => setTimeout(resolve, 10));
+
+        // Act
+        await cleanStaleEntries();
+
+        // Assert: mtime should be unchanged since no rewrite was needed
+        const statAfter = fs.statSync(registryPath);
+        assert.strictEqual(
+            statBefore.mtimeMs,
+            statAfter.mtimeMs,
+            'Registry file should not be rewritten when no stale entries exist'
+        );
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-malformed-json
+    // -------------------------------------------------------------------------
+
+    test('Given a registry file with malformed JSON, when listRegisteredDaemons() is called, then it returns an empty array (graceful degradation)', async () => {
+        // Arrange: write malformed JSON to the registry file
+        const lanesDir = path.join(tempDir, '.lanes');
+        fs.mkdirSync(lanesDir, { recursive: true });
+        const registryPath = path.join(lanesDir, 'daemons.json');
+        fs.writeFileSync(registryPath, '{ this is not valid json', 'utf-8');
+
+        // Act
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.ok(Array.isArray(result), 'Should return an array even for malformed JSON');
+        assert.strictEqual(result.length, 0, 'Malformed registry should be treated as empty');
+    });
+
+    test('Given a registry file containing a non-array JSON value, when listRegisteredDaemons() is called, then it returns an empty array', async () => {
+        // Arrange: write a JSON object (not an array) to the registry file
+        const lanesDir = path.join(tempDir, '.lanes');
+        fs.mkdirSync(lanesDir, { recursive: true });
+        const registryPath = path.join(lanesDir, 'daemons.json');
+        fs.writeFileSync(registryPath, JSON.stringify({ entry: 'not-an-array' }), 'utf-8');
+
+        // Act
+        const result = await listRegisteredDaemons();
+
+        // Assert
+        assert.strictEqual(result.length, 0, 'Non-array registry content should be treated as empty');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-registry-write-atomically
+    // -------------------------------------------------------------------------
+
+    test('Given a registered entry, when the registry file is read directly, then it contains valid JSON', async () => {
+        // Arrange
+        const entry = makeEntry({ workspaceRoot: '/workspace/json-check' });
+
+        // Act
+        await registerDaemon(entry);
+
+        // Assert: the file should be parseable JSON
+        const registryPath = path.join(tempDir, '.lanes', 'daemons.json');
+        const raw = fs.readFileSync(registryPath, 'utf-8');
+        let parsed: unknown;
+        assert.doesNotThrow(() => {
+            parsed = JSON.parse(raw);
+        }, 'Registry file should contain valid JSON after registration');
+        assert.ok(Array.isArray(parsed), 'Registry file content should be a JSON array');
+    });
+
+    test('Given an entry was deregistered, when the registry file is read directly, then the entry is absent from the JSON', async () => {
+        // Arrange
+        const entry = makeEntry({ workspaceRoot: '/workspace/gone' });
+        await registerDaemon(entry);
+
+        // Act
+        await deregisterDaemon('/workspace/gone');
+
+        // Assert
+        const registryPath = path.join(tempDir, '.lanes', 'daemons.json');
+        const raw = fs.readFileSync(registryPath, 'utf-8');
+        const parsed = JSON.parse(raw) as DaemonRegistryEntry[];
+        const found = parsed.find((e) => e.workspaceRoot === '/workspace/gone');
+        assert.strictEqual(found, undefined, 'Deregistered entry should not be present in the JSON file');
+    });
+});

--- a/src/test/daemon/router.test.ts
+++ b/src/test/daemon/router.test.ts
@@ -18,13 +18,16 @@
  *  - Workflow list, validate, create endpoints
  *  - Terminal create, send, list endpoints
  *  - parseQueryString helper (tested indirectly via route tests)
+ *  - Discovery endpoint: returns expected shape with auth, 401 without auth, null gitRemote on error
  */
 
 import * as assert from 'assert';
 import * as http from 'http';
+import * as path from 'path';
 import sinon from 'sinon';
 import { createRouter } from '../../daemon/router';
 import { JsonRpcHandlerError } from '../../core/services/SessionHandlerService';
+import * as gitService from '../../core/gitService';
 
 // ---------------------------------------------------------------------------
 // Helper: minimal fake SessionHandlerService
@@ -168,7 +171,8 @@ suite('daemon router', () => {
         const handler = createRouter(
             handlerService as never,
             notificationEmitter as never,
-            AUTH_TOKEN
+            AUTH_TOKEN,
+            { workspaceRoot: '/test/workspace', startedAt: new Date().toISOString(), port: 0 }
         );
         server = http.createServer(handler);
         server.listen(0, '127.0.0.1', done);
@@ -1036,5 +1040,75 @@ suite('daemon router', () => {
         assert.ok(handlerService.handleGitListBranches.calledOnce);
         const calledWith = handlerService.handleGitListBranches.firstCall.args[0] as Record<string, unknown>;
         assert.strictEqual(calledWith.includeRemote, false);
+    });
+
+    // -------------------------------------------------------------------------
+    // router-discovery-endpoint
+    // -------------------------------------------------------------------------
+
+    test('Given GET /api/v1/discovery with valid auth and a known git remote, when called, then it returns the expected discovery shape', async () => {
+        // Arrange
+        const gitRemoteUrl = 'https://github.com/example/test-workspace.git';
+        const execGitStub = sinon.stub(gitService, 'execGit').resolves(gitRemoteUrl + '\n');
+        handlerService.handleSessionList.resolves({ sessions: [{ name: 'session-a' }, { name: 'session-b' }] });
+
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/discovery',
+            headers: { Authorization: BEARER },
+        });
+
+        // Assert
+        execGitStub.restore();
+        assert.strictEqual(res.status, 200);
+        const body = res.body as Record<string, unknown>;
+        assert.strictEqual(body.projectName, path.basename('/test/workspace'), 'projectName should be the workspace directory name');
+        assert.strictEqual(body.gitRemote, gitRemoteUrl, 'gitRemote should be the trimmed remote URL');
+        assert.strictEqual(body.sessionCount, 2, 'sessionCount should reflect the number of sessions');
+        assert.strictEqual(typeof body.uptime, 'number', 'uptime should be a number');
+        assert.ok((body.uptime as number) >= 0, 'uptime should be non-negative');
+        assert.strictEqual(body.workspaceRoot, '/test/workspace', 'workspaceRoot should match the context workspaceRoot');
+        assert.ok(typeof body.port === 'number', 'port should be a number');
+    });
+
+    test('Given GET /api/v1/discovery without an Authorization header, when called, then it returns 401', async () => {
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/discovery',
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 401);
+        assert.strictEqual((res.body as { error: string }).error, 'Unauthorized');
+    });
+
+    test('Given GET /api/v1/discovery with a wrong Bearer token, when called, then it returns 401', async () => {
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/discovery',
+            headers: { Authorization: 'Bearer wrong-token' },
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 401);
+    });
+
+    test('Given GET /api/v1/discovery when git remote is unavailable, when called, then gitRemote is null in the response', async () => {
+        // Arrange: make execGit throw to simulate missing git remote
+        const execGitStub = sinon.stub(gitService, 'execGit').rejects(new Error('fatal: No such remote: origin'));
+        handlerService.handleSessionList.resolves({ sessions: [] });
+
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/discovery',
+            headers: { Authorization: BEARER },
+        });
+
+        // Assert
+        execGitStub.restore();
+        assert.strictEqual(res.status, 200);
+        const body = res.body as Record<string, unknown>;
+        assert.strictEqual(body.gitRemote, null, 'gitRemote should be null when git remote lookup fails');
+        assert.strictEqual(body.sessionCount, 0, 'sessionCount should be 0 when there are no sessions');
     });
 });


### PR DESCRIPTION
…covery endpoint

Introduces a global daemon registry at ~/.lanes/daemons.json so remote UIs can discover all running project daemons. Each daemon registers on startup and deregisters on shutdown. Adds GET /api/v1/discovery endpoint returning project metadata (name, git remote, session count, uptime).