### PR TITLE
feat: add terminal interaction to web UI via tmux

### DIFF
--- a/src/core/interfaces/ITerminalIOProvider.ts
+++ b/src/core/interfaces/ITerminalIOProvider.ts
@@ -1,0 +1,24 @@
+/**
+ * Platform-agnostic terminal I/O provider interface.
+ * Abstracts reading output from and writing input to a running terminal session.
+ */
+
+export interface TerminalOutputData {
+    /** Terminal content (may include ANSI escape codes). */
+    content: string;
+    /** Number of terminal rows. */
+    rows: number;
+    /** Number of terminal columns. */
+    cols: number;
+}
+
+export interface ITerminalIOProvider {
+    /** Read current terminal output. */
+    readOutput(terminalName: string): Promise<TerminalOutputData>;
+    /** Send input text to the terminal. */
+    sendInput(terminalName: string, text: string): Promise<void>;
+    /** Resize the terminal. */
+    resize(terminalName: string, cols: number, rows: number): Promise<void>;
+    /** Check if the terminal exists and is available. */
+    isAvailable(terminalName: string): Promise<boolean>;
+}

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -14,3 +14,4 @@ export type {
     IFileWatchManager,
     IHandlerContext,
 } from './IHandlerContext';
+export type { ITerminalIOProvider, TerminalOutputData } from './ITerminalIOProvider';

--- a/src/core/services/SessionHandlerService.ts
+++ b/src/core/services/SessionHandlerService.ts
@@ -31,9 +31,11 @@ import {
     saveSessionWorkflow,
     saveSessionPermissionMode,
     saveSessionTerminalMode,
+    saveSessionTmuxName,
 } from '../session/SessionDataService';
 import { ValidationError } from '../errors/ValidationError';
 import * as TmuxService from './TmuxService';
+import { TmuxTerminalIOProvider } from './TmuxTerminalIOProvider';
 import * as DiffService from './DiffService';
 import * as BrokenWorktreeService from './BrokenWorktreeService';
 import { discoverWorkflows } from '../workflow/discovery';
@@ -387,6 +389,7 @@ export class SessionHandlerService {
                         command: launch.command,
                     });
                     await saveSessionTerminalMode(worktreePath, 'tmux');
+                    await saveSessionTmuxName(worktreePath, tmuxResult.tmuxSessionName);
                     command = tmuxResult.attachCommand;
                 }
             } else {
@@ -990,6 +993,45 @@ export class SessionHandlerService {
             .map((name) => ({ name, sessionName: name }));
 
         return { terminals };
+    }
+
+    async handleTerminalOutput(params: Record<string, unknown>): Promise<unknown> {
+        const name = params.name as string;
+        validateTerminalName(name);
+
+        const provider = new TmuxTerminalIOProvider();
+        const outputData = await provider.readOutput(name);
+
+        return outputData;
+    }
+
+    async handleTerminalResize(params: Record<string, unknown>): Promise<unknown> {
+        const name = params.name as string;
+        validateTerminalName(name);
+
+        const cols = params.cols as number | undefined;
+        const rows = params.rows as number | undefined;
+
+        if (cols === undefined || rows === undefined) {
+            throw new Error('Missing required parameters: cols and rows');
+        }
+
+        if (typeof cols !== 'number' || typeof rows !== 'number') {
+            throw new Error('Parameters cols and rows must be numbers');
+        }
+
+        if (!Number.isInteger(cols) || !Number.isInteger(rows)) {
+            throw new Error('Parameters cols and rows must be integers');
+        }
+
+        if (cols < 1 || cols > 10000 || rows < 1 || rows > 10000) {
+            throw new Error('Parameters cols and rows must be between 1 and 10000');
+        }
+
+        const provider = new TmuxTerminalIOProvider();
+        await provider.resize(name, cols, rows);
+
+        return { success: true };
     }
 
     // ---------------------------------------------------------------------------

--- a/src/core/services/TmuxService.ts
+++ b/src/core/services/TmuxService.ts
@@ -241,6 +241,125 @@ export async function launchInTmux(options: TmuxLaunchOptions): Promise<TmuxLaun
 	};
 }
 
+// ---------------------------------------------------------------------------
+// Terminal I/O helpers
+// ---------------------------------------------------------------------------
+
+export interface CapturePaneOptions {
+    /** Start line for scrollback capture (negative values go back in history, '-' means beginning of history). */
+    start?: number | '-';
+    /** End line for scrollback capture. */
+    end?: number;
+    /** When true, preserves ANSI escape sequences in the output. */
+    escapeSequences?: boolean;
+}
+
+/**
+ * Capture the current content of a tmux pane.
+ *
+ * @param sessionName The tmux session name
+ * @param options Optional capture options
+ * @returns The captured pane content as a string
+ */
+export async function capturePane(
+    sessionName: string,
+    options: CapturePaneOptions = {}
+): Promise<string> {
+    const args = ['capture-pane', '-p', '-t', sessionName];
+
+    if (options.escapeSequences) {
+        args.push('-e');
+    }
+
+    if (options.start !== undefined) {
+        args.push('-S', String(options.start));
+    }
+
+    if (options.end !== undefined) {
+        args.push('-E', String(options.end));
+    }
+
+    try {
+        const { stdout } = await execFileAsync('tmux', args, { timeout: TMUX_EXEC_TIMEOUT_MS });
+        return stdout;
+    } catch (err) {
+        throw new Error(
+            `Failed to capture pane for tmux session '${sessionName}': ${err instanceof Error ? err.message : String(err)}`
+        );
+    }
+}
+
+/**
+ * Get the current dimensions of a tmux pane.
+ *
+ * @param sessionName The tmux session name
+ * @returns Object with rows and cols
+ */
+export async function getPaneSize(
+    sessionName: string
+): Promise<{ rows: number; cols: number }> {
+    try {
+        const { stdout } = await execFileAsync(
+            'tmux',
+            ['display-message', '-p', '-t', sessionName, '#{pane_width} #{pane_height}'],
+            { timeout: TMUX_EXEC_TIMEOUT_MS }
+        );
+        const parts = stdout.trim().split(' ');
+        const cols = parseInt(parts[0] ?? '80', 10);
+        const rows = parseInt(parts[1] ?? '24', 10);
+        return {
+            cols: isNaN(cols) ? 80 : cols,
+            rows: isNaN(rows) ? 24 : rows,
+        };
+    } catch (err) {
+        throw new Error(
+            `Failed to get pane size for tmux session '${sessionName}': ${err instanceof Error ? err.message : String(err)}`
+        );
+    }
+}
+
+/**
+ * Resize a tmux window/pane.
+ *
+ * @param sessionName The tmux session name
+ * @param cols Number of columns
+ * @param rows Number of rows
+ */
+export async function resizePane(
+    sessionName: string,
+    cols: number,
+    rows: number
+): Promise<void> {
+    try {
+        await execFileAsync(
+            'tmux',
+            ['resize-window', '-t', sessionName, '-x', String(cols), '-y', String(rows)],
+            { timeout: TMUX_EXEC_TIMEOUT_MS }
+        );
+    } catch (err) {
+        throw new Error(
+            `Failed to resize pane for tmux session '${sessionName}': ${err instanceof Error ? err.message : String(err)}`
+        );
+    }
+}
+
+/**
+ * Send raw keys to a tmux session without appending Enter.
+ * Unlike sendCommand(), this sends the text exactly as-is.
+ *
+ * @param sessionName The session name
+ * @param keys The keys to send (no Enter appended)
+ */
+export async function sendKeys(sessionName: string, keys: string): Promise<void> {
+    try {
+        await execFileAsync('tmux', ['send-keys', '-t', sessionName, keys], { timeout: TMUX_EXEC_TIMEOUT_MS });
+    } catch (err) {
+        throw new Error(
+            `Failed to send keys to tmux session '${sessionName}': ${err instanceof Error ? err.message : String(err)}`
+        );
+    }
+}
+
 /**
  * List all active tmux sessions.
  * Returns an empty array if tmux is not running or no sessions exist.

--- a/src/core/services/TmuxTerminalIOProvider.ts
+++ b/src/core/services/TmuxTerminalIOProvider.ts
@@ -1,0 +1,61 @@
+/**
+ * TmuxTerminalIOProvider
+ *
+ * Implements ITerminalIOProvider using TmuxService functions.
+ * This is the default implementation for reading/writing terminal I/O
+ * when the terminal mode is set to 'tmux'.
+ */
+
+import { ITerminalIOProvider, TerminalOutputData } from '../interfaces/ITerminalIOProvider';
+import * as TmuxService from './TmuxService';
+
+export class TmuxTerminalIOProvider implements ITerminalIOProvider {
+    /**
+     * Read the current output of a tmux session pane, including dimensions.
+     *
+     * @param terminalName The tmux session name
+     * @returns Terminal content and dimensions
+     */
+    async readOutput(terminalName: string): Promise<TerminalOutputData> {
+        const [content, size] = await Promise.all([
+            TmuxService.capturePane(terminalName, { escapeSequences: true, start: '-' }),
+            TmuxService.getPaneSize(terminalName),
+        ]);
+        return {
+            content,
+            rows: size.rows,
+            cols: size.cols,
+        };
+    }
+
+    /**
+     * Send input text to a tmux session as raw keys (no Enter appended).
+     *
+     * @param terminalName The tmux session name
+     * @param text The text to send as-is
+     */
+    async sendInput(terminalName: string, text: string): Promise<void> {
+        await TmuxService.sendKeys(terminalName, text);
+    }
+
+    /**
+     * Resize a tmux session window.
+     *
+     * @param terminalName The tmux session name
+     * @param cols Number of columns
+     * @param rows Number of rows
+     */
+    async resize(terminalName: string, cols: number, rows: number): Promise<void> {
+        await TmuxService.resizePane(terminalName, cols, rows);
+    }
+
+    /**
+     * Check whether a tmux session with the given name exists.
+     *
+     * @param terminalName The tmux session name
+     * @returns True if the session exists, false otherwise
+     */
+    async isAvailable(terminalName: string): Promise<boolean> {
+        return TmuxService.sessionExists(terminalName);
+    }
+}

--- a/src/core/session/SessionDataService.ts
+++ b/src/core/session/SessionDataService.ts
@@ -324,6 +324,19 @@ export async function saveSessionTerminalMode(worktreePath: string, terminal: 'c
     }
 }
 
+export async function saveSessionTmuxName(worktreePath: string, tmuxSessionName: string): Promise<void> {
+    const sessionPath = getSessionFilePath(worktreePath);
+    try {
+        await ensureDir(path.dirname(sessionPath));
+        let existingData: Record<string, unknown> = {};
+        const parsed = await readJson<Record<string, unknown>>(sessionPath);
+        if (parsed) { existingData = parsed; }
+        await writeJson(sessionPath, { ...existingData, tmuxSessionName });
+    } catch (err) {
+        console.warn('Lanes: Failed to save tmux session name:', err);
+    }
+}
+
 export async function getSessionTerminalMode(worktreePath: string): Promise<'code' | 'tmux' | null> {
     const sessionPath = await resolveSessionFilePath(worktreePath);
     try {

--- a/src/core/session/types.ts
+++ b/src/core/session/types.ts
@@ -42,6 +42,8 @@ export interface AgentSessionData {
     isChimeEnabled?: boolean;
     taskListId?: string;
     terminal?: 'code' | 'tmux';
+    /** Sanitized tmux session name (may differ from the Lanes session name) */
+    tmuxSessionName?: string;
     /** Path to the agent's session log file (for polling status on hookless agents) */
     logPath?: string;
 }

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -18,6 +18,7 @@ import { ValidationError } from '../core/errors/ValidationError';
 import { LanesError } from '../core/errors/LanesError';
 import { getDaemonPort } from './lifecycle';
 import { readTokenFile } from './auth';
+import type { TerminalOutputData } from '../core/interfaces/ITerminalIOProvider';
 
 // ---------------------------------------------------------------------------
 // Concrete error class for non-validation HTTP errors
@@ -429,8 +430,126 @@ export class DaemonClient {
     /** POST /api/v1/terminals/:name/send */
     sendToTerminal(name: string, text: string): Promise<unknown> {
         return this.request('POST', `/api/v1/terminals/${encodeURIComponent(name)}/send`, {
-            body: { command: text },
+            body: { text },
         });
+    }
+
+    /** GET /api/v1/terminals/:name/output */
+    getTerminalOutput(name: string): Promise<TerminalOutputData> {
+        return this.request<TerminalOutputData>(
+            'GET',
+            `/api/v1/terminals/${encodeURIComponent(name)}/output`
+        );
+    }
+
+    /** POST /api/v1/terminals/:name/resize */
+    resizeTerminal(name: string, cols: number, rows: number): Promise<void> {
+        return this.request<void>(
+            'POST',
+            `/api/v1/terminals/${encodeURIComponent(name)}/resize`,
+            { body: { cols, rows } }
+        );
+    }
+
+    /**
+     * Subscribe to terminal output via SSE stream.
+     * Polls terminal content at the server side (every 200ms) and sends diffs.
+     * Returns an object with a `close()` method to stop the stream.
+     */
+    streamTerminalOutput(
+        name: string,
+        callbacks: {
+            onData: (data: TerminalOutputData) => void;
+            onError?: (error: Error) => void;
+        }
+    ): { close: () => void } {
+        let closed = false;
+        let currentReq: http.ClientRequest | null = null;
+
+        const url = new URL(
+            this.baseUrl + `/api/v1/terminals/${encodeURIComponent(name)}/stream`
+        );
+        const reqOptions: http.RequestOptions = {
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname + url.search,
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer ${this.token}`,
+                Accept: 'text/event-stream',
+            },
+        };
+
+        const req = http.request(reqOptions, (res) => {
+            if (res.statusCode !== 200) {
+                res.resume();
+                callbacks.onError?.(
+                    new Error(`Terminal stream failed with status ${res.statusCode}`)
+                );
+                return;
+            }
+
+            let buffer = '';
+
+            res.on('data', (chunk: Buffer) => {
+                buffer += chunk.toString('utf-8');
+
+                const messages = buffer.split('\n\n');
+                buffer = messages.pop() ?? '';
+
+                for (const message of messages) {
+                    if (!message.trim()) {
+                        continue;
+                    }
+
+                    let dataLine = '';
+
+                    for (const line of message.split('\n')) {
+                        if (line.startsWith('data:')) {
+                            dataLine = line.slice('data:'.length).trim();
+                        }
+                    }
+
+                    if (!dataLine) {
+                        continue;
+                    }
+
+                    let parsedData: unknown;
+                    try {
+                        parsedData = JSON.parse(dataLine);
+                    } catch {
+                        continue;
+                    }
+
+                    callbacks.onData(parsedData as TerminalOutputData);
+                }
+            });
+
+            res.on('error', (err) => {
+                if (!closed) {
+                    callbacks.onError?.(err);
+                }
+            });
+        });
+
+        req.on('error', (err) => {
+            if (!closed) {
+                callbacks.onError?.(err);
+            }
+        });
+
+        currentReq = req;
+        req.end();
+
+        return {
+            close(): void {
+                closed = true;
+                if (currentReq !== null) {
+                    currentReq.destroy();
+                    currentReq = null;
+                }
+            },
+        };
     }
 
     // -------------------------------------------------------------------------

--- a/src/daemon/router.ts
+++ b/src/daemon/router.ts
@@ -600,6 +600,99 @@ export function createRouter(
                 }
             }
 
+            // GET /api/v1/terminals/:name/output
+            {
+                const match = matchRoute('/api/v1/terminals/:name/output', pathname);
+                if (method === 'GET' && match) {
+                    const result = await handlerService.handleTerminalOutput({
+                        name: match.params.name,
+                    });
+                    sendJson(res, 200, result);
+                    return;
+                }
+            }
+
+            // POST /api/v1/terminals/:name/resize
+            {
+                const match = matchRoute('/api/v1/terminals/:name/resize', pathname);
+                if (method === 'POST' && match) {
+                    const body = await readJsonBody(req);
+                    const result = await handlerService.handleTerminalResize({
+                        name: match.params.name,
+                        cols: body.cols,
+                        rows: body.rows,
+                    });
+                    sendJson(res, 200, result);
+                    return;
+                }
+            }
+
+            // GET /api/v1/terminals/:name/stream  (SSE — polls terminal content every 200ms)
+            {
+                const match = matchRoute('/api/v1/terminals/:name/stream', pathname);
+                if (method === 'GET' && match) {
+                    const terminalName = match.params.name;
+
+                    if (!terminalName || !/^[a-zA-Z0-9_-]+$/.test(terminalName)) {
+                        sendJson(res, 400, { error: 'Invalid terminal name: must only contain alphanumeric characters, hyphens, and underscores' });
+                        return;
+                    }
+
+                    res.writeHead(200, {
+                        'Content-Type': 'text/event-stream',
+                        'Cache-Control': 'no-cache',
+                        'Connection': 'keep-alive',
+                    });
+                    res.write(': connected\n\n');
+
+                    let lastContent = '';
+                    let closed = false;
+
+                    const poll = async (): Promise<void> => {
+                        if (closed) {
+                            return;
+                        }
+                        try {
+                            const outputData = await handlerService.handleTerminalOutput({
+                                name: terminalName,
+                            }) as { content: string; rows: number; cols: number };
+
+                            if (outputData.content !== lastContent) {
+                                lastContent = outputData.content;
+                                const payload = JSON.stringify(outputData);
+                                res.write(`event: terminalOutput\ndata: ${payload}\n\n`);
+                            }
+                        } catch {
+                            // Session may not exist yet or tmux error — skip this tick
+                        }
+
+                        if (!closed) {
+                            pollTimer = setTimeout(() => { void poll(); }, 200);
+                        }
+                    };
+
+                    let pollTimer: ReturnType<typeof setTimeout> | null = setTimeout(() => { void poll(); }, 200);
+
+                    req.on('close', () => {
+                        closed = true;
+                        if (pollTimer !== null) {
+                            clearTimeout(pollTimer);
+                            pollTimer = null;
+                        }
+                    });
+
+                    res.on('close', () => {
+                        closed = true;
+                        if (pollTimer !== null) {
+                            clearTimeout(pollTimer);
+                            pollTimer = null;
+                        }
+                    });
+
+                    return;
+                }
+            }
+
             // ---------------------------------------------------------------
             // No route matched
             // ---------------------------------------------------------------

--- a/src/test/core/services/SessionHandlerService.terminal.test.ts
+++ b/src/test/core/services/SessionHandlerService.terminal.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for SessionHandlerService — handleTerminalOutput and handleTerminalResize.
+ *
+ * Covers:
+ *  - handleTerminalOutput: valid name returns { content, rows, cols }
+ *  - handleTerminalOutput: invalid name throws validation error
+ *  - handleTerminalResize: valid name and dimensions returns { success: true }
+ *  - handleTerminalResize: invalid name throws validation error
+ *  - handleTerminalResize: missing cols or rows throws validation error
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import sinon from 'sinon';
+import { SessionHandlerService } from '../../../core/services/SessionHandlerService';
+import type {
+    IHandlerContext,
+    ISimpleConfigStore,
+    INotificationEmitter,
+    IFileWatchManager,
+} from '../../../core/interfaces/IHandlerContext';
+import * as TmuxService from '../../../core/services/TmuxService';
+
+// ---------------------------------------------------------------------------
+// Minimal stub implementations
+// ---------------------------------------------------------------------------
+
+class StubConfigStore implements ISimpleConfigStore {
+    private readonly data: Record<string, unknown>;
+
+    constructor(initial: Record<string, unknown> = {}) {
+        this.data = { ...initial };
+    }
+
+    get(key: string): unknown {
+        return this.data[key];
+    }
+
+    async set(key: string, value: unknown): Promise<void> {
+        this.data[key] = value;
+    }
+
+    getAll(prefix?: string): Record<string, unknown> {
+        if (!prefix) {
+            return { ...this.data };
+        }
+        const result: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(this.data)) {
+            if (k.startsWith(prefix)) {
+                result[k] = v;
+            }
+        }
+        return result;
+    }
+}
+
+class StubNotificationEmitter implements INotificationEmitter {
+    sessionStatusChanged(
+        _sessionName: string,
+        _status: { status: string; timestamp?: string; message?: string }
+    ): void {}
+
+    fileChanged(_filePath: string, _eventType: 'created' | 'changed' | 'deleted'): void {}
+
+    sessionCreated(_sessionName: string, _worktreePath: string): void {}
+
+    sessionDeleted(_sessionName: string): void {}
+}
+
+class StubFileWatchManager implements IFileWatchManager {
+    private nextId = 0;
+
+    watch(_basePath: string, _pattern: string): string {
+        return `watch-${this.nextId++}`;
+    }
+
+    async unwatch(_watchId: string): Promise<boolean> {
+        return true;
+    }
+
+    dispose(): void {}
+}
+
+function makeContext(
+    workspaceRoot: string,
+    configOverrides: Record<string, unknown> = {}
+): IHandlerContext {
+    return {
+        workspaceRoot,
+        config: new StubConfigStore(configOverrides),
+        notificationEmitter: new StubNotificationEmitter(),
+        fileWatchManager: new StubFileWatchManager(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Suite: SessionHandlerService - handleTerminalOutput
+// ---------------------------------------------------------------------------
+
+suite('SessionHandlerService - handleTerminalOutput', () => {
+    let tempDir: string;
+    let service: SessionHandlerService;
+    let capturePaneStub: sinon.SinonStub;
+    let getPaneSizeStub: sinon.SinonStub;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-terminal-output-'));
+        service = new SessionHandlerService(makeContext(tempDir));
+
+        // Stub TmuxService functions used by TmuxTerminalIOProvider internally
+        capturePaneStub = sinon.stub(TmuxService, 'capturePane');
+        getPaneSizeStub = sinon.stub(TmuxService, 'getPaneSize');
+    });
+
+    teardown(() => {
+        sinon.restore();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('Given a valid terminal name, when handleTerminalOutput is called, then it returns { content, rows, cols }', async () => {
+        // Arrange
+        capturePaneStub.resolves('some terminal output\n');
+        getPaneSizeStub.resolves({ cols: 80, rows: 24 });
+
+        // Act
+        const result = await service.handleTerminalOutput({ name: 'valid-terminal' }) as {
+            content: string;
+            rows: number;
+            cols: number;
+        };
+
+        // Assert
+        assert.strictEqual(result.content, 'some terminal output\n');
+        assert.strictEqual(result.rows, 24);
+        assert.strictEqual(result.cols, 80);
+    });
+
+    test('Given an invalid terminal name, when handleTerminalOutput is called, then it throws a validation error', async () => {
+        // Arrange — name contains slashes which are not allowed
+        const invalidNames = ['../etc/passwd', 'feat/branch', 'bad name', 'bad!name'];
+
+        for (const invalidName of invalidNames) {
+            let thrown: unknown;
+            try {
+                await service.handleTerminalOutput({ name: invalidName });
+            } catch (err) {
+                thrown = err;
+            }
+
+            assert.ok(
+                thrown instanceof Error,
+                `Should throw an Error for invalid terminal name '${invalidName}'`
+            );
+            const message = (thrown as Error).message.toLowerCase();
+            assert.ok(
+                message.includes('invalid') || message.includes('terminal') || message.includes('required'),
+                `Error should indicate invalid terminal name for '${invalidName}', got: ${(thrown as Error).message}`
+            );
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: SessionHandlerService - handleTerminalResize
+// ---------------------------------------------------------------------------
+
+suite('SessionHandlerService - handleTerminalResize', () => {
+    let tempDir: string;
+    let service: SessionHandlerService;
+    let resizePaneStub: sinon.SinonStub;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-terminal-resize-'));
+        service = new SessionHandlerService(makeContext(tempDir));
+
+        // Stub TmuxService.resizePane used by TmuxTerminalIOProvider internally
+        resizePaneStub = sinon.stub(TmuxService, 'resizePane');
+    });
+
+    teardown(() => {
+        sinon.restore();
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('Given a valid terminal name and dimensions, when handleTerminalResize is called, then it returns { success: true }', async () => {
+        // Arrange
+        resizePaneStub.resolves();
+
+        // Act
+        const result = await service.handleTerminalResize({
+            name: 'valid-terminal',
+            cols: 120,
+            rows: 40,
+        }) as { success: boolean };
+
+        // Assert
+        assert.strictEqual(result.success, true);
+        assert.ok(
+            resizePaneStub.calledOnceWith('valid-terminal', 120, 40),
+            'resizePane should be called with the terminal name, cols, and rows'
+        );
+    });
+
+    test('Given an invalid terminal name, when handleTerminalResize is called, then it throws a validation error', async () => {
+        // Arrange — name contains path separators / special chars
+        let thrown: unknown;
+        try {
+            await service.handleTerminalResize({ name: 'bad/name', cols: 80, rows: 24 });
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an Error for invalid terminal name');
+        const message = (thrown as Error).message.toLowerCase();
+        assert.ok(
+            message.includes('invalid') || message.includes('terminal'),
+            `Error should indicate invalid terminal name, got: ${(thrown as Error).message}`
+        );
+    });
+
+    test('Given missing cols, when handleTerminalResize is called, then it throws a validation error', async () => {
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await service.handleTerminalResize({ name: 'valid-terminal', rows: 24 });
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an Error when cols is missing');
+        const message = (thrown as Error).message.toLowerCase();
+        assert.ok(
+            message.includes('cols') || message.includes('missing') || message.includes('required'),
+            `Error should mention missing cols/rows, got: ${(thrown as Error).message}`
+        );
+    });
+
+    test('Given missing rows, when handleTerminalResize is called, then it throws a validation error', async () => {
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await service.handleTerminalResize({ name: 'valid-terminal', cols: 80 });
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an Error when rows is missing');
+        const message = (thrown as Error).message.toLowerCase();
+        assert.ok(
+            message.includes('rows') || message.includes('missing') || message.includes('required'),
+            `Error should mention missing cols/rows, got: ${(thrown as Error).message}`
+        );
+    });
+});

--- a/src/test/core/services/TmuxService.test.ts
+++ b/src/test/core/services/TmuxService.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for TmuxService — capturePane, getPaneSize, resizePane.
+ *
+ * These tests use a mock `tmux` script placed earlier in PATH to capture
+ * the exact arguments that TmuxService passes to tmux.
+ *
+ * Covers:
+ *  - capturePane: calls tmux capture-pane with correct flags and returns stdout
+ *  - capturePane with escapeSequences=true: includes -e flag
+ *  - capturePane with start/end options: includes -S and -E flags
+ *  - capturePane error propagation
+ *  - getPaneSize: invokes tmux display-message with correct format and parses output
+ *  - getPaneSize: correctly parses '80 24' into { cols: 80, rows: 24 }
+ *  - getPaneSize error propagation
+ *  - resizePane: calls tmux resize-window with correct arguments
+ *  - resizePane error propagation
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    capturePane,
+    getPaneSize,
+    resizePane,
+} from '../../../core/services/TmuxService';
+
+// ---------------------------------------------------------------------------
+// Helpers — fake tmux binary via PATH injection
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a temporary directory containing a mock `tmux` script.
+ * The mock writes its arguments to an args file and prints the given stdout.
+ * If exitCode is non-zero it exits with that code.
+ */
+function createMockTmux(
+    dir: string,
+    opts: { stdout?: string; exitCode?: number } = {}
+): string {
+    const argsFile = path.join(dir, 'tmux-args.txt');
+    const stdout = opts.stdout ?? '';
+    const exitCode = opts.exitCode ?? 0;
+
+    const scriptPath = path.join(dir, 'tmux');
+
+    // Write a shell script that records args and emits the configured output
+    fs.writeFileSync(
+        scriptPath,
+        [
+            '#!/bin/sh',
+            // Append all args to a file (one arg per line, preceded by count)
+            `printf '%s\\n' "$@" > "${argsFile}"`,
+            // Print the fake stdout
+            `printf '%s' "${stdout.replace(/'/g, "'\\''")}"`,
+            // Exit with the configured exit code
+            `exit ${exitCode}`,
+        ].join('\n'),
+        { mode: 0o755 }
+    );
+
+    return argsFile;
+}
+
+/**
+ * Read the recorded args from the mock tmux argsFile.
+ */
+function readRecordedArgs(argsFile: string): string[] {
+    if (!fs.existsSync(argsFile)) {
+        return [];
+    }
+    return fs.readFileSync(argsFile, 'utf-8')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0);
+}
+
+/**
+ * Temporarily prepend a directory to PATH, execute fn, then restore PATH.
+ */
+async function withMockedTmux<T>(
+    mockDir: string,
+    fn: () => Promise<T>
+): Promise<T> {
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${mockDir}:${originalPath}`;
+    try {
+        return await fn();
+    } finally {
+        process.env.PATH = originalPath;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxService - capturePane
+// ---------------------------------------------------------------------------
+
+suite('TmuxService - capturePane', () => {
+    let tempDir: string;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-tmux-cp-'));
+    });
+
+    teardown(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('Given a session name, when capturePane is called, then it invokes tmux capture-pane -p -t <name>', async () => {
+        // Arrange
+        const argsFile = createMockTmux(tempDir, { stdout: 'pane content\n' });
+
+        // Act
+        const result = await withMockedTmux(tempDir, () =>
+            capturePane('my-session')
+        );
+
+        // Assert
+        const args = readRecordedArgs(argsFile);
+        assert.ok(args.includes('capture-pane'), `args should include 'capture-pane', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-p'), `args should include '-p', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-t'), `args should include '-t', got: ${args.join(', ')}`);
+        assert.ok(args.includes('my-session'), `args should include 'my-session', got: ${args.join(', ')}`);
+        assert.strictEqual(result, 'pane content\n');
+    });
+
+    test('Given escapeSequences=true, when capturePane is called, then the -e flag is included', async () => {
+        // Arrange
+        const argsFile = createMockTmux(tempDir, { stdout: 'colored content\n' });
+
+        // Act
+        await withMockedTmux(tempDir, () =>
+            capturePane('my-session', { escapeSequences: true })
+        );
+
+        // Assert
+        const args = readRecordedArgs(argsFile);
+        assert.ok(args.includes('-e'), `args should include '-e' when escapeSequences=true, got: ${args.join(', ')}`);
+    });
+
+    test('Given start and end options, when capturePane is called, then -S and -E flags are included', async () => {
+        // Arrange
+        const argsFile = createMockTmux(tempDir, { stdout: 'range content\n' });
+
+        // Act
+        await withMockedTmux(tempDir, () =>
+            capturePane('my-session', { start: -50, end: 0 })
+        );
+
+        // Assert
+        const args = readRecordedArgs(argsFile);
+        assert.ok(args.includes('-S'), `args should include '-S', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-50'), `args should include '-50', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-E'), `args should include '-E', got: ${args.join(', ')}`);
+        assert.ok(args.includes('0'), `args should include '0', got: ${args.join(', ')}`);
+    });
+
+    test('Given tmux command fails, when capturePane is called, then the error is propagated', async () => {
+        // Arrange — mock tmux exits non-zero
+        createMockTmux(tempDir, { stdout: '', exitCode: 1 });
+
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await withMockedTmux(tempDir, () => capturePane('my-session'));
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an error when tmux fails');
+        assert.ok(
+            (thrown as Error).message.includes('my-session'),
+            `Error message should reference the session name, got: ${(thrown as Error).message}`
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxService - getPaneSize
+// ---------------------------------------------------------------------------
+
+suite('TmuxService - getPaneSize', () => {
+    let tempDir: string;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-tmux-gps-'));
+    });
+
+    teardown(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('Given a session name, when getPaneSize is called, then it invokes tmux display-message with pane_width and pane_height format', async () => {
+        // Arrange
+        const argsFile = createMockTmux(tempDir, { stdout: '80 24' });
+
+        // Act
+        await withMockedTmux(tempDir, () => getPaneSize('my-session'));
+
+        // Assert
+        const args = readRecordedArgs(argsFile);
+        assert.ok(args.includes('display-message'), `args should include 'display-message', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-t'), `args should include '-t', got: ${args.join(', ')}`);
+        assert.ok(args.includes('my-session'), `args should include 'my-session', got: ${args.join(', ')}`);
+
+        // Verify the format string contains pane_width and pane_height
+        const formatArg = args.find((a) => a.includes('pane_width') || a.includes('pane_height'));
+        assert.ok(
+            formatArg !== undefined,
+            `args should include a format string containing pane_width / pane_height, got: ${args.join(', ')}`
+        );
+    });
+
+    test("Given tmux returns '80 24', when getPaneSize is called, then it returns { cols: 80, rows: 24 }", async () => {
+        // Arrange
+        createMockTmux(tempDir, { stdout: '80 24' });
+
+        // Act
+        const result = await withMockedTmux(tempDir, () => getPaneSize('my-session'));
+
+        // Assert
+        assert.strictEqual(result.cols, 80);
+        assert.strictEqual(result.rows, 24);
+    });
+
+    test('Given tmux command fails, when getPaneSize is called, then the error is propagated', async () => {
+        // Arrange — mock tmux exits non-zero
+        createMockTmux(tempDir, { exitCode: 1 });
+
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await withMockedTmux(tempDir, () => getPaneSize('my-session'));
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an error when tmux fails');
+        assert.ok(
+            (thrown as Error).message.includes('my-session'),
+            `Error message should reference the session name, got: ${(thrown as Error).message}`
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxService - resizePane
+// ---------------------------------------------------------------------------
+
+suite('TmuxService - resizePane', () => {
+    let tempDir: string;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-tmux-rp-'));
+    });
+
+    teardown(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('Given a session name, cols and rows, when resizePane is called, then it invokes tmux resize-window -t <name> -x <cols> -y <rows>', async () => {
+        // Arrange
+        const argsFile = createMockTmux(tempDir, { stdout: '' });
+
+        // Act
+        await withMockedTmux(tempDir, () => resizePane('my-session', 120, 40));
+
+        // Assert
+        const args = readRecordedArgs(argsFile);
+        assert.ok(args.includes('resize-window'), `args should include 'resize-window', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-t'), `args should include '-t', got: ${args.join(', ')}`);
+        assert.ok(args.includes('my-session'), `args should include 'my-session', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-x'), `args should include '-x', got: ${args.join(', ')}`);
+        assert.ok(args.includes('120'), `args should include '120', got: ${args.join(', ')}`);
+        assert.ok(args.includes('-y'), `args should include '-y', got: ${args.join(', ')}`);
+        assert.ok(args.includes('40'), `args should include '40', got: ${args.join(', ')}`);
+    });
+
+    test('Given tmux command fails, when resizePane is called, then the error is propagated', async () => {
+        // Arrange — mock tmux exits non-zero
+        createMockTmux(tempDir, { exitCode: 1 });
+
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await withMockedTmux(tempDir, () => resizePane('my-session', 80, 24));
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an error when tmux fails');
+        assert.ok(
+            (thrown as Error).message.includes('my-session'),
+            `Error message should reference the session name, got: ${(thrown as Error).message}`
+        );
+    });
+});

--- a/src/test/core/services/TmuxTerminalIOProvider.test.ts
+++ b/src/test/core/services/TmuxTerminalIOProvider.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for TmuxTerminalIOProvider.
+ *
+ * Covers:
+ *  - readOutput: uses capturePane and getPaneSize, returns combined result
+ *  - readOutput error propagation
+ *  - sendInput: delegates to TmuxService.sendCommand
+ *  - sendInput error propagation
+ *  - resize: delegates to TmuxService.resizePane
+ *  - isAvailable: delegates to TmuxService.sessionExists (true / false)
+ */
+
+import * as assert from 'assert';
+import sinon from 'sinon';
+import { TmuxTerminalIOProvider } from '../../../core/services/TmuxTerminalIOProvider';
+import * as TmuxService from '../../../core/services/TmuxService';
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxTerminalIOProvider - readOutput
+// ---------------------------------------------------------------------------
+
+suite('TmuxTerminalIOProvider - readOutput', () => {
+    let capturePaneStub: sinon.SinonStub;
+    let getPaneSizeStub: sinon.SinonStub;
+    let provider: TmuxTerminalIOProvider;
+
+    setup(() => {
+        capturePaneStub = sinon.stub(TmuxService, 'capturePane');
+        getPaneSizeStub = sinon.stub(TmuxService, 'getPaneSize');
+        provider = new TmuxTerminalIOProvider();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Given a terminal name, when readOutput is called, then it returns content from capturePane and dimensions from getPaneSize', async () => {
+        // Arrange
+        capturePaneStub.resolves('terminal output content\n');
+        getPaneSizeStub.resolves({ cols: 120, rows: 40 });
+
+        // Act
+        const result = await provider.readOutput('my-terminal');
+
+        // Assert
+        assert.ok(capturePaneStub.calledOnceWith('my-terminal'), 'capturePane should be called with the terminal name');
+        assert.ok(getPaneSizeStub.calledOnceWith('my-terminal'), 'getPaneSize should be called with the terminal name');
+        assert.strictEqual(result.content, 'terminal output content\n');
+        assert.strictEqual(result.cols, 120);
+        assert.strictEqual(result.rows, 40);
+    });
+
+    test('Given tmux operations fail, when readOutput is called, then the error is propagated', async () => {
+        // Arrange
+        capturePaneStub.rejects(new Error('capturePane failed'));
+        getPaneSizeStub.resolves({ cols: 80, rows: 24 });
+
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await provider.readOutput('my-terminal');
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an error when capturePane fails');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxTerminalIOProvider - sendInput
+// ---------------------------------------------------------------------------
+
+suite('TmuxTerminalIOProvider - sendInput', () => {
+    let sendKeysStub: sinon.SinonStub;
+    let provider: TmuxTerminalIOProvider;
+
+    setup(() => {
+        sendKeysStub = sinon.stub(TmuxService, 'sendKeys');
+        provider = new TmuxTerminalIOProvider();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Given a terminal name and text, when sendInput is called, then it calls TmuxService.sendKeys with those arguments', async () => {
+        // Arrange
+        sendKeysStub.resolves();
+
+        // Act
+        await provider.sendInput('my-terminal', 'ls -la');
+
+        // Assert
+        assert.ok(
+            sendKeysStub.calledOnceWith('my-terminal', 'ls -la'),
+            'sendKeys should be called with the terminal name and text'
+        );
+    });
+
+    test('Given tmux command fails, when sendInput is called, then the error is propagated', async () => {
+        // Arrange
+        sendKeysStub.rejects(new Error('Failed to send command to tmux session'));
+
+        // Act & Assert
+        let thrown: unknown;
+        try {
+            await provider.sendInput('my-terminal', 'some command');
+        } catch (err) {
+            thrown = err;
+        }
+
+        assert.ok(thrown instanceof Error, 'Should throw an error when sendKeys fails');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxTerminalIOProvider - resize
+// ---------------------------------------------------------------------------
+
+suite('TmuxTerminalIOProvider - resize', () => {
+    let resizePaneStub: sinon.SinonStub;
+    let provider: TmuxTerminalIOProvider;
+
+    setup(() => {
+        resizePaneStub = sinon.stub(TmuxService, 'resizePane');
+        provider = new TmuxTerminalIOProvider();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Given a terminal name, cols and rows, when resize is called, then it calls TmuxService.resizePane with those arguments', async () => {
+        // Arrange
+        resizePaneStub.resolves();
+
+        // Act
+        await provider.resize('my-terminal', 120, 40);
+
+        // Assert
+        assert.ok(
+            resizePaneStub.calledOnceWith('my-terminal', 120, 40),
+            'resizePane should be called with the terminal name, cols, and rows'
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: TmuxTerminalIOProvider - isAvailable
+// ---------------------------------------------------------------------------
+
+suite('TmuxTerminalIOProvider - isAvailable', () => {
+    let sessionExistsStub: sinon.SinonStub;
+    let provider: TmuxTerminalIOProvider;
+
+    setup(() => {
+        sessionExistsStub = sinon.stub(TmuxService, 'sessionExists');
+        provider = new TmuxTerminalIOProvider();
+    });
+
+    teardown(() => {
+        sinon.restore();
+    });
+
+    test('Given an existing session, when isAvailable is called, then it returns true', async () => {
+        // Arrange
+        sessionExistsStub.resolves(true);
+
+        // Act
+        const result = await provider.isAvailable('existing-terminal');
+
+        // Assert
+        assert.strictEqual(result, true);
+        assert.ok(
+            sessionExistsStub.calledOnceWith('existing-terminal'),
+            'sessionExists should be called with the terminal name'
+        );
+    });
+
+    test('Given a non-existing session, when isAvailable is called, then it returns false', async () => {
+        // Arrange
+        sessionExistsStub.resolves(false);
+
+        // Act
+        const result = await provider.isAvailable('nonexistent-terminal');
+
+        // Assert
+        assert.strictEqual(result, false);
+        assert.ok(
+            sessionExistsStub.calledOnceWith('nonexistent-terminal'),
+            'sessionExists should be called with the terminal name'
+        );
+    });
+});

--- a/src/test/daemon/client.terminal.test.ts
+++ b/src/test/daemon/client.terminal.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Tests for DaemonClient — terminal I/O endpoints.
+ *
+ * Covers:
+ *  - getTerminalOutput(): GET /api/v1/terminals/:name/output
+ *  - getTerminalOutput(): returns TerminalOutputData from server
+ *  - resizeTerminal(): POST /api/v1/terminals/:name/resize with { cols, rows }
+ */
+
+import * as assert from 'assert';
+import * as http from 'http';
+import { DaemonClient } from '../../daemon/client';
+import type { TerminalOutputData } from '../../core/interfaces/ITerminalIOProvider';
+
+// ---------------------------------------------------------------------------
+// Helper: create a minimal HTTP server that records requests and returns a
+// pre-configured response.
+// ---------------------------------------------------------------------------
+
+interface CapturedRequest {
+    method: string;
+    url: string;
+    headers: http.IncomingHttpHeaders;
+    body: string;
+}
+
+interface ServerResponse {
+    status: number;
+    body: unknown;
+}
+
+function createTestServer(responseFactory: (req: CapturedRequest) => ServerResponse): {
+    server: http.Server;
+    captured: CapturedRequest[];
+    close: () => Promise<void>;
+    port: () => number;
+} {
+    const captured: CapturedRequest[] = [];
+
+    const server = http.createServer((req, res) => {
+        const chunks: Buffer[] = [];
+        req.on('data', (chunk: Buffer) => chunks.push(chunk));
+        req.on('end', () => {
+            const capturedReq: CapturedRequest = {
+                method: req.method ?? 'GET',
+                url: req.url ?? '/',
+                headers: req.headers,
+                body: Buffer.concat(chunks).toString('utf-8'),
+            };
+            captured.push(capturedReq);
+
+            const response = responseFactory(capturedReq);
+            res.writeHead(response.status, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify(response.body));
+        });
+    });
+
+    return {
+        server,
+        captured,
+        close: () =>
+            new Promise<void>((resolve, reject) =>
+                server.close((err) => (err ? reject(err) : resolve()))
+            ),
+        port: () => (server.address() as { port: number }).port,
+    };
+}
+
+async function startTestServer(
+    responseFactory: (req: CapturedRequest) => ServerResponse
+): Promise<ReturnType<typeof createTestServer>> {
+    const helper = createTestServer(responseFactory);
+    await new Promise<void>((resolve) => helper.server.listen(0, '127.0.0.1', resolve));
+    return helper;
+}
+
+const TEST_TOKEN = 'test-bearer-token-terminal-abc';
+
+function makeClient(port: number): DaemonClient {
+    return new DaemonClient({ port, token: TEST_TOKEN });
+}
+
+// ---------------------------------------------------------------------------
+// Suite: DaemonClient - getTerminalOutput
+// ---------------------------------------------------------------------------
+
+suite('DaemonClient - getTerminalOutput', () => {
+    test('Given a terminal name, when getTerminalOutput is called, then it makes GET /api/v1/terminals/:name/output', async () => {
+        // Arrange
+        const helper = await startTestServer(() => ({
+            status: 200,
+            body: { content: 'terminal content\n', rows: 24, cols: 80 },
+        }));
+
+        try {
+            const client = makeClient(helper.port());
+
+            // Act
+            await client.getTerminalOutput('my-terminal');
+
+            // Assert
+            assert.strictEqual(helper.captured.length, 1, 'Exactly one request should be made');
+            assert.strictEqual(helper.captured[0].method, 'GET');
+            assert.strictEqual(
+                helper.captured[0].url,
+                '/api/v1/terminals/my-terminal/output'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+
+    test('Given the server returns terminal data, when getTerminalOutput is called, then it returns TerminalOutputData', async () => {
+        // Arrange
+        const expectedData: TerminalOutputData = {
+            content: 'hello world\n',
+            rows: 40,
+            cols: 120,
+        };
+
+        const helper = await startTestServer(() => ({
+            status: 200,
+            body: expectedData,
+        }));
+
+        try {
+            const client = makeClient(helper.port());
+
+            // Act
+            const result = await client.getTerminalOutput('my-terminal');
+
+            // Assert
+            assert.strictEqual(result.content, expectedData.content);
+            assert.strictEqual(result.rows, expectedData.rows);
+            assert.strictEqual(result.cols, expectedData.cols);
+        } finally {
+            await helper.close();
+        }
+    });
+
+    test('Given a terminal name with special characters, when getTerminalOutput is called, then the name is URI-encoded in the URL', async () => {
+        // Arrange
+        const helper = await startTestServer(() => ({
+            status: 200,
+            body: { content: '', rows: 24, cols: 80 },
+        }));
+
+        try {
+            const client = makeClient(helper.port());
+
+            // Act
+            await client.getTerminalOutput('terminal with spaces');
+
+            // Assert
+            assert.strictEqual(
+                helper.captured[0].url,
+                '/api/v1/terminals/terminal%20with%20spaces/output',
+                'Terminal name should be URI-encoded in the URL'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: DaemonClient - resizeTerminal
+// ---------------------------------------------------------------------------
+
+suite('DaemonClient - resizeTerminal', () => {
+    test('Given a terminal name and dimensions, when resizeTerminal is called, then it makes POST /api/v1/terminals/:name/resize with { cols, rows }', async () => {
+        // Arrange
+        const helper = await startTestServer(() => ({
+            status: 200,
+            body: { success: true },
+        }));
+
+        try {
+            const client = makeClient(helper.port());
+
+            // Act
+            await client.resizeTerminal('my-terminal', 120, 40);
+
+            // Assert
+            assert.strictEqual(helper.captured.length, 1, 'Exactly one request should be made');
+            assert.strictEqual(helper.captured[0].method, 'POST');
+            assert.strictEqual(
+                helper.captured[0].url,
+                '/api/v1/terminals/my-terminal/resize'
+            );
+
+            // Verify the request body contains the correct cols and rows
+            const requestBody = JSON.parse(helper.captured[0].body) as { cols: number; rows: number };
+            assert.strictEqual(requestBody.cols, 120);
+            assert.strictEqual(requestBody.rows, 40);
+        } finally {
+            await helper.close();
+        }
+    });
+
+    test('Given a terminal name with URI-unsafe characters, when resizeTerminal is called, then the name is URI-encoded in the URL', async () => {
+        // Arrange
+        const helper = await startTestServer(() => ({
+            status: 200,
+            body: { success: true },
+        }));
+
+        try {
+            const client = makeClient(helper.port());
+
+            // Act
+            await client.resizeTerminal('terminal/special', 80, 24);
+
+            // Assert
+            assert.strictEqual(
+                helper.captured[0].url,
+                '/api/v1/terminals/terminal%2Fspecial/resize',
+                'Terminal name should be URI-encoded in the URL'
+            );
+        } finally {
+            await helper.close();
+        }
+    });
+});

--- a/src/test/daemon/client.test.ts
+++ b/src/test/daemon/client.test.ts
@@ -992,7 +992,7 @@ suite('DaemonClient', () => {
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
                 assert.strictEqual(helper.captured[0].url, '/api/v1/terminals/term-1/send');
-                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { command: 'ls -la' });
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { text: 'ls -la' });
             } finally {
                 await helper.close();
             }

--- a/src/test/daemon/router.terminal.test.ts
+++ b/src/test/daemon/router.terminal.test.ts
@@ -1,0 +1,427 @@
+/**
+ * Tests for daemon HTTP router — terminal I/O endpoints.
+ *
+ * Covers:
+ *  - GET /api/v1/terminals/:name/output — returns 200 with { content, rows, cols } with valid auth
+ *  - GET /api/v1/terminals/:name/output — returns 401 without auth
+ *  - POST /api/v1/terminals/:name/resize — returns 200 with { success: true } with valid auth
+ *  - POST /api/v1/terminals/:name/resize — returns 401 without auth
+ *  - GET /api/v1/terminals/:name/stream — returns Content-Type: text/event-stream with valid auth
+ *  - GET /api/v1/terminals/:name/stream — returns 401 without auth
+ */
+
+import * as assert from 'assert';
+import * as http from 'http';
+import sinon from 'sinon';
+import { createRouter } from '../../daemon/router';
+
+// ---------------------------------------------------------------------------
+// Helper: minimal fake SessionHandlerService
+// ---------------------------------------------------------------------------
+
+function makeHandlerService() {
+    return {
+        handleSessionList: sinon.stub().resolves({ sessions: [] }),
+        handleSessionCreate: sinon.stub().resolves({ sessionName: 'new-session' }),
+        handleSessionDelete: sinon.stub().resolves({ success: true }),
+        handleSessionGetStatus: sinon.stub().resolves({ status: 'idle' }),
+        handleSessionOpen: sinon.stub().resolves({ success: true }),
+        handleSessionClear: sinon.stub().resolves({ success: true }),
+        handleSessionPin: sinon.stub().resolves({ success: true }),
+        handleSessionUnpin: sinon.stub().resolves({ success: true }),
+        handleAgentList: sinon.stub().resolves({ agents: [] }),
+        handleAgentGetConfig: sinon.stub().resolves({ config: null }),
+        handleConfigGet: sinon.stub().resolves({ value: 'claude' }),
+        handleConfigSet: sinon.stub().resolves({ success: true }),
+        handleConfigGetAll: sinon.stub().resolves({ config: {} }),
+        handleGitListBranches: sinon.stub().resolves({ branches: [] }),
+        handleGitRepairWorktrees: sinon.stub().resolves({ repaired: [] }),
+        handleGitGetDiff: sinon.stub().resolves({ diff: '' }),
+        handleGitGetDiffFiles: sinon.stub().resolves({ files: [] }),
+        handleGitGetWorktreeInfo: sinon.stub().resolves({ path: '/some/path' }),
+        handleWorkflowGetState: sinon.stub().resolves({ state: null }),
+        handleSessionInsights: sinon.stub().resolves({ insights: null, analysis: null }),
+        handleWorkflowList: sinon.stub().resolves({ workflows: [] }),
+        handleWorkflowValidate: sinon.stub().resolves({ valid: true }),
+        handleWorkflowCreate: sinon.stub().resolves({ success: true }),
+        handleTerminalCreate: sinon.stub().resolves({ terminalName: 'term-1' }),
+        handleTerminalSend: sinon.stub().resolves({ success: true }),
+        handleTerminalList: sinon.stub().resolves({ terminals: [] }),
+        handleTerminalOutput: sinon.stub().resolves({ content: 'hello\n', rows: 24, cols: 80 }),
+        handleTerminalResize: sinon.stub().resolves({ success: true }),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: minimal fake DaemonNotificationEmitter
+// ---------------------------------------------------------------------------
+
+function makeNotificationEmitter() {
+    return {
+        addClient: sinon.stub(),
+        removeClient: sinon.stub(),
+        getClientCount: sinon.stub().returns(0),
+        sessionCreated: sinon.stub(),
+        sessionDeleted: sinon.stub(),
+        sessionStatusChanged: sinon.stub(),
+        fileChanged: sinon.stub(),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make an HTTP request to a test server and collect the response
+// ---------------------------------------------------------------------------
+
+interface RequestOptions {
+    method?: string;
+    path?: string;
+    headers?: Record<string, string>;
+    body?: unknown;
+}
+
+interface TestResponse {
+    status: number;
+    headers: http.IncomingHttpHeaders;
+    body: unknown;
+    rawBody: string;
+}
+
+function makeRequest(
+    server: http.Server,
+    options: RequestOptions = {}
+): Promise<TestResponse> {
+    return new Promise((resolve, reject) => {
+        const address = server.address() as { port: number };
+        const { method = 'GET', path = '/', headers = {}, body } = options;
+
+        const payload = body !== undefined ? JSON.stringify(body) : undefined;
+        const reqHeaders: Record<string, string> = { ...headers };
+        if (payload !== undefined) {
+            reqHeaders['Content-Type'] = 'application/json';
+            reqHeaders['Content-Length'] = String(Buffer.byteLength(payload));
+        }
+
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port: address.port,
+                method,
+                path,
+                headers: reqHeaders,
+            },
+            (res) => {
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => chunks.push(chunk));
+                res.on('end', () => {
+                    const rawBody = Buffer.concat(chunks).toString('utf-8');
+                    let parsedBody: unknown = rawBody;
+                    try {
+                        parsedBody = JSON.parse(rawBody);
+                    } catch {
+                        // leave as string
+                    }
+                    resolve({
+                        status: res.statusCode ?? 0,
+                        headers: res.headers,
+                        body: parsedBody,
+                        rawBody,
+                    });
+                });
+                res.on('error', reject);
+            }
+        );
+
+        req.on('error', reject);
+        if (payload !== undefined) {
+            req.write(payload);
+        }
+        req.end();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Helper: make a request that aborts immediately (for SSE endpoints)
+// ---------------------------------------------------------------------------
+
+function makeRequestAndAbort(
+    server: http.Server,
+    options: RequestOptions = {}
+): Promise<TestResponse> {
+    return new Promise((resolve, reject) => {
+        const address = server.address() as { port: number };
+        const { method = 'GET', path = '/', headers = {} } = options;
+
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port: address.port,
+                method,
+                path,
+                headers,
+            },
+            (res) => {
+                // Collect just the headers and first chunk, then abort
+                const chunks: Buffer[] = [];
+                res.on('data', (chunk: Buffer) => {
+                    chunks.push(chunk);
+                    // Destroy after getting the first chunk
+                    req.destroy();
+                });
+                res.on('close', () => {
+                    const rawBody = Buffer.concat(chunks).toString('utf-8');
+                    resolve({
+                        status: res.statusCode ?? 0,
+                        headers: res.headers,
+                        body: rawBody,
+                        rawBody,
+                    });
+                });
+                res.on('error', () => {
+                    const rawBody = Buffer.concat(chunks).toString('utf-8');
+                    resolve({
+                        status: res.statusCode ?? 0,
+                        headers: res.headers,
+                        body: rawBody,
+                        rawBody,
+                    });
+                });
+            }
+        );
+
+        req.on('error', (err) => {
+            // Socket was deliberately destroyed — that's expected
+            if ((err as NodeJS.ErrnoException).code === 'ECONNRESET') {
+                resolve({ status: 0, headers: {}, body: '', rawBody: '' });
+            } else {
+                reject(err);
+            }
+        });
+
+        req.end();
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Suite constants
+// ---------------------------------------------------------------------------
+
+const AUTH_TOKEN = 'test-secret-token-terminal-xyz';
+const BEARER = `Bearer ${AUTH_TOKEN}`;
+
+// ---------------------------------------------------------------------------
+// Suite: router - GET /api/v1/terminals/:name/output
+// ---------------------------------------------------------------------------
+
+suite('router - GET /api/v1/terminals/:name/output', () => {
+    let handlerService: ReturnType<typeof makeHandlerService>;
+    let notificationEmitter: ReturnType<typeof makeNotificationEmitter>;
+    let server: http.Server;
+
+    setup((done) => {
+        handlerService = makeHandlerService();
+        notificationEmitter = makeNotificationEmitter();
+
+        const handler = createRouter(
+            handlerService as never,
+            notificationEmitter as never,
+            AUTH_TOKEN,
+            { workspaceRoot: '/test/workspace', startedAt: new Date().toISOString(), port: 0 }
+        );
+        server = http.createServer(handler);
+        server.listen(0, '127.0.0.1', done);
+    });
+
+    teardown((done) => {
+        sinon.restore();
+        server.close(done);
+    });
+
+    test('Given a valid terminal name and auth, when GET /api/v1/terminals/:name/output is called, then it returns 200 with { content, rows, cols }', async () => {
+        // Arrange
+        handlerService.handleTerminalOutput.resolves({ content: 'hello world\n', rows: 24, cols: 80 });
+
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/terminals/my-terminal/output',
+            headers: { Authorization: BEARER },
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 200);
+        assert.ok(handlerService.handleTerminalOutput.calledOnce, 'handleTerminalOutput should be called once');
+
+        const body = res.body as { content: string; rows: number; cols: number };
+        assert.strictEqual(body.content, 'hello world\n');
+        assert.strictEqual(body.rows, 24);
+        assert.strictEqual(body.cols, 80);
+
+        // Verify the name was extracted from the URL
+        const calledWith = handlerService.handleTerminalOutput.firstCall.args[0] as Record<string, unknown>;
+        assert.strictEqual(calledWith.name, 'my-terminal');
+    });
+
+    test('Given no auth, when GET /api/v1/terminals/:name/output is called, then it returns 401', async () => {
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/terminals/my-terminal/output',
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 401);
+        assert.ok(
+            handlerService.handleTerminalOutput.notCalled,
+            'handleTerminalOutput should NOT be called when auth is missing'
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: router - POST /api/v1/terminals/:name/resize
+// ---------------------------------------------------------------------------
+
+suite('router - POST /api/v1/terminals/:name/resize', () => {
+    let handlerService: ReturnType<typeof makeHandlerService>;
+    let notificationEmitter: ReturnType<typeof makeNotificationEmitter>;
+    let server: http.Server;
+
+    setup((done) => {
+        handlerService = makeHandlerService();
+        notificationEmitter = makeNotificationEmitter();
+
+        const handler = createRouter(
+            handlerService as never,
+            notificationEmitter as never,
+            AUTH_TOKEN,
+            { workspaceRoot: '/test/workspace', startedAt: new Date().toISOString(), port: 0 }
+        );
+        server = http.createServer(handler);
+        server.listen(0, '127.0.0.1', done);
+    });
+
+    teardown((done) => {
+        sinon.restore();
+        server.close(done);
+    });
+
+    test('Given a valid terminal name, cols, rows, and auth, when POST /api/v1/terminals/:name/resize is called, then it returns 200 with { success: true }', async () => {
+        // Arrange
+        handlerService.handleTerminalResize.resolves({ success: true });
+
+        // Act
+        const res = await makeRequest(server, {
+            method: 'POST',
+            path: '/api/v1/terminals/my-terminal/resize',
+            headers: { Authorization: BEARER },
+            body: { cols: 120, rows: 40 },
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 200);
+        assert.ok(handlerService.handleTerminalResize.calledOnce, 'handleTerminalResize should be called once');
+
+        const body = res.body as { success: boolean };
+        assert.strictEqual(body.success, true);
+
+        // Verify the name, cols, and rows were passed correctly
+        const calledWith = handlerService.handleTerminalResize.firstCall.args[0] as Record<string, unknown>;
+        assert.strictEqual(calledWith.name, 'my-terminal');
+        assert.strictEqual(calledWith.cols, 120);
+        assert.strictEqual(calledWith.rows, 40);
+    });
+
+    test('Given no auth, when POST /api/v1/terminals/:name/resize is called, then it returns 401', async () => {
+        // Act
+        const res = await makeRequest(server, {
+            method: 'POST',
+            path: '/api/v1/terminals/my-terminal/resize',
+            body: { cols: 80, rows: 24 },
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 401);
+        assert.ok(
+            handlerService.handleTerminalResize.notCalled,
+            'handleTerminalResize should NOT be called when auth is missing'
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Suite: router - GET /api/v1/terminals/:name/stream
+// ---------------------------------------------------------------------------
+
+suite('router - GET /api/v1/terminals/:name/stream', () => {
+    let handlerService: ReturnType<typeof makeHandlerService>;
+    let notificationEmitter: ReturnType<typeof makeNotificationEmitter>;
+    let server: http.Server;
+
+    setup((done) => {
+        handlerService = makeHandlerService();
+        notificationEmitter = makeNotificationEmitter();
+
+        // Make handleTerminalOutput resolve so the SSE poll doesn't error
+        handlerService.handleTerminalOutput.resolves({ content: 'stream content\n', rows: 24, cols: 80 });
+
+        const handler = createRouter(
+            handlerService as never,
+            notificationEmitter as never,
+            AUTH_TOKEN,
+            { workspaceRoot: '/test/workspace', startedAt: new Date().toISOString(), port: 0 }
+        );
+        server = http.createServer(handler);
+        server.listen(0, '127.0.0.1', done);
+    });
+
+    teardown((done) => {
+        sinon.restore();
+        server.close(done);
+    });
+
+    test('Given a valid terminal name and auth, when GET /api/v1/terminals/:name/stream is called, then it returns Content-Type: text/event-stream', (done) => {
+        const address = server.address() as { port: number };
+
+        const req = http.request(
+            {
+                hostname: '127.0.0.1',
+                port: address.port,
+                method: 'GET',
+                path: '/api/v1/terminals/my-terminal/stream',
+                headers: { Authorization: BEARER },
+            },
+            (res) => {
+                // Assert response headers immediately
+                assert.strictEqual(res.statusCode, 200);
+                const contentType = res.headers['content-type'];
+                assert.ok(
+                    contentType !== undefined && contentType.includes('text/event-stream'),
+                    `Expected Content-Type: text/event-stream, got: ${contentType}`
+                );
+
+                // Destroy the connection to avoid hanging
+                req.destroy();
+                done();
+            }
+        );
+
+        req.on('error', (err: NodeJS.ErrnoException) => {
+            if (err.code === 'ECONNRESET') {
+                // Expected: we destroyed the socket
+                done();
+            } else {
+                done(err);
+            }
+        });
+
+        req.end();
+    });
+
+    test('Given no auth, when GET /api/v1/terminals/:name/stream is called, then it returns 401', async () => {
+        // Act
+        const res = await makeRequest(server, {
+            path: '/api/v1/terminals/my-terminal/stream',
+        });
+
+        // Assert
+        assert.strictEqual(res.status, 401);
+    });
+});

--- a/web-ui/src/api/client.ts
+++ b/web-ui/src/api/client.ts
@@ -29,6 +29,8 @@ import type {
     CreateTerminalRequest,
     CreateTerminalResponse,
     TerminalSendRequest,
+    TerminalOutputData,
+    TerminalResizeRequest,
 } from './types';
 
 // ---------------------------------------------------------------------------
@@ -392,5 +394,114 @@ export class DaemonApiClient {
             `/api/v1/terminals/${encodeURIComponent(name)}/send`,
             { body: params }
         );
+    }
+
+    /**
+     * GET /api/v1/terminals/:name/output
+     */
+    async getTerminalOutput(name: string): Promise<TerminalOutputData> {
+        return this.request<TerminalOutputData>(
+            'GET',
+            `/api/v1/terminals/${encodeURIComponent(name)}/output`
+        );
+    }
+
+    /**
+     * POST /api/v1/terminals/:name/resize
+     */
+    async resizeTerminal(name: string, params: TerminalResizeRequest): Promise<unknown> {
+        return this.request<unknown>(
+            'POST',
+            `/api/v1/terminals/${encodeURIComponent(name)}/resize`,
+            { body: params }
+        );
+    }
+
+    /**
+     * GET /api/v1/terminals/:name/stream (SSE)
+     *
+     * Connects to the terminal output SSE stream using the Fetch API's ReadableStream.
+     * Returns an object with a `close()` method to abort the stream.
+     *
+     * @param name Terminal name
+     * @param onData Callback invoked with each TerminalOutputData event
+     * @param onError Optional callback for stream errors
+     */
+    streamTerminalOutput(
+        name: string,
+        onData: (data: TerminalOutputData) => void,
+        onError?: (error: Error) => void
+    ): { close: () => void } {
+        const controller = new AbortController();
+        const url = `${this.baseUrl}/api/v1/terminals/${encodeURIComponent(name)}/stream`;
+
+        const run = async (): Promise<void> => {
+            try {
+                const res = await fetch(url, {
+                    method: 'GET',
+                    headers: {
+                        Authorization: `Bearer ${this.token}`,
+                        Accept: 'text/event-stream',
+                    },
+                    signal: controller.signal,
+                });
+
+                if (!res.ok || !res.body) {
+                    onError?.(new Error(`Terminal stream failed with status ${res.status}`));
+                    return;
+                }
+
+                const reader = res.body.getReader();
+                const decoder = new TextDecoder();
+                let buffer = '';
+
+                while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) {
+                        break;
+                    }
+                    buffer += decoder.decode(value, { stream: true });
+
+                    const messages = buffer.split('\n\n');
+                    buffer = messages.pop() ?? '';
+
+                    for (const message of messages) {
+                        if (!message.trim()) {
+                            continue;
+                        }
+
+                        let dataLine = '';
+                        for (const line of message.split('\n')) {
+                            if (line.startsWith('data:')) {
+                                dataLine = line.slice('data:'.length).trim();
+                            }
+                        }
+
+                        if (!dataLine) {
+                            continue;
+                        }
+
+                        try {
+                            const parsed = JSON.parse(dataLine) as TerminalOutputData;
+                            onData(parsed);
+                        } catch {
+                            // Skip unparseable events
+                        }
+                    }
+                }
+            } catch (err) {
+                if (err instanceof Error && err.name !== 'AbortError') {
+                    onError?.(err);
+                }
+            }
+        };
+
+        void run();
+
+        return {
+            close(): void {
+                controller.abort();
+            },
+        };
     }
 }

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -35,6 +35,7 @@ export interface SessionData {
     agentName?: string;
     permissionMode?: string;
     terminal?: string;
+    tmuxSessionName?: string;
 }
 
 export interface SessionInfo {
@@ -210,6 +211,20 @@ export interface CreateTerminalResponse {
 
 export interface TerminalSendRequest {
     text: string;
+}
+
+export interface TerminalOutputData {
+    /** Terminal content (may include ANSI escape codes). */
+    content: string;
+    /** Number of terminal rows. */
+    rows: number;
+    /** Number of terminal columns. */
+    cols: number;
+}
+
+export interface TerminalResizeRequest {
+    cols: number;
+    rows: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/web-ui/src/components/TerminalView.tsx
+++ b/web-ui/src/components/TerminalView.tsx
@@ -1,0 +1,201 @@
+/**
+ * TerminalView — displays live terminal output and provides a text input
+ * for sending commands to the running agent session.
+ *
+ * Terminal content is streamed via SSE from the daemon. ANSI escape codes
+ * are stripped for clean plain-text display in a <pre> element.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo, KeyboardEvent } from 'react';
+import type { DaemonApiClient } from '../api/client';
+import { useTerminal } from '../hooks/useTerminal';
+import styles from '../styles/TerminalView.module.css';
+
+// ---------------------------------------------------------------------------
+// ANSI stripping
+// ---------------------------------------------------------------------------
+
+/**
+ * Removes ANSI escape sequences from a string so the content can be safely
+ * rendered as plain text. Covers the most common forms:
+ *   - CSI sequences: ESC [ ... (letter)
+ *   - OSC sequences: ESC ] ... ST or BEL
+ *   - Single-char escape sequences: ESC (letter)
+ *   - Raw ESC char without a recognised follower
+ */
+function stripAnsi(text: string): string {
+    return text
+        // CSI sequences: ESC [ optional params final byte (0x40–0x7E)
+        .replace(/\x1b\[[0-9;?]*[A-Za-z]/g, '')
+        // OSC sequences: ESC ] ... ESC \ or ESC ] ... BEL
+        .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')
+        // Single-char escape sequences: ESC followed by a printable char
+        .replace(/\x1b[A-Za-z]/g, '')
+        // Any remaining lone ESC
+        .replace(/\x1b/g, '');
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface TerminalViewProps {
+    apiClient: DaemonApiClient | null;
+    terminalName: string | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TerminalView({ apiClient, terminalName }: TerminalViewProps) {
+    const { content, connected, error, sendInput } = useTerminal(apiClient, terminalName);
+
+    const [inputValue, setInputValue] = useState('');
+    const [sending, setSending] = useState(false);
+    const [timedOut, setTimedOut] = useState(false);
+
+    const outputRef = useRef<HTMLDivElement>(null);
+
+    // Show a helpful message if connection takes too long (no tmux session found)
+    useEffect(() => {
+        if (connected || error) {
+            setTimedOut(false);
+            return;
+        }
+        const timer = setTimeout(() => setTimedOut(true), 5000);
+        return () => clearTimeout(timer);
+    }, [connected, error, terminalName]);
+
+    // Auto-scroll to the bottom only when the user is already near the bottom.
+    // This prevents yanking the view away when the user is reading scrollback.
+    useEffect(() => {
+        const el = outputRef.current;
+        if (el) {
+            const isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+            if (isNearBottom) {
+                el.scrollTop = el.scrollHeight;
+            }
+        }
+    }, [content]);
+
+    const handleSend = useCallback(async () => {
+        const text = inputValue.trim();
+        if (!text || sending || !connected) return;
+
+        setSending(true);
+        try {
+            await sendInput(text);
+            setInputValue('');
+        } catch (err) {
+            console.error('Failed to send terminal input:', err);
+        } finally {
+            setSending(false);
+        }
+    }, [inputValue, sending, connected, sendInput]);
+
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLInputElement>) => {
+            if (e.key === 'Enter') {
+                void handleSend();
+            }
+        },
+        [handleSend]
+    );
+
+    // Compute status indicator state
+    let statusLabel: string;
+    let dotClass: string;
+    if (error) {
+        statusLabel = 'Error';
+        dotClass = styles.statusDotError;
+    } else if (connected) {
+        statusLabel = 'Connected';
+        dotClass = styles.statusDotConnected;
+    } else {
+        statusLabel = 'Connecting…';
+        dotClass = styles.statusDotConnecting;
+    }
+
+    const displayContent = useMemo(() => stripAnsi(content), [content]);
+    const canSend = connected && !sending && !!apiClient && !!terminalName;
+
+    return (
+        <div className={styles.root}>
+            {/* Toolbar */}
+            <div className={styles.toolbar}>
+                <span className={styles.toolbarTitle}>
+                    {terminalName ?? 'Terminal'}
+                </span>
+                <span className={styles.connectionStatus} aria-live="polite">
+                    <span className={`${styles.statusDot} ${dotClass}`} aria-hidden="true" />
+                    {statusLabel}
+                </span>
+            </div>
+
+            {/* Error banner */}
+            {error && (
+                <div className={styles.errorBanner} role="alert">
+                    <span className={styles.errorTitle}>Stream error</span>
+                    <span className={styles.errorMessage}>{error.message}</span>
+                </div>
+            )}
+
+            {/* Output */}
+            <div
+                ref={outputRef}
+                className={styles.output}
+                aria-label="Terminal output"
+                aria-live="off"
+            >
+                {!connected && !error ? (
+                    <div className={styles.connecting} role="status" aria-label="Connecting to terminal">
+                        {timedOut ? (
+                            <>
+                                <span className={styles.connectingTitle}>No terminal session found</span>
+                                <span className={styles.connectingHint}>
+                                    No tmux session found for this terminal.
+                                    Make sure the session was created with terminal mode
+                                    set to &ldquo;tmux&rdquo;.
+                                </span>
+                            </>
+                        ) : (
+                            <>
+                                <div className={styles.spinner} aria-hidden="true" />
+                                <span>Connecting to terminal&hellip;</span>
+                            </>
+                        )}
+                    </div>
+                ) : (
+                    <pre className={styles.pre}>{displayContent}</pre>
+                )}
+            </div>
+
+            {/* Input row */}
+            <div className={styles.inputRow}>
+                <span className={styles.inputPrompt} aria-hidden="true">&gt;</span>
+                <input
+                    type="text"
+                    className={styles.input}
+                    value={inputValue}
+                    onChange={(e) => setInputValue(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={canSend ? 'Send a message… (Enter to send)' : 'Waiting for connection…'}
+                    disabled={!canSend}
+                    aria-label="Terminal input"
+                    autoComplete="off"
+                    spellCheck={false}
+                />
+                <button
+                    type="button"
+                    className={styles.sendButton}
+                    onClick={() => void handleSend()}
+                    disabled={!canSend || !inputValue.trim()}
+                    aria-label="Send input"
+                >
+                    Send
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/web-ui/src/hooks/useTerminal.ts
+++ b/web-ui/src/hooks/useTerminal.ts
@@ -1,0 +1,100 @@
+/**
+ * useTerminal — connects to the daemon's terminal SSE stream for a named terminal.
+ *
+ * Streams live terminal output via Server-Sent Events and exposes helpers for
+ * sending input and resizing. Follows the same pattern as useDiff.ts.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type { DaemonApiClient } from '../api/client';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseTerminalResult {
+    /** Current terminal content (may include ANSI escape codes). */
+    content: string;
+    /** Terminal rows reported by the daemon. */
+    rows: number;
+    /** Terminal columns reported by the daemon. */
+    cols: number;
+    /** True once the first SSE event has been received. */
+    connected: boolean;
+    /** Set when the SSE stream encounters an error. */
+    error: Error | null;
+    /** Send a line of text to the terminal (the backend appends Enter). */
+    sendInput: (text: string) => Promise<void>;
+    /** Resize the terminal to the given dimensions. */
+    resize: (cols: number, rows: number) => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useTerminal(
+    apiClient: DaemonApiClient | null,
+    terminalName: string | undefined
+): UseTerminalResult {
+    const [content, setContent] = useState<string>('');
+    const [rows, setRows] = useState<number>(0);
+    const [cols, setCols] = useState<number>(0);
+    const [connected, setConnected] = useState<boolean>(false);
+    const [error, setError] = useState<Error | null>(null);
+
+    useEffect(() => {
+        if (!apiClient || !terminalName) {
+            setContent('');
+            setRows(0);
+            setCols(0);
+            setConnected(false);
+            setError(null);
+            return;
+        }
+
+        setError(null);
+        setConnected(false);
+
+        let cancelled = false;
+
+        const handle = apiClient.streamTerminalOutput(
+            terminalName,
+            (data) => {
+                if (cancelled) return;
+                setContent(data.content);
+                setRows(data.rows);
+                setCols(data.cols);
+                setConnected(true);
+            },
+            (err) => {
+                if (cancelled) return;
+                setError(err);
+                setConnected(false);
+            }
+        );
+
+        return () => {
+            cancelled = true;
+            handle.close();
+        };
+    }, [apiClient, terminalName]);
+
+    const sendInput = useCallback(
+        async (text: string): Promise<void> => {
+            if (!apiClient || !terminalName) return;
+            await apiClient.sendToTerminal(terminalName, { text });
+        },
+        [apiClient, terminalName]
+    );
+
+    const resize = useCallback(
+        async (newCols: number, newRows: number): Promise<void> => {
+            if (!apiClient || !terminalName) return;
+            await apiClient.resizeTerminal(terminalName, { cols: newCols, rows: newRows });
+        },
+        [apiClient, terminalName]
+    );
+
+    return { content, rows, cols, connected, error, sendInput, resize };
+}

--- a/web-ui/src/pages/SessionDetail.tsx
+++ b/web-ui/src/pages/SessionDetail.tsx
@@ -24,6 +24,7 @@ import { StepProgressTracker } from '../components/StepProgressTracker';
 import { WorkflowTaskList } from '../components/WorkflowTaskList';
 import { formatReviewForClipboard } from '../utils/reviewFormat';
 import type { ReviewComment } from '../utils/reviewFormat';
+import { TerminalView } from '../components/TerminalView';
 import type { SseCallbacks } from '../api/sse';
 import type { AgentSessionStatus, SessionInfo, WorktreeInfo, WorkflowState, WorkflowStep } from '../api/types';
 import styles from '../styles/SessionDetail.module.css';
@@ -63,7 +64,7 @@ function buildFallbackSteps(workflow: WorkflowState): WorkflowStep[] {
 // Tab type
 // ---------------------------------------------------------------------------
 
-type ActiveTab = 'changes' | 'insights';
+type ActiveTab = 'changes' | 'insights' | 'terminal';
 
 // ---------------------------------------------------------------------------
 // Component
@@ -542,6 +543,17 @@ export function SessionDetail() {
                         >
                             Insights
                         </button>
+                        <button
+                            type="button"
+                            role="tab"
+                            id="tab-terminal"
+                            aria-selected={activeTab === 'terminal'}
+                            aria-controls="tabpanel-terminal"
+                            className={`${styles.tabButton} ${activeTab === 'terminal' ? styles.tabButtonActive : ''}`}
+                            onClick={() => setActiveTab('terminal')}
+                        >
+                            Terminal
+                        </button>
                     </div>
 
                     {/* Changes tab */}
@@ -654,6 +666,16 @@ export function SessionDetail() {
                                 loading={insightsLoading}
                                 error={insightsError}
                                 onGenerate={refreshInsights}
+                            />
+                        </div>
+                    )}
+
+                    {/* Terminal tab */}
+                    {activeTab === 'terminal' && (
+                        <div role="tabpanel" id="tabpanel-terminal" aria-labelledby="tab-terminal">
+                            <TerminalView
+                                apiClient={apiClient}
+                                terminalName={session.data?.tmuxSessionName ?? decodedName}
                             />
                         </div>
                     )}

--- a/web-ui/src/styles/TerminalView.module.css
+++ b/web-ui/src/styles/TerminalView.module.css
@@ -1,0 +1,262 @@
+/* ==========================================================================
+   TerminalView — terminal output display and input
+   ========================================================================== */
+
+.root {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    background-color: var(--color-bg-surface);
+    border: 1px solid var(--color-border-default);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    min-height: 400px;
+    max-height: 70vh;
+}
+
+/* --------------------------------------------------------------------------
+   Toolbar
+   -------------------------------------------------------------------------- */
+
+.toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--spacing-2) var(--spacing-3);
+    background-color: var(--color-bg-overlay);
+    border-bottom: 1px solid var(--color-border-default);
+    flex-shrink: 0;
+}
+
+.toolbarTitle {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-family: var(--font-family-mono);
+}
+
+.connectionStatus {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-1);
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    font-family: var(--font-family-mono);
+}
+
+.statusDot {
+    width: 6px;
+    height: 6px;
+    border-radius: var(--radius-full);
+    flex-shrink: 0;
+}
+
+.statusDotConnected {
+    background-color: var(--color-success);
+    box-shadow: 0 0 4px rgba(63, 185, 80, 0.6);
+}
+
+.statusDotConnecting {
+    background-color: var(--color-warning);
+    animation: pulse 1.4s ease-in-out infinite;
+}
+
+.statusDotError {
+    background-color: var(--color-danger);
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
+}
+
+/* --------------------------------------------------------------------------
+   Output area
+   -------------------------------------------------------------------------- */
+
+.output {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    overflow-x: auto;
+    padding: var(--spacing-3);
+    background-color: var(--color-bg-surface);
+}
+
+.pre {
+    margin: 0;
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+    color: var(--color-text-primary);
+    white-space: pre;
+    word-break: normal;
+    min-height: 100%;
+}
+
+/* Scrollbar styling for the output area */
+.output::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+}
+
+.output::-webkit-scrollbar-track {
+    background: var(--color-bg-surface);
+}
+
+.output::-webkit-scrollbar-thumb {
+    background: var(--color-border-emphasis);
+    border-radius: var(--radius-full);
+}
+
+.output::-webkit-scrollbar-thumb:hover {
+    background: var(--color-text-muted);
+}
+
+/* --------------------------------------------------------------------------
+   State overlays
+   -------------------------------------------------------------------------- */
+
+.connecting {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-3);
+    height: 100%;
+    min-height: 200px;
+    color: var(--color-text-secondary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    text-align: center;
+    padding: var(--spacing-4);
+}
+
+.connectingTitle {
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+    font-size: var(--font-size-base);
+}
+
+.connectingHint {
+    color: var(--color-text-muted);
+    font-size: var(--font-size-sm);
+    max-width: 400px;
+    line-height: 1.5;
+}
+
+.spinner {
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--color-border-default);
+    border-top-color: var(--color-warning);
+    border-radius: var(--radius-full);
+    animation: spin 0.7s linear infinite;
+    flex-shrink: 0;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+.errorBanner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+    padding: var(--spacing-3) var(--spacing-4);
+    background-color: rgba(248, 81, 73, 0.12);
+    border-bottom: 1px solid rgba(248, 81, 73, 0.3);
+    flex-shrink: 0;
+}
+
+.errorTitle {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-danger);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.errorMessage {
+    font-size: var(--font-size-sm);
+    color: var(--color-text-secondary);
+    font-family: var(--font-family-mono);
+}
+
+/* --------------------------------------------------------------------------
+   Input row
+   -------------------------------------------------------------------------- */
+
+.inputRow {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background-color: var(--color-bg-overlay);
+    border-top: 1px solid var(--color-border-default);
+    flex-shrink: 0;
+}
+
+.inputPrompt {
+    padding: var(--spacing-2) var(--spacing-2) var(--spacing-2) var(--spacing-3);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    color: var(--color-success);
+    flex-shrink: 0;
+    user-select: none;
+}
+
+.input {
+    flex: 1;
+    padding: var(--spacing-2) var(--spacing-2);
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--color-text-primary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    caret-color: var(--color-text-primary);
+}
+
+.input:focus-visible {
+    box-shadow: inset 0 0 0 1px var(--color-accent-primary);
+}
+
+.input::placeholder {
+    color: var(--color-text-muted);
+}
+
+.input:disabled {
+    color: var(--color-text-disabled);
+    cursor: not-allowed;
+}
+
+.sendButton {
+    padding: var(--spacing-2) var(--spacing-3);
+    background-color: transparent;
+    border: none;
+    border-left: 1px solid var(--color-border-default);
+    color: var(--color-text-secondary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-xs);
+    cursor: pointer;
+    transition: color 0.15s ease, background-color 0.15s ease;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.sendButton:hover:not(:disabled) {
+    color: var(--color-text-primary);
+    background-color: var(--color-bg-active);
+}
+
+.sendButton:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.sendButton:focus-visible {
+    outline: 2px solid var(--color-accent-primary);
+    outline-offset: -2px;
+}

--- a/web-ui/src/test/components/TerminalView.test.tsx
+++ b/web-ui/src/test/components/TerminalView.test.tsx
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { TerminalView } from '../../components/TerminalView';
+import type { DaemonApiClient } from '../../api/client';
+
+// ---------------------------------------------------------------------------
+// Mock useTerminal so we can control the hook's returned state
+// ---------------------------------------------------------------------------
+
+const mockUseTerminal = vi.fn();
+vi.mock('../../hooks/useTerminal', () => ({
+    useTerminal: (...args: unknown[]) => mockUseTerminal(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface UseTerminalState {
+    content: string;
+    rows: number;
+    cols: number;
+    connected: boolean;
+    error: Error | null;
+    sendInput: (text: string) => Promise<void>;
+    resize: (cols: number, rows: number) => Promise<void>;
+}
+
+function makeTerminalState(overrides: Partial<UseTerminalState> = {}): UseTerminalState {
+    return {
+        content: '',
+        rows: 0,
+        cols: 0,
+        connected: false,
+        error: null,
+        sendInput: vi.fn().mockResolvedValue(undefined),
+        resize: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    };
+}
+
+function makeApiClient(): DaemonApiClient {
+    return {
+        streamTerminalOutput: vi.fn().mockReturnValue({ close: vi.fn() }),
+        sendToTerminal: vi.fn().mockResolvedValue(undefined),
+        resizeTerminal: vi.fn().mockResolvedValue(undefined),
+    } as unknown as DaemonApiClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TerminalView component', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // -------------------------------------------------------------------------
+    // High: renders-connecting
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient and terminalName are provided but no SSE event has arrived yet, when TerminalView renders, then it shows a connecting indicator', () => {
+        mockUseTerminal.mockReturnValue(makeTerminalState({ connected: false, error: null }));
+
+        const apiClient = makeApiClient();
+
+        render(<TerminalView apiClient={apiClient} terminalName="my-terminal" />);
+
+        // The connecting spinner/status should be present
+        expect(screen.getByRole('status', { name: /connecting to terminal/i })).toBeInTheDocument();
+        // Status label in toolbar should say "Connecting…"
+        expect(screen.getByText('Connecting\u2026')).toBeInTheDocument();
+    });
+
+    // -------------------------------------------------------------------------
+    // Critical: renders-content
+    // -------------------------------------------------------------------------
+
+    it('Given the useTerminal hook returns content, when TerminalView renders, then the content is displayed in a pre element', () => {
+        mockUseTerminal.mockReturnValue(
+            makeTerminalState({ connected: true, content: 'Hello, terminal!' })
+        );
+
+        const apiClient = makeApiClient();
+
+        render(<TerminalView apiClient={apiClient} terminalName="my-terminal" />);
+
+        const pre = screen.getByText('Hello, terminal!');
+        expect(pre.tagName.toLowerCase()).toBe('pre');
+    });
+
+    // -------------------------------------------------------------------------
+    // High: strips-ansi
+    // -------------------------------------------------------------------------
+
+    it('Given terminal content contains ANSI escape sequences like \\x1b[32m, when TerminalView renders, then those sequences are removed from the displayed text', () => {
+        const rawContent = '\x1b[32mGreen text\x1b[0m and \x1b[1mbold\x1b[0m';
+        mockUseTerminal.mockReturnValue(
+            makeTerminalState({ connected: true, content: rawContent })
+        );
+
+        const apiClient = makeApiClient();
+
+        render(<TerminalView apiClient={apiClient} terminalName="my-terminal" />);
+
+        // The pre element should show stripped text only
+        const pre = screen.getByText('Green text and bold');
+        expect(pre.tagName.toLowerCase()).toBe('pre');
+        expect(pre.textContent).not.toContain('\x1b');
+    });
+
+    // -------------------------------------------------------------------------
+    // Critical: send-input
+    // -------------------------------------------------------------------------
+
+    it('Given a user types text in the input field and presses Enter, when the key event fires, then sendInput is called with the typed text and the input field is cleared', async () => {
+        const sendInput = vi.fn().mockResolvedValue(undefined);
+        mockUseTerminal.mockReturnValue(
+            makeTerminalState({ connected: true, sendInput })
+        );
+
+        const apiClient = makeApiClient();
+
+        render(<TerminalView apiClient={apiClient} terminalName="my-terminal" />);
+
+        const input = screen.getByRole('textbox', { name: /terminal input/i });
+
+        // Type into the input
+        fireEvent.change(input, { target: { value: 'ls -la' } });
+        expect(input).toHaveValue('ls -la');
+
+        // Press Enter
+        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+        // sendInput should be called with the typed text
+        await waitFor(() => {
+            expect(sendInput).toHaveBeenCalledWith('ls -la');
+        });
+
+        // Input should be cleared after send
+        await waitFor(() => {
+            expect(input).toHaveValue('');
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // High: error-state
+    // -------------------------------------------------------------------------
+
+    it('Given the useTerminal hook returns an error, when TerminalView renders, then an error message is displayed', () => {
+        const error = new Error('Connection refused');
+        mockUseTerminal.mockReturnValue(
+            makeTerminalState({ connected: false, error })
+        );
+
+        const apiClient = makeApiClient();
+
+        render(<TerminalView apiClient={apiClient} terminalName="my-terminal" />);
+
+        // Error banner with role="alert" should be present
+        const alert = screen.getByRole('alert');
+        expect(alert).toBeInTheDocument();
+        expect(alert).toHaveTextContent('Connection refused');
+
+        // Status label should say "Error"
+        expect(screen.getByText('Error')).toBeInTheDocument();
+    });
+});

--- a/web-ui/src/test/hooks/useTerminal.test.ts
+++ b/web-ui/src/test/hooks/useTerminal.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { useTerminal } from '../../hooks/useTerminal';
+import type { DaemonApiClient } from '../../api/client';
+import type { TerminalOutputData } from '../../api/types';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Creates a fake stream handle whose callbacks can be invoked in tests. */
+function makeStreamHandle() {
+    let storedOnData: ((data: TerminalOutputData) => void) | undefined;
+    let storedOnError: ((err: Error) => void) | undefined;
+    const closeFn = vi.fn();
+
+    const streamTerminalOutput = vi.fn(
+        (
+            _name: string,
+            onData: (data: TerminalOutputData) => void,
+            onError?: (err: Error) => void
+        ) => {
+            storedOnData = onData;
+            storedOnError = onError;
+            return { close: closeFn };
+        }
+    );
+
+    return {
+        streamTerminalOutput,
+        closeFn,
+        emitData: (data: TerminalOutputData) => storedOnData?.(data),
+        emitError: (err: Error) => storedOnError?.(err),
+    };
+}
+
+function makeApiClient(overrides: Partial<DaemonApiClient> = {}): DaemonApiClient {
+    return {
+        streamTerminalOutput: vi.fn().mockReturnValue({ close: vi.fn() }),
+        sendToTerminal: vi.fn().mockResolvedValue(undefined),
+        resizeTerminal: vi.fn().mockResolvedValue(undefined),
+        ...overrides,
+    } as unknown as DaemonApiClient;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTerminal hook', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    // -------------------------------------------------------------------------
+    // Critical: no-client
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient is null, when useTerminal is called, then content is empty string, rows and cols are 0, connected is false, error is null', () => {
+        const { result } = renderHook(() => useTerminal(null, 'my-terminal'));
+
+        expect(result.current.content).toBe('');
+        expect(result.current.rows).toBe(0);
+        expect(result.current.cols).toBe(0);
+        expect(result.current.connected).toBe(false);
+        expect(result.current.error).toBeNull();
+    });
+
+    // -------------------------------------------------------------------------
+    // Critical: no-name
+    // -------------------------------------------------------------------------
+
+    it('Given terminalName is undefined, when useTerminal is called, then content is empty string, connected is false', () => {
+        const apiClient = makeApiClient();
+
+        const { result } = renderHook(() => useTerminal(apiClient, undefined));
+
+        expect(result.current.content).toBe('');
+        expect(result.current.connected).toBe(false);
+    });
+
+    // -------------------------------------------------------------------------
+    // Critical: stream-data
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient and terminalName are provided, when streamTerminalOutput calls onData callback with TerminalOutputData, then content, rows, cols are updated and connected becomes true', async () => {
+        const handle = makeStreamHandle();
+        const apiClient = makeApiClient({ streamTerminalOutput: handle.streamTerminalOutput });
+
+        const { result } = renderHook(() => useTerminal(apiClient, 'my-terminal'));
+
+        // Stream should have been started
+        expect(handle.streamTerminalOutput).toHaveBeenCalledWith(
+            'my-terminal',
+            expect.any(Function),
+            expect.any(Function)
+        );
+
+        act(() => {
+            handle.emitData({ content: 'Hello world', rows: 24, cols: 80 });
+        });
+
+        await waitFor(() => {
+            expect(result.current.content).toBe('Hello world');
+            expect(result.current.rows).toBe(24);
+            expect(result.current.cols).toBe(80);
+            expect(result.current.connected).toBe(true);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // High: stream-error
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient and terminalName are provided, when streamTerminalOutput calls onError callback, then error state is set and connected is false', async () => {
+        const handle = makeStreamHandle();
+        const apiClient = makeApiClient({ streamTerminalOutput: handle.streamTerminalOutput });
+
+        const { result } = renderHook(() => useTerminal(apiClient, 'my-terminal'));
+
+        act(() => {
+            handle.emitError(new Error('Stream disconnected'));
+        });
+
+        await waitFor(() => {
+            expect(result.current.error).toBeInstanceOf(Error);
+            expect(result.current.error?.message).toBe('Stream disconnected');
+            expect(result.current.connected).toBe(false);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // High: send-input
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient and terminalName are provided, when sendInput is called with text, then apiClient.sendToTerminal is called with the terminal name and the text', async () => {
+        const apiClient = makeApiClient();
+
+        const { result } = renderHook(() => useTerminal(apiClient, 'my-terminal'));
+
+        await act(async () => {
+            await result.current.sendInput('ls -la');
+        });
+
+        expect(apiClient.sendToTerminal).toHaveBeenCalledWith('my-terminal', { text: 'ls -la' });
+    });
+
+    // -------------------------------------------------------------------------
+    // Medium: resize
+    // -------------------------------------------------------------------------
+
+    it('Given apiClient and terminalName are provided, when resize is called with cols and rows, then apiClient.resizeTerminal is called with correct params', async () => {
+        const apiClient = makeApiClient();
+
+        const { result } = renderHook(() => useTerminal(apiClient, 'my-terminal'));
+
+        await act(async () => {
+            await result.current.resize(120, 40);
+        });
+
+        expect(apiClient.resizeTerminal).toHaveBeenCalledWith('my-terminal', { cols: 120, rows: 40 });
+    });
+
+    // -------------------------------------------------------------------------
+    // High: cleanup
+    // -------------------------------------------------------------------------
+
+    it('Given the hook has started a stream, when the component unmounts, then the close() method on the stream handle is called', () => {
+        const handle = makeStreamHandle();
+        const apiClient = makeApiClient({ streamTerminalOutput: handle.streamTerminalOutput });
+
+        const { unmount } = renderHook(() => useTerminal(apiClient, 'my-terminal'));
+
+        expect(handle.streamTerminalOutput).toHaveBeenCalled();
+        expect(handle.closeFn).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(handle.closeFn).toHaveBeenCalledOnce();
+    });
+});

--- a/web-ui/src/test/pages/SessionDetail.test.tsx
+++ b/web-ui/src/test/pages/SessionDetail.test.tsx
@@ -66,6 +66,9 @@ function makeApiClient(sessions: SessionInfo[], worktree: WorktreeInfo, workflow
         getSessionDiffFiles: vi.fn().mockResolvedValue({ files: [], sessionName: 'my-session' }),
         getSessionDiff: vi.fn().mockResolvedValue({ diff: '', sessionName: 'my-session' }),
         getSessionInsights: vi.fn().mockResolvedValue({ insights: '', analysis: undefined, sessionName: 'my-session' }),
+        streamTerminalOutput: vi.fn().mockReturnValue({ close: vi.fn() }),
+        sendToTerminal: vi.fn().mockResolvedValue(undefined),
+        resizeTerminal: vi.fn().mockResolvedValue(undefined),
     } as unknown as DaemonApiClient;
 }
 
@@ -269,6 +272,58 @@ describe('SessionDetail', () => {
         // The last call should pass includeUncommitted=true
         const lastCall = vi.mocked(apiClient.getSessionDiff).mock.calls.at(-1);
         expect(lastCall?.[1]).toBe(true);
+    });
+
+    // -------------------------------------------------------------------------
+    // SessionDetail-terminal-tab: Terminal tab button is present
+    // -------------------------------------------------------------------------
+
+    it('Given a session is loaded, when the tab bar renders, then a Terminal tab button is present', async () => {
+        const session = makeSession({ name: 'my-session' });
+        const apiClient = makeApiClient([session], makeWorktreeInfo(), makeWorkflowState());
+
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient,
+            sseClient: null,
+            loading: false,
+            error: null,
+        });
+
+        renderSessionDetail('3942', 'my-session');
+
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: /terminal/i })).toBeInTheDocument();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // SessionDetail-terminal-tab-content: TerminalView shown when Terminal tab clicked
+    // -------------------------------------------------------------------------
+
+    it('Given a session is loaded and the Terminal tab is clicked, when the tab panel renders, then the TerminalView component is shown', async () => {
+        const session = makeSession({ name: 'my-session' });
+        const apiClient = makeApiClient([session], makeWorktreeInfo(), makeWorkflowState());
+
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient,
+            sseClient: null,
+            loading: false,
+            error: null,
+        });
+
+        renderSessionDetail('3942', 'my-session');
+
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: /terminal/i })).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('tab', { name: /terminal/i })).toHaveAttribute('aria-selected', 'true');
+            // TerminalView renders an aria-label="Terminal output" on its output div
+            expect(screen.getByLabelText(/terminal output/i)).toBeInTheDocument();
+        });
     });
 });
 


### PR DESCRIPTION
Add the ability to view and interact with running agent chat sessions from the web UI. Terminal output is streamed via SSE through the daemon, with input sent via the existing terminal send endpoint.

Backend:
- Add ITerminalIOProvider interface for extensibility (future agents)
- Add TmuxTerminalIOProvider with capturePane, sendKeys, resize
- Extend TmuxService with capturePane, getPaneSize, resizePane, sendKeys
- Add daemon endpoints: GET /output, POST /resize, GET /stream (SSE)
- Persist tmuxSessionName in session data for reliable lookup
- Update DaemonClient and web DaemonApiClient

Web UI:
- Add useTerminal hook with SSE streaming
- Add TerminalView component with ANSI stripping, smart auto-scroll, connection timeout message, and chat input
- Add Terminal tab to SessionDetail page