### PR TITLE
feat: add DaemonClient and VS Code daemon integration (#169)

### DIFF
--- a/.lanes/phase4-plan.md
+++ b/.lanes/phase4-plan.md
@@ -1,0 +1,134 @@
+# Phase 4: VS Code as Daemon Client — Task Plan
+
+## Goal
+
+Enable the VS Code extension to operate as a client of the Lanes daemon, routing operations through the REST API instead of making direct core service calls. This enables remote UI scenarios and unifies the execution path.
+
+## Architecture Analysis
+
+### Current State
+
+The VS Code extension currently calls core services directly:
+- `createSessionWorktree()` from `src/core/services/SessionCreationService.ts`
+- `DiffService.generateDiffContent()` / `DiffService.generateDiffFiles()`
+- `SessionDataService` for reading session data/status
+- `BrokenWorktreeService` for worktree repair
+- `generateInsights()` / `analyzeInsights()` from `InsightsService`
+- `execGit()` for git operations
+- `WorkflowService` for workflow listing/validation
+- `CodeAgentFactory` for agent config
+- Config via `VscodeConfigProvider`
+
+### Target State
+
+When `lanes.useDaemon` is enabled:
+1. A `DaemonClient` HTTP client routes operations to the daemon's REST API
+2. The daemon handles all core logic (session CRUD, git, diff, workflows, etc.)
+3. VS Code-specific operations (terminals, UI dialogs, tree views) remain local
+4. SSE subscription provides real-time session status updates
+5. Daemon is auto-started if not running
+
+### Boundary: What Routes Through Daemon vs. Stays Local
+
+**Through Daemon (28 REST endpoints):**
+- Session list, create, delete, status, open, clear, pin, unpin
+- Git branches, diff, diff files, worktree info, repair
+- Workflow list, validate, create, get state
+- Agent list, agent config
+- Config get, set, get all
+- Terminal create, send, list (tmux)
+- Insights
+- Discovery, health
+
+**Stays in VS Code:**
+- Terminal creation (`vscode.window.createTerminal`)
+- UI interactions (dialogs, quick picks, input boxes)
+- File opening in editor
+- Tree view rendering
+- File system watching (in local mode; SSE in daemon mode)
+- Extension context/storage
+
+## Tasks
+
+### Task 1: DaemonClient (`src/daemon/client.ts`)
+
+Create a typed HTTP client class that wraps all REST endpoints + SSE subscription.
+
+**Scope:**
+- `DaemonClient` class with constructor taking `{ port, token }` or `{ baseUrl, token }`
+- Methods for all 28+ REST endpoints, organized by category:
+  - `health()`, `discovery()`
+  - `listSessions()`, `createSession(opts)`, `deleteSession(name)`, `getSessionStatus(name)`, `openSession(name, opts)`, `clearSession(name)`, `pinSession(name)`, `unpinSession(name)`
+  - `getSessionInsights(name, opts)`
+  - `listBranches(opts)`, `getSessionDiff(name, opts)`, `getSessionDiffFiles(name, opts)`, `getWorktreeInfo(name)`, `repairWorktrees(opts)`
+  - `listWorkflows(opts)`, `validateWorkflow(path)`, `createWorkflow(name, content)`, `getWorkflowState(name)`
+  - `listAgents()`, `getAgentConfig(name)`
+  - `getConfig(key)`, `setConfig(key, value)`, `getAllConfig()`
+  - `listTerminals(opts)`, `createTerminal(opts)`, `sendToTerminal(name, text)`
+  - `subscribeEvents(callbacks)` — SSE subscription with reconnection
+- Error handling: map HTTP 400/401/404/500 to typed errors
+- Connection management: timeout, retry on transient failures
+- Token loading utility: `DaemonClient.fromWorkspace(workspaceRoot)` static factory
+- Tests
+
+**Key files to create:**
+- `src/daemon/client.ts`
+- `src/test/daemon/client.test.ts`
+
+**Key files to reference:**
+- `src/daemon/router.ts` (endpoint signatures)
+- `src/daemon/auth.ts` (token format)
+- `src/daemon/lifecycle.ts` (port/token file paths)
+
+### Task 2: VS Code Daemon Integration
+
+Wire the DaemonClient into the VS Code extension with a config option and auto-start.
+
+**Scope:**
+- Add `lanes.useDaemon` (boolean, default: false) to `package.json` contributes.configuration
+- Create `src/vscode/services/DaemonService.ts`:
+  - Auto-start daemon if not running (using lifecycle.ts functions)
+  - Manage DaemonClient instance lifecycle
+  - SSE subscription for real-time status/file-change events
+  - Reconnection logic on daemon restart
+  - Cleanup on extension deactivation
+- Modify `src/vscode/extension.ts`:
+  - Initialize DaemonService when `lanes.useDaemon` is true
+  - Pass DaemonClient to commands that need it
+  - Listen for config changes to toggle daemon mode
+- Modify commands (in `src/vscode/commands/sessionCommands.ts`) to use DaemonClient when available:
+  - Session creation: use `client.createSession()` instead of `createSessionWorktree()`
+  - Session deletion: use `client.deleteSession()` instead of direct git/fs calls
+  - Session listing/status: via daemon instead of direct file reads
+  - Diff generation: use `client.getSessionDiff()` / `client.getSessionDiffFiles()`
+  - Insights: use `client.getSessionInsights()`
+  - Pin/unpin: use `client.pinSession()` / `client.unpinSession()`
+- Modify providers to use DaemonClient for data:
+  - `AgentSessionProvider.ts`: fetch sessions via daemon
+  - SSE events trigger tree refresh instead of file watchers
+- Tests
+
+**Key files to create:**
+- `src/vscode/services/DaemonService.ts`
+- `src/test/vscode/services/DaemonService.test.ts`
+
+**Key files to modify:**
+- `package.json` (config option)
+- `src/vscode/extension.ts` (initialization)
+- `src/vscode/commands/sessionCommands.ts` (routing)
+- `src/vscode/providers/AgentSessionProvider.ts` (data fetching)
+
+## Dependencies
+
+Task 2 depends on Task 1 (DaemonClient must exist before VS Code integration can use it).
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Single `DaemonClient` class | Mirrors the single `SessionHandlerService` — one client, one server |
+| Static factory `fromWorkspace()` | Encapsulates token/port file reading for convenience |
+| SSE with auto-reconnect | Daemon may restart; client should recover transparently |
+| Default `useDaemon: false` | Non-breaking change; users opt-in |
+| Graceful fallback | If daemon is unreachable, show error but don't crash extension |
+| Commands check for client | Simple `if (daemonClient) { ... } else { ... }` pattern in commands |

--- a/package.json
+++ b/package.json
@@ -342,6 +342,12 @@
             "default": "copy",
             "description": "How to propagate .claude/settings.local.json to worktrees. Ensures your local Claude Code configuration is available in all sessions.",
             "order": 1
+          },
+          "lanes.useDaemon": {
+            "type": "boolean",
+            "default": false,
+            "description": "Route operations through the Lanes daemon REST API instead of calling core services directly. Enable for remote UI or unified execution path scenarios.",
+            "order": 2
           }
         }
       },

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -1,0 +1,588 @@
+/**
+ * DaemonClient — Typed HTTP client for the Lanes daemon REST API + SSE events.
+ *
+ * Uses the Node.js built-in `http` module only — zero external dependencies.
+ *
+ * Authentication:
+ *   All requests (except health) include `Authorization: Bearer <token>`.
+ *
+ * Error mapping:
+ *   400 → ValidationError
+ *   401 → DaemonHttpError (auth)
+ *   404 → DaemonHttpError (not-found)
+ *   5xx → DaemonHttpError (server error)
+ */
+
+import * as http from 'http';
+import { ValidationError } from '../core/errors/ValidationError';
+import { LanesError } from '../core/errors/LanesError';
+import { getDaemonPort } from './lifecycle';
+import { readTokenFile } from './auth';
+
+// ---------------------------------------------------------------------------
+// Concrete error class for non-validation HTTP errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Error thrown by DaemonClient when the daemon returns a non-400 HTTP error.
+ */
+export class DaemonHttpError extends LanesError {
+    // Note: 'config' is used because LanesError's kind union does not yet include
+    // an HTTP/network variant. This should be revisited when the union is extended.
+    public readonly kind = 'config' as const;
+
+    /** The HTTP status code that triggered this error. */
+    public readonly statusCode: number;
+
+    constructor(statusCode: number, message: string) {
+        super(message, `Request failed with status ${statusCode}`);
+        this.name = 'DaemonHttpError';
+        this.statusCode = statusCode;
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, DaemonHttpError);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SSE subscription types
+// ---------------------------------------------------------------------------
+
+export interface SseCallbacks {
+    onSessionStatusChanged?: (data: { sessionName: string; status: unknown }) => void;
+    onFileChanged?: (data: { path: string; eventType: 'created' | 'changed' | 'deleted' }) => void;
+    onSessionCreated?: (data: { sessionName: string; worktreePath: string }) => void;
+    onSessionDeleted?: (data: { sessionName: string }) => void;
+    onError?: (err: Error) => void;
+    onConnected?: () => void;
+}
+
+export interface SseSubscription {
+    close(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal request options
+// ---------------------------------------------------------------------------
+
+interface RequestOpts {
+    body?: unknown;
+    /** Include Authorization header (default: true) */
+    auth?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// DaemonClient
+// ---------------------------------------------------------------------------
+
+export interface DaemonClientOptions {
+    port?: number;
+    baseUrl?: string;
+    token: string;
+}
+
+export class DaemonClient {
+    private readonly baseUrl: string;
+    private readonly token: string;
+
+    constructor(options: DaemonClientOptions) {
+        if (options.baseUrl !== undefined) {
+            this.baseUrl = options.baseUrl.replace(/\/$/, '');
+        } else if (options.port !== undefined) {
+            this.baseUrl = `http://127.0.0.1:${options.port}`;
+        } else {
+            throw new Error('DaemonClient requires either baseUrl or port');
+        }
+        this.token = options.token;
+    }
+
+    /**
+     * Create a DaemonClient by reading port and token from workspace files.
+     * Reads `.lanes/daemon.port` and `.lanes/daemon.token`.
+     */
+    static async fromWorkspace(workspaceRoot: string): Promise<DaemonClient> {
+        const port = await getDaemonPort(workspaceRoot);
+        if (port === undefined) {
+            throw new Error('Daemon port file not found or invalid. Is the daemon running?');
+        }
+        const token = await readTokenFile(workspaceRoot);
+        return new DaemonClient({ port, token });
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal HTTP helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Make an HTTP request and return the parsed JSON body.
+     * Handles error status codes by throwing typed errors.
+     */
+    private request<T>(
+        method: string,
+        path: string,
+        opts: RequestOpts = {}
+    ): Promise<T> {
+        const { body, auth = true } = opts;
+        const url = new URL(this.baseUrl + path);
+
+        const headers: Record<string, string> = {};
+        if (auth) {
+            headers['Authorization'] = `Bearer ${this.token}`;
+        }
+
+        const bodyStr = body !== undefined ? JSON.stringify(body) : undefined;
+        if (bodyStr !== undefined) {
+            headers['Content-Type'] = 'application/json';
+            headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
+        }
+
+        const reqOptions: http.RequestOptions = {
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname + url.search,
+            method,
+            headers,
+            timeout: 30_000,
+        };
+
+        return new Promise<T>((resolve, reject) => {
+            const req = http.request(reqOptions, (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    const raw = Buffer.concat(chunks).toString('utf-8').trim();
+
+                    let parsed: unknown;
+                    try {
+                        parsed = raw ? JSON.parse(raw) : {};
+                    } catch {
+                        parsed = {};
+                    }
+
+                    const statusCode = res.statusCode ?? 0;
+
+                    if (statusCode >= 200 && statusCode < 300) {
+                        resolve(parsed as T);
+                        return;
+                    }
+
+                    const errorMessage =
+                        parsed !== null &&
+                        typeof parsed === 'object' &&
+                        'error' in (parsed as Record<string, unknown>)
+                            ? String((parsed as Record<string, unknown>).error)
+                            : `HTTP ${statusCode}`;
+
+                    if (statusCode === 400) {
+                        reject(new ValidationError('request', '', errorMessage));
+                        return;
+                    }
+                    if (statusCode === 401) {
+                        reject(new DaemonHttpError(401, `Unauthorized: ${errorMessage}`));
+                        return;
+                    }
+                    if (statusCode === 404) {
+                        reject(new DaemonHttpError(404, `Not found: ${errorMessage}`));
+                        return;
+                    }
+                    reject(new DaemonHttpError(statusCode, `Server error: ${errorMessage}`));
+                });
+                res.on('error', reject);
+            });
+
+            req.on('error', reject);
+            req.on('timeout', () => {
+                req.destroy(new Error('Request timed out after 30s'));
+            });
+
+            if (bodyStr !== undefined) {
+                req.write(bodyStr);
+            }
+            req.end();
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Health & Discovery
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/health — no authentication required */
+    health(): Promise<{ status: string; version: string }> {
+        return this.request('GET', '/api/v1/health', { auth: false });
+    }
+
+    /** GET /api/v1/discovery */
+    discovery(): Promise<{
+        projectName: string;
+        gitRemote: string | null;
+        sessionCount: number;
+        uptime: number;
+        workspaceRoot: string;
+        port: number;
+    }> {
+        return this.request('GET', '/api/v1/discovery');
+    }
+
+    // -------------------------------------------------------------------------
+    // Sessions
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/sessions */
+    listSessions(): Promise<unknown> {
+        return this.request('GET', '/api/v1/sessions');
+    }
+
+    /** POST /api/v1/sessions */
+    createSession(opts: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', '/api/v1/sessions', { body: opts });
+    }
+
+    /** DELETE /api/v1/sessions/:name */
+    deleteSession(name: string): Promise<unknown> {
+        return this.request('DELETE', `/api/v1/sessions/${encodeURIComponent(name)}`);
+    }
+
+    /** GET /api/v1/sessions/:name/status */
+    getSessionStatus(name: string): Promise<unknown> {
+        return this.request('GET', `/api/v1/sessions/${encodeURIComponent(name)}/status`);
+    }
+
+    /** POST /api/v1/sessions/:name/open */
+    openSession(name: string, opts?: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', `/api/v1/sessions/${encodeURIComponent(name)}/open`, {
+            body: opts ?? {},
+        });
+    }
+
+    /** POST /api/v1/sessions/:name/clear */
+    clearSession(name: string): Promise<unknown> {
+        return this.request('POST', `/api/v1/sessions/${encodeURIComponent(name)}/clear`, {
+            body: {},
+        });
+    }
+
+    /** POST /api/v1/sessions/:name/pin */
+    pinSession(name: string): Promise<unknown> {
+        return this.request('POST', `/api/v1/sessions/${encodeURIComponent(name)}/pin`, {
+            body: {},
+        });
+    }
+
+    /** DELETE /api/v1/sessions/:name/pin */
+    unpinSession(name: string): Promise<unknown> {
+        return this.request('DELETE', `/api/v1/sessions/${encodeURIComponent(name)}/pin`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Insights
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/sessions/:name/insights?includeAnalysis=true|false */
+    getSessionInsights(name: string, opts?: { includeAnalysis?: boolean }): Promise<unknown> {
+        const qs =
+            opts?.includeAnalysis !== undefined
+                ? `?includeAnalysis=${opts.includeAnalysis}`
+                : '';
+        return this.request('GET', `/api/v1/sessions/${encodeURIComponent(name)}/insights${qs}`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Git Operations
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/git/branches?includeRemote=true|false */
+    listBranches(opts?: { includeRemote?: boolean }): Promise<unknown> {
+        const qs =
+            opts?.includeRemote !== undefined ? `?includeRemote=${opts.includeRemote}` : '';
+        return this.request('GET', `/api/v1/git/branches${qs}`);
+    }
+
+    /** POST /api/v1/git/repair */
+    repairWorktrees(opts?: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', '/api/v1/git/repair', { body: opts ?? {} });
+    }
+
+    /** GET /api/v1/sessions/:name/diff?includeUncommitted=true|false */
+    getSessionDiff(name: string, opts?: { includeUncommitted?: boolean }): Promise<unknown> {
+        const qs =
+            opts?.includeUncommitted !== undefined
+                ? `?includeUncommitted=${opts.includeUncommitted}`
+                : '';
+        return this.request('GET', `/api/v1/sessions/${encodeURIComponent(name)}/diff${qs}`);
+    }
+
+    /** GET /api/v1/sessions/:name/diff/files?includeUncommitted=true|false */
+    getSessionDiffFiles(name: string, opts?: { includeUncommitted?: boolean }): Promise<unknown> {
+        const qs =
+            opts?.includeUncommitted !== undefined
+                ? `?includeUncommitted=${opts.includeUncommitted}`
+                : '';
+        return this.request(
+            'GET',
+            `/api/v1/sessions/${encodeURIComponent(name)}/diff/files${qs}`
+        );
+    }
+
+    /** GET /api/v1/sessions/:name/worktree */
+    getWorktreeInfo(name: string): Promise<unknown> {
+        return this.request('GET', `/api/v1/sessions/${encodeURIComponent(name)}/worktree`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Workflows
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/workflows?includeBuiltin=true&includeCustom=true */
+    listWorkflows(opts?: { includeBuiltin?: boolean; includeCustom?: boolean }): Promise<unknown> {
+        const params: string[] = [];
+        if (opts?.includeBuiltin !== undefined) {
+            params.push(`includeBuiltin=${opts.includeBuiltin}`);
+        }
+        if (opts?.includeCustom !== undefined) {
+            params.push(`includeCustom=${opts.includeCustom}`);
+        }
+        const qs = params.length > 0 ? `?${params.join('&')}` : '';
+        return this.request('GET', `/api/v1/workflows${qs}`);
+    }
+
+    /** POST /api/v1/workflows/validate */
+    validateWorkflow(content: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', '/api/v1/workflows/validate', { body: content });
+    }
+
+    /** POST /api/v1/workflows */
+    createWorkflow(name: string, content: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', '/api/v1/workflows', { body: { name, content } });
+    }
+
+    /** GET /api/v1/sessions/:name/workflow */
+    getWorkflowState(name: string): Promise<unknown> {
+        return this.request('GET', `/api/v1/sessions/${encodeURIComponent(name)}/workflow`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Agents
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/agents */
+    listAgents(): Promise<unknown> {
+        return this.request('GET', '/api/v1/agents');
+    }
+
+    /** GET /api/v1/agents/:name */
+    getAgentConfig(name: string): Promise<unknown> {
+        return this.request('GET', `/api/v1/agents/${encodeURIComponent(name)}`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Config
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/config */
+    getAllConfig(): Promise<unknown> {
+        return this.request('GET', '/api/v1/config');
+    }
+
+    /** GET /api/v1/config/:key */
+    getConfig(key: string): Promise<unknown> {
+        return this.request('GET', `/api/v1/config/${encodeURIComponent(key)}`);
+    }
+
+    /** PUT /api/v1/config/:key */
+    setConfig(key: string, value: unknown): Promise<unknown> {
+        return this.request('PUT', `/api/v1/config/${encodeURIComponent(key)}`, {
+            body: { value },
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Terminals
+    // -------------------------------------------------------------------------
+
+    /** GET /api/v1/terminals?sessionName=optional */
+    listTerminals(opts?: { sessionName?: string }): Promise<unknown> {
+        const qs = opts?.sessionName
+            ? `?sessionName=${encodeURIComponent(opts.sessionName)}`
+            : '';
+        return this.request('GET', `/api/v1/terminals${qs}`);
+    }
+
+    /** POST /api/v1/terminals */
+    createTerminal(opts: Record<string, unknown>): Promise<unknown> {
+        return this.request('POST', '/api/v1/terminals', { body: opts });
+    }
+
+    /** POST /api/v1/terminals/:name/send */
+    sendToTerminal(name: string, text: string): Promise<unknown> {
+        return this.request('POST', `/api/v1/terminals/${encodeURIComponent(name)}/send`, {
+            body: { command: text },
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // SSE Events
+    // -------------------------------------------------------------------------
+
+    /**
+     * Subscribe to server-sent events from the daemon.
+     * Auto-reconnects on connection loss with exponential backoff.
+     * Returns an object with a `close()` method to stop listening.
+     */
+    subscribeEvents(callbacks: SseCallbacks): SseSubscription {
+        let closed = false;
+        let currentReq: http.ClientRequest | null = null;
+        let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+        let attempt = 0;
+
+        const connect = (): void => {
+            if (closed) {
+                return;
+            }
+
+            const url = new URL(this.baseUrl + '/api/v1/events');
+            const reqOptions: http.RequestOptions = {
+                hostname: url.hostname,
+                port: url.port,
+                path: url.pathname + url.search,
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${this.token}`,
+                    Accept: 'text/event-stream',
+                },
+            };
+
+            const req = http.request(reqOptions, (res) => {
+                if (res.statusCode !== 200) {
+                    // Not a valid SSE connection — consume body and schedule reconnect
+                    res.resume();
+                    callbacks.onError?.(new Error(`SSE connection failed with status ${res.statusCode}`));
+                    scheduleReconnect();
+                    return;
+                }
+
+                // Reset backoff on successful connection
+                attempt = 0;
+                callbacks.onConnected?.();
+
+                let buffer = '';
+
+                res.on('data', (chunk: Buffer) => {
+                    buffer += chunk.toString('utf-8');
+
+                    // SSE messages are separated by double newlines
+                    const messages = buffer.split('\n\n');
+                    // The last element may be an incomplete message
+                    buffer = messages.pop() ?? '';
+
+                    for (const message of messages) {
+                        if (!message.trim()) {
+                            continue;
+                        }
+
+                        let eventType = 'message';
+                        let dataLine = '';
+
+                        for (const line of message.split('\n')) {
+                            if (line.startsWith('event:')) {
+                                eventType = line.slice('event:'.length).trim();
+                            } else if (line.startsWith('data:')) {
+                                dataLine = line.slice('data:'.length).trim();
+                            }
+                        }
+
+                        if (!dataLine) {
+                            continue;
+                        }
+
+                        let parsedData: unknown;
+                        try {
+                            parsedData = JSON.parse(dataLine);
+                        } catch {
+                            continue;
+                        }
+
+                        switch (eventType) {
+                            case 'sessionStatusChanged':
+                                callbacks.onSessionStatusChanged?.(
+                                    parsedData as { sessionName: string; status: unknown }
+                                );
+                                break;
+                            case 'fileChanged':
+                                callbacks.onFileChanged?.(
+                                    parsedData as {
+                                        path: string;
+                                        eventType: 'created' | 'changed' | 'deleted';
+                                    }
+                                );
+                                break;
+                            case 'sessionCreated':
+                                callbacks.onSessionCreated?.(
+                                    parsedData as { sessionName: string; worktreePath: string }
+                                );
+                                break;
+                            case 'sessionDeleted':
+                                callbacks.onSessionDeleted?.(
+                                    parsedData as { sessionName: string }
+                                );
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+                });
+
+                res.on('error', (err) => {
+                    if (!closed) {
+                        callbacks.onError?.(err);
+                        scheduleReconnect();
+                    }
+                });
+
+                res.on('end', () => {
+                    if (!closed) {
+                        scheduleReconnect();
+                    }
+                });
+            });
+
+            req.on('error', (err) => {
+                if (!closed) {
+                    callbacks.onError?.(err);
+                    scheduleReconnect();
+                }
+            });
+
+            currentReq = req;
+            req.end();
+        };
+
+        const scheduleReconnect = (): void => {
+            if (closed) {
+                return;
+            }
+            // Exponential backoff: 1s, 2s, 4s, 8s, max 30s
+            const delayMs = Math.min(1000 * Math.pow(2, attempt), 30_000);
+            attempt++;
+            reconnectTimer = setTimeout(() => {
+                reconnectTimer = null;
+                connect();
+            }, delayMs);
+        };
+
+        connect();
+
+        return {
+            close(): void {
+                closed = true;
+                if (reconnectTimer !== null) {
+                    clearTimeout(reconnectTimer);
+                    reconnectTimer = null;
+                }
+                if (currentReq !== null) {
+                    currentReq.destroy();
+                    currentReq = null;
+                }
+            },
+        };
+    }
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -32,3 +32,5 @@ export {
     listRegisteredDaemons,
     cleanStaleEntries,
 } from './registry';
+export type { DaemonClientOptions, SseCallbacks, SseSubscription } from './client';
+export { DaemonClient, DaemonHttpError } from './client';

--- a/src/test/daemon/client.test.ts
+++ b/src/test/daemon/client.test.ts
@@ -1,0 +1,1359 @@
+/**
+ * Tests for DaemonClient — the typed HTTP client for the Lanes daemon REST API.
+ *
+ * Covers:
+ *  - Constructor with port option
+ *  - Constructor with baseUrl option (trailing slash stripped)
+ *  - Constructor throws when neither port nor baseUrl is given
+ *  - fromWorkspace() static factory reads daemon.port and daemon.token files
+ *  - fromWorkspace() throws when port file is absent
+ *  - health() sends GET /api/v1/health without Authorization header
+ *  - All other methods include Authorization: Bearer <token>
+ *  - listSessions() GET /api/v1/sessions
+ *  - createSession() POST /api/v1/sessions with body
+ *  - deleteSession() DELETE /api/v1/sessions/:name with URI encoding
+ *  - getSessionStatus() GET /api/v1/sessions/:name/status
+ *  - openSession() POST /api/v1/sessions/:name/open
+ *  - clearSession() POST /api/v1/sessions/:name/clear
+ *  - pinSession() POST /api/v1/sessions/:name/pin
+ *  - unpinSession() DELETE /api/v1/sessions/:name/pin
+ *  - getSessionInsights() with and without includeAnalysis query param
+ *  - listBranches() with includeRemote query param
+ *  - repairWorktrees() POST /api/v1/git/repair
+ *  - getSessionDiff() with query param
+ *  - getSessionDiffFiles() with query param
+ *  - getWorktreeInfo()
+ *  - listWorkflows() with query params
+ *  - validateWorkflow()
+ *  - createWorkflow()
+ *  - getWorkflowState()
+ *  - listAgents()
+ *  - getAgentConfig() with URI encoding
+ *  - getAllConfig()
+ *  - getConfig() with URI encoding
+ *  - setConfig() PUT with body
+ *  - listTerminals() with optional sessionName query param
+ *  - createTerminal()
+ *  - sendToTerminal() with body
+ *  - HTTP 400 → ValidationError
+ *  - HTTP 401 → DaemonHttpError (statusCode 401)
+ *  - HTTP 404 → DaemonHttpError (statusCode 404)
+ *  - HTTP 500 → DaemonHttpError (statusCode 500)
+ *  - HTTP error message extracted from JSON body { error: '...' }
+ *  - HTTP error falls back to 'HTTP <statusCode>' when no error field
+ *  - subscribeEvents() connects to /api/v1/events, fires onConnected
+ *  - subscribeEvents() parses SSE events and calls the right callback
+ *  - subscribeEvents() close() destroys the connection
+ */
+
+import * as assert from 'assert';
+import * as http from 'http';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DaemonClient, DaemonHttpError } from '../../daemon/client';
+import { ValidationError } from '../../core/errors/ValidationError';
+
+// ---------------------------------------------------------------------------
+// Helper: create a minimal HTTP server that records requests and returns a
+// pre-configured response.
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string;
+    url: string;
+    headers: http.IncomingHttpHeaders;
+    body: string;
+}
+
+interface ServerResponse {
+    status: number;
+    body: unknown;
+    /** Optional raw body (overrides body when set) */
+    rawBody?: string;
+    /** Extra headers to include */
+    headers?: Record<string, string>;
+}
+
+function createTestServer(responseFactory: (req: CapturedRequest) => ServerResponse): {
+    server: http.Server;
+    captured: CapturedRequest[];
+    close: () => Promise<void>;
+    port: () => number;
+} {
+    const captured: CapturedRequest[] = [];
+
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => {
+            const capturedReq: CapturedRequest = {
+                method: req.method ?? 'GET',
+                url: req.url ?? '/',
+                headers: req.headers,
+                body: Buffer.concat(chunks).toString('utf-8'),
+            };
+            captured.push(capturedReq);
+
+            const response = responseFactory(capturedReq);
+
+            const extraHeaders = response.headers ?? {};
+            res.writeHead(response.status, {
+                'Content-Type': 'application/json',
+                ...extraHeaders,
+            });
+
+            if (response.rawBody !== undefined) {
+                res.end(response.rawBody);
+            } else {
+                res.end(JSON.stringify(response.body));
+            }
+        });
+    });
+
+    return {
+        server,
+        captured,
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((err) => (err ? reject(err) : resolve()))
+            ),
+        port: () => (server.address() as { port: number }).port,
+    };
+}
+
+/** Start the server on a random port and return the helper. */
+async function startTestServer(
+    responseFactory: (req: CapturedRequest) => ServerResponse
+): Promise<ReturnType<typeof createTestServer>> {
+    const helper = createTestServer(responseFactory);
+    await new Promise<void>((resolve) => helper.server.listen(0, '127.0.0.1', resolve));
+    return helper;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make a client pointing at the test server
+// ---------------------------------------------------------------------------
+
+const TEST_TOKEN = 'test-bearer-token-xyz';
+
+function makeClient(port: number): DaemonClient {
+    return new DaemonClient({ port, token: TEST_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: decode a `?a=1&b=2` query string into an object
+// ---------------------------------------------------------------------------
+
+function parseQs(url: string): Record<string, string> {
+    const idx = url.indexOf('?');
+    if (idx === -1) {
+        return {};
+    }
+    const qs = url.slice(idx + 1);
+    const result: Record<string, string> = {};
+    for (const part of qs.split('&')) {
+        const [k, v] = part.split('=');
+        result[decodeURIComponent(k)] = decodeURIComponent(v ?? '');
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Suite: DaemonClient constructor
+// ---------------------------------------------------------------------------
+
+suite('DaemonClient', () => {
+    // -------------------------------------------------------------------------
+    // daemon-client-constructor-port
+    // -------------------------------------------------------------------------
+
+    test('Given port=3000 and token, when constructing DaemonClient, then the client makes requests to http://127.0.0.1:3000', async () => {
+        // We verify this indirectly by connecting to a server on port 3000 range.
+        const helper = await startTestServer(() => ({ status: 200, body: { status: 'ok', version: '1' } }));
+        try {
+            const client = new DaemonClient({ port: helper.port(), token: TEST_TOKEN });
+            await client.health();
+            assert.strictEqual(helper.captured.length, 1, 'One request should be made');
+        } finally {
+            await helper.close();
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-constructor-baseurl
+    // -------------------------------------------------------------------------
+
+    test('Given baseUrl with trailing slash, when constructing DaemonClient, then trailing slash is stripped from requests', async () => {
+        const helper = await startTestServer(() => ({ status: 200, body: { status: 'ok', version: '1' } }));
+        try {
+            // The baseUrl points at our test server
+            const client = new DaemonClient({
+                baseUrl: `http://127.0.0.1:${helper.port()}/`,
+                token: TEST_TOKEN,
+            });
+            await client.health();
+            // URL should be /api/v1/health, not //api/v1/health
+            assert.ok(
+                helper.captured[0].url === '/api/v1/health',
+                `Expected /api/v1/health but got ${helper.captured[0].url}`
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+
+    test('Given neither port nor baseUrl, when constructing DaemonClient, then it throws', () => {
+        assert.throws(
+            () => new DaemonClient({ token: TEST_TOKEN } as never),
+            /requires either baseUrl or port/i
+        );
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-from-workspace
+    // -------------------------------------------------------------------------
+
+    suite('fromWorkspace()', () => {
+        let tempDir: string;
+
+        setup(() => {
+            tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-client-test-'));
+        });
+
+        teardown(() => {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        });
+
+        test('Given daemon.port and daemon.token in .lanes/, when fromWorkspace is called, then DaemonClient is constructed', async () => {
+            // Arrange
+            const lanesDir = path.join(tempDir, '.lanes');
+            fs.mkdirSync(lanesDir, { recursive: true });
+            fs.writeFileSync(path.join(lanesDir, 'daemon.port'), '9876', 'utf-8');
+            fs.writeFileSync(path.join(lanesDir, 'daemon.token'), 'workspace-token-abc', 'utf-8');
+
+            // Act
+            const client = await DaemonClient.fromWorkspace(tempDir);
+
+            // Assert — client should be a DaemonClient instance
+            assert.ok(client instanceof DaemonClient, 'fromWorkspace should return a DaemonClient');
+        });
+
+        test('Given no daemon.port file, when fromWorkspace is called, then it throws', async () => {
+            // Arrange: only create the token file (no port file)
+            const lanesDir = path.join(tempDir, '.lanes');
+            fs.mkdirSync(lanesDir, { recursive: true });
+            fs.writeFileSync(path.join(lanesDir, 'daemon.token'), 'some-token', 'utf-8');
+
+            // Act & Assert
+            let thrown: unknown;
+            try {
+                await DaemonClient.fromWorkspace(tempDir);
+            } catch (err) {
+                thrown = err;
+            }
+            assert.ok(thrown instanceof Error, 'fromWorkspace should throw when port file is absent');
+            assert.ok(
+                (thrown as Error).message.includes('Daemon port file not found'),
+                'Error message should mention the port file'
+            );
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-health
+    // -------------------------------------------------------------------------
+
+    suite('health()', () => {
+        test('Given a mock server, when health() is called, then a GET request is sent to /api/v1/health', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { status: 'ok', version: '1.0.0' },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                await client.health();
+
+                assert.strictEqual(helper.captured.length, 1);
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/health');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given health() is called, then no Authorization header is included', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { status: 'ok', version: '1.0.0' },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                await client.health();
+
+                assert.strictEqual(helper.captured[0].headers['authorization'], undefined);
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given a 200 response, when health() resolves, then the result matches the response body', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { status: 'ok', version: '2.1.0' },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                const result = await client.health();
+
+                assert.deepStrictEqual(result, { status: 'ok', version: '2.1.0' });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-auth-header
+    // -------------------------------------------------------------------------
+
+    suite('Authorization header', () => {
+        test('Given token="mytoken", when listSessions() is called, then Authorization: Bearer mytoken header is included', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { sessions: [] } }));
+            try {
+                const client = new DaemonClient({ port: helper.port(), token: 'mytoken' });
+                await client.listSessions();
+
+                assert.strictEqual(
+                    helper.captured[0].headers['authorization'],
+                    'Bearer mytoken'
+                );
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given a token, when discovery() is called, then Authorization header is present', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: {
+                    projectName: 'test',
+                    gitRemote: null,
+                    sessionCount: 0,
+                    uptime: 100,
+                    workspaceRoot: '/tmp',
+                    port: 1234,
+                },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                await client.discovery();
+
+                assert.ok(
+                    helper.captured[0].headers['authorization']?.startsWith('Bearer '),
+                    'Authorization header should start with Bearer'
+                );
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-list-sessions
+    // -------------------------------------------------------------------------
+
+    suite('listSessions()', () => {
+        test('Given a mock server, when listSessions() is called, then GET /api/v1/sessions is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { sessions: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listSessions();
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given a 200 response with session list, when listSessions() resolves, then the result matches the response body', async () => {
+            const responseBody = { sessions: [{ name: 'feat-a' }, { name: 'feat-b' }] };
+            const helper = await startTestServer(() => ({ status: 200, body: responseBody }));
+            try {
+                const client = makeClient(helper.port());
+                const result = await client.listSessions();
+
+                assert.deepStrictEqual(result, responseBody);
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-create-session
+    // -------------------------------------------------------------------------
+
+    suite('createSession()', () => {
+        test('Given opts, when createSession() is called, then POST /api/v1/sessions is made with that body', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { sessionName: 'test' },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                const opts = { sessionName: 'test', agentName: 'claude' };
+                await client.createSession(opts);
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), opts);
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given a 200 response, when createSession() resolves, then the result matches the response body', async () => {
+            const responseBody = { sessionName: 'test', worktreePath: '/tmp/test' };
+            const helper = await startTestServer(() => ({ status: 200, body: responseBody }));
+            try {
+                const client = makeClient(helper.port());
+                const result = await client.createSession({ sessionName: 'test', agentName: 'claude' });
+
+                assert.deepStrictEqual(result, responseBody);
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-delete-session
+    // -------------------------------------------------------------------------
+
+    suite('deleteSession()', () => {
+        test('Given session name "my session", when deleteSession() is called, then DELETE /api/v1/sessions/my%20session is requested', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { success: true },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                await client.deleteSession('my session');
+
+                assert.strictEqual(helper.captured[0].method, 'DELETE');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my%20session');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given a 200 response, when deleteSession() resolves, then the result matches the response body', async () => {
+            const responseBody = { success: true };
+            const helper = await startTestServer(() => ({ status: 200, body: responseBody }));
+            try {
+                const client = makeClient(helper.port());
+                const result = await client.deleteSession('test-session');
+
+                assert.deepStrictEqual(result, responseBody);
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Session-level endpoints
+    // -------------------------------------------------------------------------
+
+    suite('getSessionStatus()', () => {
+        test('Given session name, when getSessionStatus() is called, then GET /api/v1/sessions/:name/status is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { status: 'idle' } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionStatus('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/status');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('openSession()', () => {
+        test('Given session name, when openSession() is called, then POST /api/v1/sessions/:name/open is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.openSession('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/open');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given session name and opts, when openSession() is called, then opts are sent as body', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.openSession('my-session', { newWindow: true });
+
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { newWindow: true });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('clearSession()', () => {
+        test('Given session name, when clearSession() is called, then POST /api/v1/sessions/:name/clear is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.clearSession('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/clear');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('pinSession() / unpinSession()', () => {
+        test('Given session name, when pinSession() is called, then POST /api/v1/sessions/:name/pin is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.pinSession('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/pin');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given session name, when unpinSession() is called, then DELETE /api/v1/sessions/:name/pin is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.unpinSession('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'DELETE');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/pin');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-session-insights
+    // -------------------------------------------------------------------------
+
+    suite('getSessionInsights()', () => {
+        test('Given opts.includeAnalysis=false, when getSessionInsights() is called, then URL includes ?includeAnalysis=false', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { insights: null } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionInsights('my-session', { includeAnalysis: false });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['includeAnalysis'], 'false');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given opts.includeAnalysis=true, when getSessionInsights() is called, then URL includes ?includeAnalysis=true', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { insights: null } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionInsights('my-session', { includeAnalysis: true });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['includeAnalysis'], 'true');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given no opts, when getSessionInsights() is called, then URL does not include includeAnalysis query param', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { insights: null } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionInsights('my-session');
+
+                assert.ok(
+                    !helper.captured[0].url.includes('includeAnalysis'),
+                    'URL should not include includeAnalysis when no opts given'
+                );
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Git endpoints
+    // -------------------------------------------------------------------------
+
+    suite('listBranches()', () => {
+        test('Given opts.includeRemote=true, when listBranches() is called, then URL includes ?includeRemote=true', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { branches: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listBranches({ includeRemote: true });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['includeRemote'], 'true');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given no opts, when listBranches() is called, then GET /api/v1/git/branches is requested without query string', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { branches: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listBranches();
+
+                assert.strictEqual(helper.captured[0].url, '/api/v1/git/branches');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('repairWorktrees()', () => {
+        test('Given a call to repairWorktrees(), then POST /api/v1/git/repair is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { repaired: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.repairWorktrees();
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/git/repair');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getSessionDiff()', () => {
+        test('Given opts.includeUncommitted=true, when getSessionDiff() is called, then URL includes ?includeUncommitted=true', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { diff: '' } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionDiff('feat', { includeUncommitted: true });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['includeUncommitted'], 'true');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getSessionDiffFiles()', () => {
+        test('Given a session name, when getSessionDiffFiles() is called, then GET /api/v1/sessions/:name/diff/files is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { files: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getSessionDiffFiles('feat-session');
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.ok(helper.captured[0].url.startsWith('/api/v1/sessions/feat-session/diff/files'));
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getWorktreeInfo()', () => {
+        test('Given a session name, when getWorktreeInfo() is called, then GET /api/v1/sessions/:name/worktree is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { path: '/tmp' } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getWorktreeInfo('my-session');
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/worktree');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Workflow endpoints
+    // -------------------------------------------------------------------------
+
+    suite('listWorkflows()', () => {
+        test('Given opts with both flags, when listWorkflows() is called, then URL includes both query params', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { workflows: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listWorkflows({ includeBuiltin: true, includeCustom: false });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['includeBuiltin'], 'true');
+                assert.strictEqual(qs['includeCustom'], 'false');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given no opts, when listWorkflows() is called, then GET /api/v1/workflows is requested without query string', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { workflows: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listWorkflows();
+
+                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('validateWorkflow()', () => {
+        test('Given workflow content, when validateWorkflow() is called, then POST /api/v1/workflows/validate is made with body', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { valid: true } }));
+            try {
+                const client = makeClient(helper.port());
+                const content = { name: 'my-workflow', steps: [] };
+                await client.validateWorkflow(content);
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows/validate');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), content);
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('createWorkflow()', () => {
+        test('Given name and content, when createWorkflow() is called, then POST /api/v1/workflows is made with { name, content }', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.createWorkflow('my-wf', { steps: ['a', 'b'] });
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), {
+                    name: 'my-wf',
+                    content: { steps: ['a', 'b'] },
+                });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getWorkflowState()', () => {
+        test('Given session name, when getWorkflowState() is called, then GET /api/v1/sessions/:name/workflow is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { state: null } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getWorkflowState('wf-session');
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/wf-session/workflow');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Agent endpoints
+    // -------------------------------------------------------------------------
+
+    suite('listAgents()', () => {
+        test('Given a call to listAgents(), then GET /api/v1/agents is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { agents: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listAgents();
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/agents');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getAgentConfig()', () => {
+        test('Given agent name with special chars, when getAgentConfig() is called, then name is URI-encoded in the URL', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { config: {} } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getAgentConfig('claude code');
+
+                assert.strictEqual(helper.captured[0].url, '/api/v1/agents/claude%20code');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Config endpoints
+    // -------------------------------------------------------------------------
+
+    suite('getAllConfig()', () => {
+        test('Given a call to getAllConfig(), then GET /api/v1/config is made', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { config: {} } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getAllConfig();
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/config');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('getConfig()', () => {
+        test('Given key with special chars, when getConfig() is called, then key is URI-encoded in the URL', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { value: 'claude' } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.getConfig('lanes.agent/name');
+
+                assert.strictEqual(helper.captured[0].url, '/api/v1/config/lanes.agent%2Fname');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('setConfig()', () => {
+        test('Given key and value, when setConfig() is called, then PUT /api/v1/config/:key is made with { value }', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.setConfig('agentName', 'claude');
+
+                assert.strictEqual(helper.captured[0].method, 'PUT');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/config/agentName');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { value: 'claude' });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Terminal endpoints
+    // -------------------------------------------------------------------------
+
+    suite('listTerminals()', () => {
+        test('Given no opts, when listTerminals() is called, then GET /api/v1/terminals is requested without query string', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { terminals: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listTerminals();
+
+                assert.strictEqual(helper.captured[0].method, 'GET');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals');
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given opts.sessionName, when listTerminals() is called, then sessionName is URI-encoded in query string', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { terminals: [] } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.listTerminals({ sessionName: 'my session' });
+
+                const qs = parseQs(helper.captured[0].url);
+                assert.strictEqual(qs['sessionName'], 'my session');
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('createTerminal()', () => {
+        test('Given opts, when createTerminal() is called, then POST /api/v1/terminals is made with body', async () => {
+            const helper = await startTestServer(() => ({
+                status: 200,
+                body: { terminalName: 'term-1' },
+            }));
+            try {
+                const client = makeClient(helper.port());
+                await client.createTerminal({ sessionName: 'feat', shell: 'bash' });
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), {
+                    sessionName: 'feat',
+                    shell: 'bash',
+                });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
+    suite('sendToTerminal()', () => {
+        test('Given name and text, when sendToTerminal() is called, then POST /api/v1/terminals/:name/send is made with { command: text }', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
+            try {
+                const client = makeClient(helper.port());
+                await client.sendToTerminal('term-1', 'ls -la');
+
+                assert.strictEqual(helper.captured[0].method, 'POST');
+                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals/term-1/send');
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { command: 'ls -la' });
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: DaemonClient error handling
+// ---------------------------------------------------------------------------
+
+suite('DaemonClient error handling', () => {
+    // -------------------------------------------------------------------------
+    // daemon-client-error-400
+    // -------------------------------------------------------------------------
+
+    test('Given a 400 response with { error: "bad input" }, when any method is called, then a ValidationError is thrown with the server error message', async () => {
+        const helper = await startTestServer(() => ({
+            status: 400,
+            body: { error: 'bad input' },
+        }));
+        try {
+            const client = makeClient(helper.port());
+
+            let thrown: unknown;
+            try {
+                await client.listSessions();
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(thrown instanceof ValidationError, 'Should throw a ValidationError for 400');
+            assert.ok(
+                (thrown as ValidationError).message.includes('bad input'),
+                'Error message should contain the server error message'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-error-401
+    // -------------------------------------------------------------------------
+
+    test('Given a 401 response, when any method is called, then a DaemonHttpError is thrown with statusCode 401', async () => {
+        const helper = await startTestServer(() => ({
+            status: 401,
+            body: { error: 'Unauthorized' },
+        }));
+        try {
+            const client = makeClient(helper.port());
+
+            let thrown: unknown;
+            try {
+                await client.listSessions();
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(thrown instanceof DaemonHttpError, 'Should throw a DaemonHttpError for 401');
+            assert.strictEqual((thrown as DaemonHttpError).statusCode, 401);
+            assert.ok(
+                (thrown as DaemonHttpError).message.toLowerCase().includes('unauthorized'),
+                'Error message should contain auth-related text'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-error-404
+    // -------------------------------------------------------------------------
+
+    test('Given a 404 response with { error: "not found" }, when any method is called, then a DaemonHttpError is thrown with statusCode 404', async () => {
+        const helper = await startTestServer(() => ({
+            status: 404,
+            body: { error: 'not found' },
+        }));
+        try {
+            const client = makeClient(helper.port());
+
+            let thrown: unknown;
+            try {
+                await client.listSessions();
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(thrown instanceof DaemonHttpError, 'Should throw a DaemonHttpError for 404');
+            assert.strictEqual((thrown as DaemonHttpError).statusCode, 404);
+        } finally {
+            await helper.close();
+        }
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-client-error-500
+    // -------------------------------------------------------------------------
+
+    test('Given a 500 response with { error: "server error" }, when any method is called, then a DaemonHttpError is thrown with statusCode 500', async () => {
+        const helper = await startTestServer(() => ({
+            status: 500,
+            body: { error: 'server error' },
+        }));
+        try {
+            const client = makeClient(helper.port());
+
+            let thrown: unknown;
+            try {
+                await client.listSessions();
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(thrown instanceof DaemonHttpError, 'Should throw a DaemonHttpError for 500');
+            assert.strictEqual((thrown as DaemonHttpError).statusCode, 500);
+            assert.ok(
+                (thrown as DaemonHttpError).message.includes('server error'),
+                'Error message should contain the server error text'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+
+    test('Given a 503 response with no error field in body, when any method is called, then DaemonHttpError message falls back to "HTTP 503"', async () => {
+        const helper = await startTestServer(() => ({
+            status: 503,
+            body: { message: 'service unavailable' }, // no "error" key
+        }));
+        try {
+            const client = makeClient(helper.port());
+
+            let thrown: unknown;
+            try {
+                await client.listSessions();
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(thrown instanceof DaemonHttpError, 'Should throw DaemonHttpError');
+            assert.ok(
+                (thrown as DaemonHttpError).message.includes('HTTP 503'),
+                `Expected "HTTP 503" in message but got: ${(thrown as DaemonHttpError).message}`
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: DaemonClient SSE
+// ---------------------------------------------------------------------------
+
+suite('DaemonClient SSE', () => {
+    // -------------------------------------------------------------------------
+    // daemon-client-subscribe-events
+    // -------------------------------------------------------------------------
+
+    test('Given a mock SSE server, when subscribeEvents() is called, then a GET request to /api/v1/events is made', (done) => {
+        // Create a minimal SSE server that closes immediately after receiving the request
+        const server = http.createServer((req, res) => {
+            if (req.url === '/api/v1/events') {
+                res.writeHead(200, {
+                    'Content-Type': 'text/event-stream',
+                    'Cache-Control': 'no-cache',
+                    Connection: 'keep-alive',
+                });
+                // Record and then end (simulating a quick disconnect)
+                res.end();
+            } else {
+                res.writeHead(404);
+                res.end();
+            }
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            let requestReceived = false;
+
+            // Override our check using the server request event
+            server.once('request', (req) => {
+                requestReceived = true;
+                assert.strictEqual(req.method, 'GET');
+                assert.strictEqual(req.url, '/api/v1/events');
+            });
+
+            const sub = client.subscribeEvents({
+                onConnected: () => {
+                    // Close to avoid reconnect loops
+                    sub.close();
+                },
+                onError: () => {
+                    // After close, reconnect is suppressed
+                },
+            });
+
+            // Allow time for the request to reach the server and be verified
+            setTimeout(() => {
+                sub.close();
+                server.close(() => {
+                    assert.ok(requestReceived, 'A request to /api/v1/events should have been made');
+                    done();
+                });
+            }, 500);
+        });
+    });
+
+    test('Given a subscribeEvents() call, when close() is called on the returned handle, then the connection is terminated', (done) => {
+        // Server that keeps the SSE stream open
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            // Keep the connection open - we rely on close() to destroy it
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            const sub = client.subscribeEvents({});
+
+            // Give the connection time to establish then close it
+            setTimeout(() => {
+                // close() should not throw
+                assert.doesNotThrow(() => sub.close());
+
+                server.close(done);
+            }, 100);
+        });
+    });
+
+    test('Given an SSE event "sessionStatusChanged", when the server emits it, then onSessionStatusChanged callback is called', (done) => {
+        const eventData = { sessionName: 'feat-a', status: 'working' };
+
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            // Send a sessionStatusChanged event then end
+            res.write(`event: sessionStatusChanged\ndata: ${JSON.stringify(eventData)}\n\n`);
+            res.end();
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            let callbackCalled = false;
+
+            const sub = client.subscribeEvents({
+                onSessionStatusChanged: (data) => {
+                    callbackCalled = true;
+                    assert.deepStrictEqual(data, eventData);
+                    sub.close();
+                    server.close(done);
+                },
+                onError: () => {
+                    // suppress reconnect errors after close
+                },
+            });
+
+            // Timeout guard
+            setTimeout(() => {
+                if (!callbackCalled) {
+                    sub.close();
+                    server.close(() => {
+                        done(new Error('onSessionStatusChanged was not called within timeout'));
+                    });
+                }
+            }, 2000);
+        });
+    });
+
+    test('Given an SSE event "sessionCreated", when the server emits it, then onSessionCreated callback is called', (done) => {
+        const eventData = { sessionName: 'new-session', worktreePath: '/tmp/new-session' };
+
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            res.write(`event: sessionCreated\ndata: ${JSON.stringify(eventData)}\n\n`);
+            res.end();
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            let callbackCalled = false;
+
+            const sub = client.subscribeEvents({
+                onSessionCreated: (data) => {
+                    callbackCalled = true;
+                    assert.deepStrictEqual(data, eventData);
+                    sub.close();
+                    server.close(done);
+                },
+                onError: () => {},
+            });
+
+            setTimeout(() => {
+                if (!callbackCalled) {
+                    sub.close();
+                    server.close(() => {
+                        done(new Error('onSessionCreated was not called within timeout'));
+                    });
+                }
+            }, 2000);
+        });
+    });
+
+    test('Given an SSE event "sessionDeleted", when the server emits it, then onSessionDeleted callback is called', (done) => {
+        const eventData = { sessionName: 'old-session' };
+
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            res.write(`event: sessionDeleted\ndata: ${JSON.stringify(eventData)}\n\n`);
+            res.end();
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            let callbackCalled = false;
+
+            const sub = client.subscribeEvents({
+                onSessionDeleted: (data) => {
+                    callbackCalled = true;
+                    assert.deepStrictEqual(data, eventData);
+                    sub.close();
+                    server.close(done);
+                },
+                onError: () => {},
+            });
+
+            setTimeout(() => {
+                if (!callbackCalled) {
+                    sub.close();
+                    server.close(() => {
+                        done(new Error('onSessionDeleted was not called within timeout'));
+                    });
+                }
+            }, 2000);
+        });
+    });
+
+    test('Given an SSE event "fileChanged", when the server emits it, then onFileChanged callback is called', (done) => {
+        const eventData = { path: '/src/foo.ts', eventType: 'changed' as const };
+
+        const server = http.createServer((_req, res) => {
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            res.write(`event: fileChanged\ndata: ${JSON.stringify(eventData)}\n\n`);
+            res.end();
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: TEST_TOKEN });
+
+            let callbackCalled = false;
+
+            const sub = client.subscribeEvents({
+                onFileChanged: (data) => {
+                    callbackCalled = true;
+                    assert.deepStrictEqual(data, eventData);
+                    sub.close();
+                    server.close(done);
+                },
+                onError: () => {},
+            });
+
+            setTimeout(() => {
+                if (!callbackCalled) {
+                    sub.close();
+                    server.close(() => {
+                        done(new Error('onFileChanged was not called within timeout'));
+                    });
+                }
+            }, 2000);
+        });
+    });
+
+    test('Given subscribeEvents(), when the SSE connection emits an Authorization header, then it matches the token', (done) => {
+        let authHeader: string | undefined;
+
+        const server = http.createServer((req, res) => {
+            authHeader = req.headers['authorization'];
+            res.writeHead(200, {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+            });
+            res.end();
+        });
+
+        server.listen(0, '127.0.0.1', () => {
+            const port = (server.address() as { port: number }).port;
+            const client = new DaemonClient({ port, token: 'sse-token-test' });
+
+            const sub = client.subscribeEvents({
+                onConnected: () => {
+                    sub.close();
+                },
+                onError: () => {},
+            });
+
+            setTimeout(() => {
+                sub.close();
+                server.close(() => {
+                    assert.strictEqual(authHeader, 'Bearer sse-token-test');
+                    done();
+                });
+            }, 500);
+        });
+    });
+});

--- a/src/test/vscode/services/DaemonService.test.ts
+++ b/src/test/vscode/services/DaemonService.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for DaemonService — VS Code daemon lifecycle manager.
+ *
+ * Covers:
+ *  - initialize() starts daemon when not running
+ *  - initialize() skips startDaemon when daemon is already running
+ *  - initialize() SSE events trigger onRefresh callback
+ *  - dispose() closes the SSE subscription and resets client
+ *  - initialize() handles daemon startup failure gracefully
+ *  - isEnabled() returns false before init and true after successful init
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import sinon from 'sinon';
+import { DaemonService } from '../../../vscode/services/DaemonService';
+import * as lifecycle from '../../../daemon/lifecycle';
+import * as clientModule from '../../../daemon/client';
+import type { SseCallbacks, SseSubscription } from '../../../daemon/client';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Write fake daemon PID/port/token files to simulate a running daemon. */
+function writeFakeDaemonFiles(workspaceRoot: string, pid: number, port: number): void {
+    const lanesDir = path.join(workspaceRoot, '.lanes');
+    fs.mkdirSync(lanesDir, { recursive: true });
+    fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), String(pid), 'utf-8');
+    fs.writeFileSync(path.join(lanesDir, 'daemon.port'), String(port), 'utf-8');
+    fs.writeFileSync(path.join(lanesDir, 'daemon.token'), 'test-token-123', 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+suite('DaemonService', () => {
+    let tempDir: string;
+    let onRefreshStub: sinon.SinonSpy;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-daemon-service-test-'));
+        onRefreshStub = sinon.spy();
+    });
+
+    teardown(() => {
+        sinon.restore();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-reuse-running-daemon
+    // -------------------------------------------------------------------------
+
+    test('Given daemon is already running, when initialize() is called, then startDaemon is NOT invoked', async () => {
+        // Arrange: write fake daemon files and stub isDaemonRunning to return true
+        writeFakeDaemonFiles(tempDir, process.pid, 4299);
+        const isDaemonRunningStub = sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+        const startDaemonStub = sinon.stub(lifecycle, 'startDaemon').resolves();
+
+        // Stub DaemonClient.fromWorkspace to return a minimal mock client
+        const fakeClient = {
+            subscribeEvents: sinon.stub().returns({ close: () => {} }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        // Act
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+
+        // Assert
+        assert.ok(isDaemonRunningStub.calledOnce, 'isDaemonRunning should be checked');
+        assert.ok(startDaemonStub.notCalled, 'startDaemon should NOT be called when daemon is already running');
+        assert.ok(service.isEnabled(), 'service should be enabled after successful init');
+
+        service.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-initialize-starts-daemon
+    // -------------------------------------------------------------------------
+
+    test('Given daemon is not running, when initialize() is called, then startDaemon is invoked with correct options', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(false);
+        const startDaemonStub = sinon.stub(lifecycle, 'startDaemon').resolves();
+        // getDaemonPort returns a valid port immediately on first poll
+        sinon.stub(lifecycle, 'getDaemonPort').resolves(4300);
+
+        const fakeClient = {
+            subscribeEvents: sinon.stub().returns({ close: () => {} }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const extensionPath = '/fake/extension';
+
+        // Act
+        const service = new DaemonService(tempDir, extensionPath, onRefreshStub);
+        await service.initialize();
+
+        // Assert
+        assert.ok(startDaemonStub.calledOnce, 'startDaemon should be called when daemon is not running');
+        const callArgs = startDaemonStub.firstCall.args[0] as lifecycle.StartDaemonOptions;
+        assert.strictEqual(callArgs.workspaceRoot, tempDir, 'workspaceRoot should match');
+        const expectedServerPath = path.join(extensionPath, 'out', 'daemon', 'server.js');
+        assert.strictEqual(callArgs.serverPath, expectedServerPath, 'serverPath should point to bundled server');
+        assert.ok(service.getClient() !== undefined, 'getClient() should return a client after successful init');
+
+        service.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-sse-triggers-refresh
+    // -------------------------------------------------------------------------
+
+    test('Given an active SSE subscription, when sessionCreated event fires, then onRefresh is called', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        let capturedCallbacks: SseCallbacks = {};
+        const fakeClient = {
+            subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
+                capturedCallbacks = callbacks;
+                return { close: () => {} };
+            }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+
+        // Act: simulate SSE event
+        capturedCallbacks.onSessionCreated?.({ sessionName: 'test', worktreePath: '/tmp/test' });
+
+        // Assert
+        assert.ok(onRefreshStub.calledOnce, 'onRefresh should be called when sessionCreated event fires');
+
+        service.dispose();
+    });
+
+    test('Given an active SSE subscription, when sessionDeleted event fires, then onRefresh is called', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        let capturedCallbacks: SseCallbacks = {};
+        const fakeClient = {
+            subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
+                capturedCallbacks = callbacks;
+                return { close: () => {} };
+            }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+
+        // Act
+        capturedCallbacks.onSessionDeleted?.({ sessionName: 'test' });
+
+        // Assert
+        assert.ok(onRefreshStub.calledOnce, 'onRefresh should be called when sessionDeleted event fires');
+
+        service.dispose();
+    });
+
+    test('Given an active SSE subscription, when sessionStatusChanged event fires, then onRefresh is called', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        let capturedCallbacks: SseCallbacks = {};
+        const fakeClient = {
+            subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
+                capturedCallbacks = callbacks;
+                return { close: () => {} };
+            }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+
+        // Act
+        capturedCallbacks.onSessionStatusChanged?.({ sessionName: 'test', status: 'working' });
+
+        // Assert
+        assert.ok(onRefreshStub.calledOnce, 'onRefresh should be called when sessionStatusChanged event fires');
+
+        service.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-dispose-closes-sse
+    // -------------------------------------------------------------------------
+
+    test('Given an active SSE subscription, when dispose() is called, then subscription.close() is invoked', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        let closeCalled = false;
+        const fakeSubscription: SseSubscription = { close: () => { closeCalled = true; } };
+        const fakeClient = {
+            subscribeEvents: sinon.stub().returns(fakeSubscription),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+        assert.ok(service.isEnabled(), 'service should be enabled before dispose');
+
+        // Act
+        service.dispose();
+
+        // Assert
+        assert.ok(closeCalled, 'SSE subscription.close() should be called on dispose()');
+        assert.strictEqual(service.getClient(), undefined, 'getClient() should return undefined after dispose()');
+        assert.strictEqual(service.isEnabled(), false, 'isEnabled() should return false after dispose()');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-graceful-error
+    // -------------------------------------------------------------------------
+
+    test('Given startDaemon throws, when initialize() is called, then error is handled gracefully', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(false);
+        sinon.stub(lifecycle, 'startDaemon').rejects(new Error('startDaemon failed'));
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+
+        // Act: should not throw
+        await assert.doesNotReject(async () => {
+            await service.initialize();
+        }, 'initialize() should not throw even if daemon fails to start');
+
+        // Assert
+        assert.strictEqual(service.getClient(), undefined, 'getClient() should be undefined after failed init');
+        assert.strictEqual(service.isEnabled(), false, 'isEnabled() should be false after failed init');
+    });
+
+    test('Given DaemonClient.fromWorkspace throws, when initialize() is called, then error is handled gracefully', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').rejects(new Error('port file not found'));
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+
+        // Act
+        await service.initialize();
+
+        // Assert
+        assert.strictEqual(service.getClient(), undefined, 'getClient() should be undefined after failed init');
+        assert.strictEqual(service.isEnabled(), false, 'isEnabled() should be false after failed init');
+    });
+
+    // -------------------------------------------------------------------------
+    // daemon-service-is-enabled
+    // -------------------------------------------------------------------------
+
+    test('Given DaemonService is newly constructed, when isEnabled() is called before initialize(), then false is returned', () => {
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        assert.strictEqual(service.isEnabled(), false, 'isEnabled() should be false before initialize()');
+        assert.strictEqual(service.getClient(), undefined, 'getClient() should be undefined before initialize()');
+    });
+
+    test('Given initialize() completed successfully, when isEnabled() is called, then true is returned', async () => {
+        // Arrange
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        const fakeClient = {
+            subscribeEvents: sinon.stub().returns({ close: () => {} }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        await service.initialize();
+
+        // Assert
+        assert.strictEqual(service.isEnabled(), true, 'isEnabled() should be true after successful init');
+        assert.ok(service.getClient() !== undefined, 'getClient() should return client after successful init');
+
+        service.dispose();
+    });
+
+    // -------------------------------------------------------------------------
+    // service-container-daemon-client-optional
+    // -------------------------------------------------------------------------
+
+    test('ServiceContainer interface allows daemonClient to be optional', () => {
+        // This is a compile-time check. We verify at runtime that a service container
+        // without daemonClient can be constructed and used without errors.
+        // The actual TypeScript check happens at compile time.
+        const container = {
+            extensionContext: {} as import('vscode').ExtensionContext,
+            sessionProvider: {} as import('../../../vscode/providers/AgentSessionProvider').AgentSessionProvider,
+            sessionFormProvider: {} as import('../../../vscode/providers/SessionFormProvider').SessionFormProvider,
+            previousSessionProvider: {} as import('../../../vscode/providers/PreviousSessionProvider').PreviousSessionProvider,
+            workflowsProvider: {} as import('../../../vscode/providers/WorkflowsProvider').WorkflowsProvider,
+            workspaceRoot: '/tmp/test',
+            baseRepoPath: '/tmp/test',
+            extensionPath: '/fake/ext',
+            codeAgent: {} as import('../../../core/codeAgents').CodeAgent,
+            // daemonClient intentionally omitted
+        };
+
+        // No daemonClient — accessing it should return undefined
+        assert.strictEqual((container as Record<string, unknown>).daemonClient, undefined);
+    });
+});

--- a/src/types/serviceContainer.d.ts
+++ b/src/types/serviceContainer.d.ts
@@ -4,6 +4,7 @@ import type { SessionFormProvider } from '../vscode/providers/SessionFormProvide
 import type { PreviousSessionProvider } from '../vscode/providers/PreviousSessionProvider';
 import type { WorkflowsProvider } from '../vscode/providers/WorkflowsProvider';
 import type { CodeAgent } from '../core/codeAgents';
+import type { DaemonClient } from '../daemon/client';
 
 /**
  * Service container for dependency injection.
@@ -26,6 +27,9 @@ export interface ServiceContainer {
 
     // Code agent
     codeAgent: CodeAgent;
+
+    // Optional daemon client (present only when lanes.useDaemon is true and daemon is reachable)
+    daemonClient?: DaemonClient;
 }
 
 /**

--- a/src/vscode/commands/sessionCommands.ts
+++ b/src/vscode/commands/sessionCommands.ts
@@ -42,7 +42,8 @@ export function registerSessionCommands(
     const {
         sessionProvider,
         baseRepoPath,
-        codeAgent
+        codeAgent,
+        daemonClient
     } = services;
 
     const warnedMergeBaseBranches = new Set<string>();
@@ -146,7 +147,16 @@ export function registerSessionCommands(
             return;
         }
 
-        await createSession(name, '', 'acceptEdits', '', null, [], baseRepoPath, sessionProvider, codeAgent);
+        if (daemonClient) {
+            try {
+                await daemonClient.createSession({ name, agent: codeAgent.name });
+                sessionProvider.refresh();
+            } catch (err) {
+                vscode.window.showErrorMessage(`Failed to create session via daemon: ${getErrorMessage(err)}`);
+            }
+        } else {
+            await createSession(name, '', 'acceptEdits', '', null, [], baseRepoPath, sessionProvider, codeAgent);
+        }
     });
 
     // Command: Open/resume a session
@@ -186,12 +196,17 @@ export function registerSessionCommands(
             // Remove from Project Manager
             await removeProject(item.worktreePath);
 
-            // Remove worktree
-            if (baseRepoPath) {
-                await execGit(['worktree', 'remove', item.worktreePath, '--force'], baseRepoPath);
+            if (daemonClient) {
+                // Route git/fs deletion through the daemon
+                await daemonClient.deleteSession(item.label);
+            } else {
+                // Direct path: remove worktree via git
+                if (baseRepoPath) {
+                    await execGit(['worktree', 'remove', item.worktreePath, '--force'], baseRepoPath);
+                }
             }
 
-            // Clean up repo-local settings files
+            // Clean up repo-local settings files (always local, not handled by daemon)
             {
                 const settingsDir = getSettingsDir(item.worktreePath);
                 await fsPromises.rm(settingsDir, { recursive: true, force: true }).catch(() => {
@@ -253,8 +268,18 @@ export function registerSessionCommands(
         }
 
         try {
-            const baseBranch = await DiffService.getBaseBranch(item.worktreePath, vscode.workspace.getConfiguration('lanes').get<string>('baseBranch', ''));
-            const diffContent = await generateDiffContent(item.worktreePath, baseBranch);
+            let diffContent: string;
+            let baseBranch: string;
+
+            if (daemonClient) {
+                const diffResult = await daemonClient.getSessionDiff(item.label) as { diff?: string; baseBranch?: string } | undefined;
+                diffContent = (diffResult as Record<string, unknown>)?.diff as string ?? '';
+                baseBranch = (diffResult as Record<string, unknown>)?.baseBranch as string
+                    ?? await DiffService.getBaseBranch(item.worktreePath, vscode.workspace.getConfiguration('lanes').get<string>('baseBranch', ''));
+            } else {
+                baseBranch = await DiffService.getBaseBranch(item.worktreePath, vscode.workspace.getConfiguration('lanes').get<string>('baseBranch', ''));
+                diffContent = await generateDiffContent(item.worktreePath, baseBranch);
+            }
 
             if (!diffContent || diffContent.trim() === '') {
                 vscode.window.showInformationMessage(`No changes found when comparing to '${baseBranch}'.`);
@@ -551,20 +576,31 @@ export function registerSessionCommands(
         }
 
         try {
-            const insights = await vscode.window.withProgress(
-                { location: vscode.ProgressLocation.Notification, title: 'Generating insights...' },
-                () => generateInsights(item.worktreePath)
-            );
+            if (daemonClient) {
+                const insightsResult = await vscode.window.withProgress(
+                    { location: vscode.ProgressLocation.Notification, title: 'Generating insights...' },
+                    () => daemonClient.getSessionInsights(item.label, { includeAnalysis: true })
+                );
+                const report = (insightsResult as Record<string, unknown>)?.report as string
+                    ?? JSON.stringify(insightsResult, null, 2);
+                const document = await vscode.workspace.openTextDocument({ content: report, language: 'markdown' });
+                await vscode.window.showTextDocument(document, { preview: false });
+            } else {
+                const insights = await vscode.window.withProgress(
+                    { location: vscode.ProgressLocation.Notification, title: 'Generating insights...' },
+                    () => generateInsights(item.worktreePath)
+                );
 
-            if (insights.sessionCount === 0) {
-                vscode.window.showInformationMessage(`No conversation data found for session '${item.label}'.`);
-                return;
+                if (insights.sessionCount === 0) {
+                    vscode.window.showInformationMessage(`No conversation data found for session '${item.label}'.`);
+                    return;
+                }
+
+                const analysis = analyzeInsights(insights);
+                const report = formatInsightsReport(item.label, insights, analysis);
+                const document = await vscode.workspace.openTextDocument({ content: report, language: 'markdown' });
+                await vscode.window.showTextDocument(document, { preview: false });
             }
-
-            const analysis = analyzeInsights(insights);
-            const report = formatInsightsReport(item.label, insights, analysis);
-            const document = await vscode.workspace.openTextDocument({ content: report, language: 'markdown' });
-            await vscode.window.showTextDocument(document, { preview: false });
         } catch (err) {
             vscode.window.showErrorMessage(`Failed to generate insights: ${getErrorMessage(err)}`);
         }
@@ -578,7 +614,11 @@ export function registerSessionCommands(
         }
 
         try {
-            await sessionProvider.pinSession(item.worktreePath);
+            if (daemonClient) {
+                await daemonClient.pinSession(item.label);
+            } else {
+                await sessionProvider.pinSession(item.worktreePath);
+            }
             sessionProvider.refresh();
         } catch (err) {
             vscode.window.showErrorMessage(`Failed to pin session: ${getErrorMessage(err)}`);
@@ -593,7 +633,11 @@ export function registerSessionCommands(
         }
 
         try {
-            await sessionProvider.unpinSession(item.worktreePath);
+            if (daemonClient) {
+                await daemonClient.unpinSession(item.label);
+            } else {
+                await sessionProvider.unpinSession(item.worktreePath);
+            }
             sessionProvider.refresh();
         } catch (err) {
             vscode.window.showErrorMessage(`Failed to unpin session: ${getErrorMessage(err)}`);

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -47,6 +47,7 @@ import { validateWorkflow as validateWorkflowService } from '../core/services/Wo
 import { createSession } from './services/SessionService';
 import { openAgentTerminal } from './services/TerminalService';
 import { VscodeConfigProvider } from './adapters/VscodeConfigProvider';
+import { DaemonService } from './services/DaemonService';
 
 /**
  * Activate the extension.
@@ -153,6 +154,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         })();
     }
 
+    // Read the useDaemon flag early so we know whether to set up DaemonService
+    const useDaemon = vscode.workspace.getConfiguration('lanes').get<boolean>('useDaemon', false);
+
     // Create the global code agent instance using the factory
     // Reads lanes.defaultAgent setting and creates the appropriate agent
     // CLI availability is checked lazily at session creation time, not here.
@@ -178,6 +182,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     });
     context.subscriptions.push(sessionTreeView);
     context.subscriptions.push(sessionProvider);
+
+    // Initialize daemon service if lanes.useDaemon is enabled
+    let daemonService: DaemonService | undefined;
+    if (useDaemon && baseRepoPath) {
+        daemonService = new DaemonService(baseRepoPath, context.extensionPath, () => sessionProvider.refresh());
+        try {
+            await Promise.race([
+                daemonService.initialize(),
+                new Promise<void>((_, reject) => setTimeout(() => reject(new Error('Daemon initialization timed out')), 5000))
+            ]);
+            // Wire daemon client into the session tree provider
+            if (daemonService.isEnabled()) {
+                sessionProvider.setDaemonClient(daemonService.getClient());
+            }
+        } catch (err) {
+            console.error('Lanes: Failed to initialize daemon service:', getErrorMessage(err));
+            daemonService = undefined;
+        }
+        if (daemonService) {
+            context.subscriptions.push(daemonService);
+        }
+    }
 
     // Update chime and workflow context keys when session selection changes
     sessionTreeView.onDidChangeSelection(async (e) => {
@@ -303,7 +329,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         workspaceRoot,
         baseRepoPath,
         extensionPath: context.extensionPath,
-        codeAgent
+        codeAgent,
+        daemonClient: daemonService?.getClient()
     };
 
     // Register all file system watchers
@@ -318,6 +345,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 vscode.window.showWarningMessage(newAgentResult.warning);
             }
             sessionFormProvider.setDefaultAgent(newAgentResult.agent);
+        }
+        if (event.affectsConfiguration('lanes.useDaemon')) {
+            vscode.window.showInformationMessage(
+                'Lanes: The "Use Daemon" setting change will take effect after reloading the window.',
+                'Reload Window'
+            ).then(selection => {
+                if (selection === 'Reload Window') {
+                    void vscode.commands.executeCommand('workbench.action.reloadWindow');
+                }
+            });
         }
     });
 

--- a/src/vscode/providers/AgentSessionProvider.ts
+++ b/src/vscode/providers/AgentSessionProvider.ts
@@ -11,6 +11,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { CodeAgent } from '../../core/codeAgents';
 import type { IConfigProvider } from '../../core/interfaces/IConfigProvider';
+import type { DaemonClient } from '../../daemon/client';
 import { fileExists, readDir, isDirectory } from '../../core/services/FileService';
 
 // Re-export everything from core session module
@@ -208,9 +209,18 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
     private _onDidChangeTreeData: vscode.EventEmitter<SessionItem | SessionDetailItem | undefined | null | void> = new vscode.EventEmitter<SessionItem | SessionDetailItem | undefined | null | void>();
     readonly onDidChangeTreeData: vscode.Event<SessionItem | SessionDetailItem | undefined | null | void> = this._onDidChangeTreeData.event;
     private readonly sessionsRoot: string | undefined;
+    private daemonClient: DaemonClient | undefined;
 
     constructor(private workspaceRoot: string | undefined, baseRepoPath?: string, private codeAgent?: CodeAgent, private extensionContext?: vscode.ExtensionContext) {
         this.sessionsRoot = baseRepoPath || workspaceRoot;
+    }
+
+    /**
+     * Set or unset the daemon client for data fetching.
+     * When set, listSessions() is used instead of direct filesystem reads.
+     */
+    setDaemonClient(client: DaemonClient | undefined): void {
+        this.daemonClient = client;
     }
 
     dispose(): void { this._onDidChangeTreeData.dispose(); }
@@ -245,10 +255,59 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
             }
             return [];
         }
+
+        if (this.daemonClient) {
+            return this.getSessionsFromDaemon();
+        }
+
         const worktreesDir = path.join(this.sessionsRoot, getWorktreesFolder());
         const exists = await fileExists(worktreesDir);
         if (!exists) { return []; }
         return this.getSessionsInDir(worktreesDir);
+    }
+
+    /**
+     * Fetch sessions from the daemon via listSessions().
+     * Falls back to an empty list on error so the tree view stays functional.
+     */
+    private async getSessionsFromDaemon(): Promise<SessionItem[]> {
+        if (!this.daemonClient) {
+            return [];
+        }
+
+        try {
+            const result = await this.daemonClient.listSessions();
+            const sessions = Array.isArray(result) ? result : (result as Record<string, unknown>)?.sessions as unknown[];
+            if (!Array.isArray(sessions)) {
+                return [];
+            }
+
+            const items: SessionItem[] = [];
+
+            for (const session of sessions) {
+                const s = session as Record<string, unknown>;
+                const name = s.name as string | undefined;
+                const worktreePath = s.worktreePath as string | undefined;
+                if (!name || !worktreePath) {
+                    continue;
+                }
+                // Fetch status info from the filesystem for icon/description accuracy
+                const agentStatus = await SessionDataService.getAgentStatus(worktreePath);
+                const workflowStatus = await SessionDataService.getWorkflowStatus(worktreePath);
+                const chimeEnabled = await SessionDataService.getSessionChimeEnabled(worktreePath);
+                // Use daemon-provided pin state as the source of truth
+                const pinned = (s.isPinned as boolean) ?? false;
+                items.push(new SessionItem(name, worktreePath, vscode.TreeItemCollapsibleState.None, agentStatus, workflowStatus, chimeEnabled, pinned));
+            }
+
+            // Sort: pinned items first, then unpinned.
+            const pinnedItems = items.filter(item => item.contextValue === 'sessionItemPinned');
+            const unpinnedItems = items.filter(item => item.contextValue !== 'sessionItemPinned');
+            return [...pinnedItems, ...unpinnedItems];
+        } catch (err) {
+            console.error('Lanes: Failed to list sessions from daemon:', err);
+            return [];
+        }
     }
 
     private async getSessionsInDir(dirPath: string): Promise<SessionItem[]> {

--- a/src/vscode/services/DaemonService.ts
+++ b/src/vscode/services/DaemonService.ts
@@ -1,0 +1,153 @@
+/**
+ * DaemonService - Manages the lifecycle of the Lanes daemon within VS Code.
+ *
+ * Responsibilities:
+ * - Checks if the daemon is running and auto-starts it if needed
+ * - Creates and holds a DaemonClient instance
+ * - Subscribes to SSE events to trigger tree view refreshes
+ * - Cleans up SSE connections on deactivation (implements vscode.Disposable)
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { DaemonClient, type SseSubscription } from '../../daemon/client';
+import { startDaemon, isDaemonRunning, getDaemonPort } from '../../daemon/lifecycle';
+import { getErrorMessage } from '../../core/utils';
+
+/** Maximum number of attempts to poll for the daemon port file after starting. */
+const PORT_POLL_ATTEMPTS = 10;
+/** Delay in milliseconds between each port-file poll attempt. */
+const PORT_POLL_DELAY_MS = 300;
+
+export class DaemonService implements vscode.Disposable {
+    private client: DaemonClient | undefined;
+    private sseSubscription: SseSubscription | undefined;
+    private enabled = false;
+
+    /**
+     * @param workspaceRoot - Absolute path to the repository root.
+     * @param extensionPath - Absolute path to the extension installation directory.
+     * @param onRefresh    - Callback invoked when the session tree view should refresh.
+     */
+    constructor(
+        private readonly workspaceRoot: string,
+        private readonly extensionPath: string,
+        private readonly onRefresh: () => void
+    ) {}
+
+    /**
+     * Initialize the daemon service:
+     * 1. Checks if the daemon is already running.
+     * 2. If not, starts it using the bundled server script.
+     * 3. Waits for the port file to be written (polls a few times).
+     * 4. Creates a DaemonClient from workspace files.
+     * 5. Subscribes to SSE events that trigger onRefresh().
+     *
+     * Errors are logged but not re-thrown — a failure leaves the service
+     * disabled so the extension can fall back to direct service calls.
+     */
+    async initialize(): Promise<void> {
+        try {
+            const running = await isDaemonRunning(this.workspaceRoot);
+
+            if (!running) {
+                const serverPath = path.join(this.extensionPath, 'out', 'daemon', 'server.js');
+                await startDaemon({ workspaceRoot: this.workspaceRoot, serverPath });
+
+                // Poll until the daemon writes its port file (it may need a moment)
+                await this.waitForPortFile();
+            }
+
+            this.client = await DaemonClient.fromWorkspace(this.workspaceRoot);
+            this.enabled = true;
+
+            this.subscribeToEvents();
+        } catch (err) {
+            console.error('Lanes: DaemonService initialization failed:', getErrorMessage(err));
+            this.client = undefined;
+            this.enabled = false;
+        }
+    }
+
+    /**
+     * Return the active DaemonClient, or undefined if not initialized / initialization failed.
+     */
+    getClient(): DaemonClient | undefined {
+        return this.client;
+    }
+
+    /**
+     * Returns true if the daemon service initialized successfully and a client is available.
+     */
+    isEnabled(): boolean {
+        return this.enabled && this.client !== undefined;
+    }
+
+    /**
+     * Clean up: close the SSE subscription.
+     * The daemon process itself is left running so other windows can use it.
+     */
+    dispose(): void {
+        if (this.sseSubscription) {
+            this.sseSubscription.close();
+            this.sseSubscription = undefined;
+        }
+        this.client = undefined;
+        this.enabled = false;
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Poll for the daemon port file up to PORT_POLL_ATTEMPTS times.
+     * Resolves when a valid port is found; rejects if the timeout is exceeded.
+     */
+    private async waitForPortFile(): Promise<void> {
+        for (let attempt = 0; attempt < PORT_POLL_ATTEMPTS; attempt++) {
+            const port = await getDaemonPort(this.workspaceRoot);
+            if (port !== undefined && port > 0) {
+                return;
+            }
+            await delay(PORT_POLL_DELAY_MS);
+        }
+        throw new Error(
+            `Daemon port file not available after ${PORT_POLL_ATTEMPTS * PORT_POLL_DELAY_MS}ms. ` +
+            'The daemon may have failed to start.'
+        );
+    }
+
+    /**
+     * Subscribe to SSE events from the daemon.
+     * Fires onRefresh() for session lifecycle events (created, deleted, status changed).
+     */
+    private subscribeToEvents(): void {
+        if (!this.client) {
+            return;
+        }
+
+        this.sseSubscription = this.client.subscribeEvents({
+            onSessionCreated: () => {
+                this.onRefresh();
+            },
+            onSessionDeleted: () => {
+                this.onRefresh();
+            },
+            onSessionStatusChanged: () => {
+                this.onRefresh();
+            },
+            onConnected: () => {
+                console.log('Lanes: Connected to daemon SSE stream');
+            },
+            onError: (err) => {
+                console.error('Lanes: Daemon SSE error:', getErrorMessage(err));
+            },
+        });
+    }
+}
+
+/** Simple promise-based delay. */
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Add typed HTTP client for the Lanes daemon REST API and wire it into the VS Code extension with a `lanes.useDaemon` config option.

- DaemonClient: typed methods for all 28+ REST endpoints, SSE subscription with exponential backoff reconnection and status code validation
- DaemonService: auto-starts daemon, manages client lifecycle, SSE events trigger tree view refresh, proper disposal on deactivation
- Session commands route through daemon when enabled (create, delete, diff, insights, pin/unpin) with graceful fallback to direct mode
- AgentSessionProvider fetches sessions via daemon with daemon-provided pin state as source of truth