### PR TITLE
feat: add session preflight dependency checks

### DIFF
--- a/src/cli/commands/create.ts
+++ b/src/cli/commands/create.ts
@@ -14,6 +14,7 @@ import {
     initializeGlobalStorageContext,
 } from '../../core/session/SessionDataService';
 import { createSessionWorktree } from '../../core/services/SessionCreationService';
+import * as PreflightService from '../../core/services/PreflightService';
 import { execIntoAgent } from './open';
 
 export function registerCreateCommand(program: Command): void {
@@ -68,6 +69,12 @@ export function registerCreateCommand(program: Command): void {
                 // Create worktree via core service
                 console.log(`Creating session '${sanitizedName}'...`);
                 const propagationMode = config.get<LocalSettingsPropagationMode>('lanes', 'localSettingsPropagation', 'copy');
+                const useTmux = options.tmux || config.get<string>('lanes', 'terminalMode', 'vscode') === 'tmux';
+
+                await PreflightService.assertSessionLaunchPrerequisites({
+                    codeAgent,
+                    terminalMode: useTmux ? 'tmux' : 'vscode',
+                });
 
                 const { worktreePath } = await createSessionWorktree({
                     repoRoot,
@@ -96,7 +103,7 @@ export function registerCreateCommand(program: Command): void {
                     prompt: options.prompt,
                     permissionMode: options.permissionMode || config.get('lanes', 'permissionMode', 'acceptEdits'),
                     workflow: options.workflow,
-                    useTmux: options.tmux || config.get<string>('lanes', 'terminalMode', 'vscode') === 'tmux',
+                    useTmux,
                     isNewSession: true,
                 });
             } catch (err) {

--- a/src/cli/commands/open.ts
+++ b/src/cli/commands/open.ts
@@ -22,6 +22,7 @@ import { CodeAgent } from '../../core/codeAgents/CodeAgent';
 import type { McpConfig } from '../../core/codeAgents/CodeAgent';
 import { prepareAgentLaunchContext } from '../../core/services/AgentLaunchService';
 import * as TmuxService from '../../core/services/TmuxService';
+import * as PreflightService from '../../core/services/PreflightService';
 
 /**
  * Shared function used by both `lanes open` and `lanes create` to exec into an agent.
@@ -171,6 +172,12 @@ export function registerOpenCommand(program: Command): void {
                     repoRoot,
                     codeAgent
                 );
+                const useTmux = options.tmux || config.get<string>('lanes', 'terminalMode', 'vscode') === 'tmux';
+
+                await PreflightService.assertSessionLaunchPrerequisites({
+                    codeAgent,
+                    terminalMode: useTmux ? 'tmux' : 'vscode',
+                });
 
                 await execIntoAgent({
                     sessionName,
@@ -178,7 +185,7 @@ export function registerOpenCommand(program: Command): void {
                     repoRoot,
                     codeAgent,
                     config,
-                    useTmux: options.tmux || config.get<string>('lanes', 'terminalMode', 'vscode') === 'tmux',
+                    useTmux,
                     isNewSession: false,
                 });
             } catch (err) {

--- a/src/core/services/PreflightService.ts
+++ b/src/core/services/PreflightService.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { CodeAgent } from '../codeAgents/CodeAgent';
+import { isTmuxMode } from './TmuxService';
+
+const execFileAsync = promisify(execFile);
+const COMMAND_CHECK_TIMEOUT_MS = 5_000;
+
+export interface MissingPrerequisite {
+    command: string;
+    message: string;
+}
+
+export interface SessionPreflightOptions {
+    codeAgent: CodeAgent;
+    terminalMode?: string;
+    requireJq?: boolean;
+}
+
+async function isCommandAvailable(command: string): Promise<boolean> {
+    try {
+        await execFileAsync('which', [command], { timeout: COMMAND_CHECK_TIMEOUT_MS });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+export const preflightDeps = {
+    isCommandAvailable,
+};
+
+export async function getMissingSessionPrerequisites(
+    options: SessionPreflightOptions
+): Promise<MissingPrerequisite[]> {
+    const { codeAgent, terminalMode, requireJq = true } = options;
+    const missing: MissingPrerequisite[] = [];
+
+    if (requireJq && !await preflightDeps.isCommandAvailable('jq')) {
+        missing.push({
+            command: 'jq',
+            message: 'jq is required for session tracking and workflow hooks.',
+        });
+    }
+
+    if (!await preflightDeps.isCommandAvailable(codeAgent.cliCommand)) {
+        missing.push({
+            command: codeAgent.cliCommand,
+            message: `${codeAgent.displayName} CLI ('${codeAgent.cliCommand}') is not installed.`,
+        });
+    }
+
+    if (isTmuxMode(terminalMode) && !await preflightDeps.isCommandAvailable('tmux')) {
+        missing.push({
+            command: 'tmux',
+            message: 'tmux is required when lanes.terminalMode is set to tmux.',
+        });
+    }
+
+    return missing;
+}
+
+export function formatMissingPrerequisites(
+    missing: MissingPrerequisite[]
+): string {
+    if (missing.length === 0) {
+        return 'All prerequisites are installed.';
+    }
+
+    if (missing.length === 1) {
+        return `${missing[0].message} Install it and try again.`;
+    }
+
+    return `Missing prerequisites: ${missing.map((item) => item.message).join(' ')} Install them and try again.`;
+}
+
+export async function assertSessionLaunchPrerequisites(
+    options: SessionPreflightOptions
+): Promise<void> {
+    const missing = await getMissingSessionPrerequisites(options);
+    if (missing.length > 0) {
+        throw new Error(formatMissingPrerequisites(missing));
+    }
+}

--- a/src/core/services/SessionHandlerService.ts
+++ b/src/core/services/SessionHandlerService.ts
@@ -39,6 +39,7 @@ import {
     setSessionChimeEnabled,
     getSessionTmuxName,
     getSessionTerminalMode,
+    getSessionAgentName,
 } from '../session/SessionDataService';
 import { ValidationError } from '../errors/ValidationError';
 import * as TmuxService from './TmuxService';
@@ -51,11 +52,13 @@ import { assemblePrompt, writePromptFile } from './PromptService';
 import { getAgent, getAvailableAgents } from '../codeAgents';
 import { readJson } from './FileService';
 import { buildAgentLaunchCommand, prepareAgentLaunchContext } from './AgentLaunchSetupService';
+import * as PreflightService from './PreflightService';
 import { IHandlerContext } from '../interfaces/IHandlerContext';
 import { validateSessionName as coreValidateSessionName, validateComparisonRef } from '../validation';
 import { generateInsights, formatInsightsReport, SessionInsights } from './InsightsService';
 import { analyzeInsights } from './InsightsAnalyzer';
 import type { SettingsScope, SettingsView } from './UnifiedSettingsService';
+import { CodeAgent } from '../codeAgents/CodeAgent';
 
 const MAX_SESSION_FORM_ATTACHMENTS = 20;
 const MAX_PROMPT_IMPROVE_STDOUT = 1024 * 1024;
@@ -173,6 +176,31 @@ export class SessionHandlerService {
         return mode ?? 'vscode';
     }
 
+    private getDefaultAgentName(): string {
+        return (this.ctx.config.get('lanes.defaultAgent') as string | undefined) ?? 'claude';
+    }
+
+    private resolveLaunchAgent(agentName?: string): CodeAgent {
+        const defaultAgentName = this.getDefaultAgentName();
+        return getAgent(agentName ?? defaultAgentName)
+            ?? getAgent(defaultAgentName)
+            ?? getAgent('claude')!;
+    }
+
+    private async assertSessionLaunchPrerequisites(
+        codeAgent: CodeAgent,
+        preferredTerminalMode?: string | null
+    ): Promise<void> {
+        const terminalMode = this.normalizeTerminalMode(
+            preferredTerminalMode ?? this.ctx.config.get('lanes.terminalMode') as string | undefined
+        );
+
+        await PreflightService.assertSessionLaunchPrerequisites({
+            codeAgent,
+            terminalMode,
+        });
+    }
+
     private async prepareTerminalLaunch(
         sessionName: string,
         worktreePath: string,
@@ -190,21 +218,23 @@ export class SessionHandlerService {
 
         if (TmuxService.isTmuxMode(terminalMode)) {
             const tmuxInstalled = await TmuxService.isTmuxInstalled();
-            if (tmuxInstalled) {
-                const tmuxResult = await TmuxService.launchInTmux({
-                    sessionName,
-                    worktreePath,
-                    command: agentCommand,
-                });
-                await saveSessionTerminalMode(worktreePath, 'tmux');
-                await saveSessionTmuxName(worktreePath, tmuxResult.tmuxSessionName);
-                return {
-                    terminalMode: 'tmux',
-                    command: tmuxResult.attachCommand,
-                    attachCommand: tmuxResult.attachCommand,
-                    tmuxSessionName: tmuxResult.tmuxSessionName,
-                };
+            if (!tmuxInstalled) {
+                throw new Error('tmux is not installed. Install tmux or switch lanes.terminalMode to vscode.');
             }
+
+            const tmuxResult = await TmuxService.launchInTmux({
+                sessionName,
+                worktreePath,
+                command: agentCommand,
+            });
+            await saveSessionTerminalMode(worktreePath, 'tmux');
+            await saveSessionTmuxName(worktreePath, tmuxResult.tmuxSessionName);
+            return {
+                terminalMode: 'tmux',
+                command: tmuxResult.attachCommand,
+                attachCommand: tmuxResult.attachCommand,
+                tmuxSessionName: tmuxResult.tmuxSessionName,
+            };
         }
 
         await saveSessionTerminalMode(worktreePath, 'vscode');
@@ -514,6 +544,9 @@ export class SessionHandlerService {
 
         const worktreesFolder = getWorktreesFolder();
         const worktreePath = path.join(this.ctx.workspaceRoot, worktreesFolder, name);
+        const codeAgent = this.resolveLaunchAgent(agent);
+
+        await this.assertSessionLaunchPrerequisites(codeAgent);
 
         const worktreeArgs = ['worktree', 'add'];
         if (branch) {
@@ -533,8 +566,7 @@ export class SessionHandlerService {
                 workflow: workflow ?? null,
                 permissionMode,
                 agentName: agent,
-                defaultAgentName:
-                    (this.ctx.config.get('lanes.defaultAgent') as string) ?? 'claude',
+                defaultAgentName: this.getDefaultAgentName(),
                 repoRoot: this.ctx.workspaceRoot,
                 workflowResolver: (name: string) => this.resolveWorkflowPath(name),
             });
@@ -746,18 +778,24 @@ export class SessionHandlerService {
 
         const worktreesFolder = getWorktreesFolder();
         const worktreePath = path.join(this.ctx.workspaceRoot, worktreesFolder, sessionName);
+        const savedTerminalMode = await getSessionTerminalMode(worktreePath);
+        const sessionAgentName = await getSessionAgentName(worktreePath);
+
+        await this.assertSessionLaunchPrerequisites(
+            this.resolveLaunchAgent(sessionAgentName),
+            savedTerminalMode
+        );
 
         const launchContext = await prepareAgentLaunchContext({
             worktreePath,
             workflow: null,
             permissionMode: undefined,
-            defaultAgentName:
-                (this.ctx.config.get('lanes.defaultAgent') as string) ?? 'claude',
+            agentName: sessionAgentName,
+            defaultAgentName: this.getDefaultAgentName(),
             repoRoot: this.ctx.workspaceRoot,
             workflowResolver: (name: string) => this.resolveWorkflowPath(name),
         });
         const launch = await buildAgentLaunchCommand(launchContext);
-        const savedTerminalMode = await getSessionTerminalMode(worktreePath);
 
         const terminalLaunch = await this.prepareTerminalLaunch(
             sessionName,

--- a/src/test/cli/commands/create.test.ts
+++ b/src/test/cli/commands/create.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { chmodSync } from 'fs';
+import { Command } from 'commander';
+import sinon from 'sinon';
+import { registerCreateCommand } from '../../../cli/commands/create';
+import * as cliUtils from '../../../cli/utils';
+import * as PreflightService from '../../../core/services/PreflightService';
+import * as SessionCreationService from '../../../core/services/SessionCreationService';
+import * as SessionDataService from '../../../core/session/SessionDataService';
+import * as openCommand from '../../../cli/commands/open';
+
+suite('CreateCommand', () => {
+    let tempDir: string;
+    let binDir: string;
+    let originalPath: string | undefined;
+    let program: Command;
+    let initCliStub: sinon.SinonStub;
+    let initializeStorageStub: sinon.SinonStub;
+    let isCommandAvailableStub: sinon.SinonStub;
+    let createSessionWorktreeStub: sinon.SinonStub;
+    let execIntoAgentStub: sinon.SinonStub;
+    let processExitStub: sinon.SinonStub;
+    let consoleErrorStub: sinon.SinonStub;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-create-command-'));
+        binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-create-bin-'));
+        fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n', 'utf-8');
+        chmodSync(path.join(binDir, 'claude'), 0o755);
+        originalPath = process.env.PATH;
+        process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+
+        program = new Command();
+        program.exitOverride();
+        program.configureOutput({
+            writeOut: () => {},
+            writeErr: () => {},
+        });
+
+        initCliStub = sinon.stub(cliUtils, 'initCli').resolves({
+            config: {
+                get: <T>(_section: string, key: string, fallback: T): T => {
+                    if (key === 'worktreesFolder') { return '.worktrees' as T; }
+                    if (key === 'defaultAgent') { return 'claude' as T; }
+                    if (key === 'localSettingsPropagation') { return 'copy' as T; }
+                    if (key === 'terminalMode') { return 'vscode' as T; }
+                    return fallback;
+                },
+            } as never,
+            repoRoot: tempDir,
+        });
+        initializeStorageStub = sinon.stub(SessionDataService, 'initializeGlobalStorageContext').returns(undefined);
+        isCommandAvailableStub = sinon.stub(PreflightService.preflightDeps, 'isCommandAvailable').callsFake(async (command: string) => {
+            return command === 'claude';
+        });
+        createSessionWorktreeStub = sinon.stub(SessionCreationService, 'createSessionWorktree').resolves({
+            worktreePath: path.join(tempDir, '.worktrees', 'feat-preflight'),
+        });
+        execIntoAgentStub = sinon.stub(openCommand, 'execIntoAgent').resolves();
+        consoleErrorStub = sinon.stub(console, 'error');
+        processExitStub = sinon.stub(process, 'exit').callsFake(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 0}`);
+        }) as never);
+
+        registerCreateCommand(program);
+    });
+
+    teardown(() => {
+        sinon.restore();
+        process.env.PATH = originalPath;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        fs.rmSync(binDir, { recursive: true, force: true });
+    });
+
+    test('exits before creating a session when preflight fails', async () => {
+        await assert.rejects(
+            program.parseAsync(['node', 'lanes', 'create', '--name', 'feat-preflight']),
+            /process\.exit:1/
+        );
+
+        sinon.assert.calledWith(isCommandAvailableStub, 'jq');
+        sinon.assert.notCalled(createSessionWorktreeStub);
+        sinon.assert.notCalled(execIntoAgentStub);
+        sinon.assert.calledWith(
+            consoleErrorStub,
+            'Error: jq is required for session tracking and workflow hooks. Install it and try again.'
+        );
+        sinon.assert.calledWith(processExitStub, 1);
+    });
+});

--- a/src/test/cli/commands/open.test.ts
+++ b/src/test/cli/commands/open.test.ts
@@ -1,0 +1,81 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { chmodSync } from 'fs';
+import { Command } from 'commander';
+import sinon from 'sinon';
+import { registerOpenCommand } from '../../../cli/commands/open';
+import * as cliUtils from '../../../cli/utils';
+import * as PreflightService from '../../../core/services/PreflightService';
+
+suite('OpenCommand', () => {
+    let tempDir: string;
+    let worktreePath: string;
+    let binDir: string;
+    let originalPath: string | undefined;
+    let program: Command;
+    let initCliStub: sinon.SinonStub;
+    let isCommandAvailableStub: sinon.SinonStub;
+    let processExitStub: sinon.SinonStub;
+    let consoleErrorStub: sinon.SinonStub;
+
+    setup(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-open-command-'));
+        worktreePath = path.join(tempDir, '.worktrees', 'feat-preflight');
+        fs.mkdirSync(worktreePath, { recursive: true });
+        binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-open-bin-'));
+        fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\nexit 0\n', 'utf-8');
+        chmodSync(path.join(binDir, 'claude'), 0o755);
+        originalPath = process.env.PATH;
+        process.env.PATH = `${binDir}:${originalPath ?? ''}`;
+
+        program = new Command();
+        program.exitOverride();
+        program.configureOutput({
+            writeOut: () => {},
+            writeErr: () => {},
+        });
+
+        initCliStub = sinon.stub(cliUtils, 'initCli').resolves({
+            config: {
+                get: <T>(_section: string, key: string, fallback: T): T => {
+                    if (key === 'worktreesFolder') { return '.worktrees' as T; }
+                    if (key === 'terminalMode') { return 'tmux' as T; }
+                    return fallback;
+                },
+            } as never,
+            repoRoot: tempDir,
+        });
+        isCommandAvailableStub = sinon.stub(PreflightService.preflightDeps, 'isCommandAvailable').callsFake(async (command: string) => {
+            return command !== 'tmux';
+        });
+        consoleErrorStub = sinon.stub(console, 'error');
+        processExitStub = sinon.stub(process, 'exit').callsFake(((code?: number) => {
+            throw new Error(`process.exit:${code ?? 0}`);
+        }) as never);
+
+        registerOpenCommand(program);
+    });
+
+    teardown(() => {
+        sinon.restore();
+        process.env.PATH = originalPath;
+        fs.rmSync(tempDir, { recursive: true, force: true });
+        fs.rmSync(binDir, { recursive: true, force: true });
+    });
+
+    test('exits before launching a session when preflight fails', async () => {
+        await assert.rejects(
+            program.parseAsync(['node', 'lanes', 'open', 'feat-preflight']),
+            /process\.exit:1/
+        );
+
+        sinon.assert.calledWith(isCommandAvailableStub, 'tmux');
+        sinon.assert.calledWith(
+            consoleErrorStub,
+            'Error: tmux is required when lanes.terminalMode is set to tmux. Install it and try again.'
+        );
+        sinon.assert.calledWith(processExitStub, 1);
+    });
+});

--- a/src/test/core/services/PreflightService.test.ts
+++ b/src/test/core/services/PreflightService.test.ts
@@ -1,0 +1,82 @@
+import * as assert from 'assert';
+import sinon from 'sinon';
+import { getAgent } from '../../../core/codeAgents';
+import {
+    assertSessionLaunchPrerequisites,
+    formatMissingPrerequisites,
+    getMissingSessionPrerequisites,
+    preflightDeps,
+} from '../../../core/services/PreflightService';
+
+suite('PreflightService', () => {
+    let isCommandAvailableStub: sinon.SinonStub;
+
+    setup(() => {
+        isCommandAvailableStub = sinon.stub(preflightDeps, 'isCommandAvailable').resolves(true);
+    });
+
+    teardown(() => {
+        isCommandAvailableStub.restore();
+    });
+
+    test('returns no missing prerequisites when jq, agent CLI, and tmux are installed', async () => {
+        const missing = await getMissingSessionPrerequisites({
+            codeAgent: getAgent('claude')!,
+            terminalMode: 'tmux',
+        });
+
+        assert.deepStrictEqual(missing, []);
+        sinon.assert.calledWith(isCommandAvailableStub, 'jq');
+        sinon.assert.calledWith(isCommandAvailableStub, 'claude');
+        sinon.assert.calledWith(isCommandAvailableStub, 'tmux');
+    });
+
+    test('skips tmux checks when terminal mode is not tmux', async () => {
+        await getMissingSessionPrerequisites({
+            codeAgent: getAgent('codex')!,
+            terminalMode: 'vscode',
+        });
+
+        sinon.assert.neverCalledWith(isCommandAvailableStub, 'tmux');
+    });
+
+    test('reports jq, agent CLI, and tmux when they are missing', async () => {
+        isCommandAvailableStub.callsFake(async (command: string) => command === 'claude');
+
+        const missing = await getMissingSessionPrerequisites({
+            codeAgent: getAgent('codex')!,
+            terminalMode: 'tmux',
+        });
+
+        assert.deepStrictEqual(
+            missing.map((item) => item.command),
+            ['jq', 'codex', 'tmux']
+        );
+    });
+
+    test('assertSessionLaunchPrerequisites throws a combined user-facing error', async () => {
+        isCommandAvailableStub.callsFake(async (command: string) => command === 'claude');
+
+        await assert.rejects(
+            assertSessionLaunchPrerequisites({
+                codeAgent: getAgent('codex')!,
+                terminalMode: 'tmux',
+            }),
+            /Missing prerequisites: jq is required.*Codex CLI.*tmux is required/
+        );
+    });
+
+    test('formatMissingPrerequisites adds install guidance for a single issue', () => {
+        const message = formatMissingPrerequisites([
+            {
+                command: 'jq',
+                message: 'jq is required for session tracking and workflow hooks.',
+            },
+        ]);
+
+        assert.strictEqual(
+            message,
+            'jq is required for session tracking and workflow hooks. Install it and try again.'
+        );
+    });
+});

--- a/src/test/jetbrains-ide-bridge/session-create.test.ts
+++ b/src/test/jetbrains-ide-bridge/session-create.test.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import sinon from 'sinon';
 import * as gitService from '../../core/gitService';
 import * as launchSetupService from '../../core/services/AgentLaunchSetupService';
+import * as PreflightService from '../../core/services/PreflightService';
 import * as tmuxService from '../../core/services/TmuxService';
 import { ConfigStore } from '../../jetbrains-ide-bridge/config';
 import { NotificationEmitter } from '../../jetbrains-ide-bridge/notifications';
@@ -17,6 +18,7 @@ suite('Bridge session.create branch behavior', () => {
     let execGitStub: sinon.SinonStub;
     let prepareLaunchContextStub: sinon.SinonStub;
     let buildLaunchCommandStub: sinon.SinonStub;
+    let preflightStub: sinon.SinonStub;
     let isTmuxInstalledStub: sinon.SinonStub;
     let launchInTmuxStub: sinon.SinonStub;
 
@@ -40,6 +42,7 @@ suite('Bridge session.create branch behavior', () => {
             mode: 'start',
             command: 'claude --settings "/tmp/claude-settings.json"'
         });
+        preflightStub = sinon.stub(PreflightService, 'assertSessionLaunchPrerequisites').resolves();
         isTmuxInstalledStub = sinon.stub(tmuxService, 'isTmuxInstalled').resolves(false);
         launchInTmuxStub = sinon.stub(tmuxService, 'launchInTmux').resolves({
             tmuxSessionName: 'feat-command',
@@ -52,6 +55,7 @@ suite('Bridge session.create branch behavior', () => {
         execGitStub.restore();
         prepareLaunchContextStub.restore();
         buildLaunchCommandStub.restore();
+        preflightStub.restore();
         isTmuxInstalledStub.restore();
         launchInTmuxStub.restore();
         fs.rmSync(tempDir, { recursive: true, force: true });
@@ -142,6 +146,22 @@ suite('Bridge session.create branch behavior', () => {
         assert.strictEqual(result.command, 'claude --settings "/tmp/claude-settings.json"');
         sinon.assert.called(prepareLaunchContextStub);
         sinon.assert.called(buildLaunchCommandStub);
+    });
+
+    test('fails before creating the worktree when preflight detects missing prerequisites', async () => {
+        preflightStub.rejects(new Error('jq is required for session tracking and workflow hooks.'));
+
+        await assert.rejects(
+            handleRequest('session.create', {
+                name: 'feat-missing-jq',
+                branch: ''
+            }),
+            /jq is required/
+        );
+
+        sinon.assert.notCalled(execGitStub);
+        sinon.assert.notCalled(prepareLaunchContextStub);
+        sinon.assert.notCalled(buildLaunchCommandStub);
     });
 
     test('returns explicit tmux metadata when tmux mode is enabled on session.create', async () => {

--- a/src/test/jetbrains-ide-bridge/session-open.test.ts
+++ b/src/test/jetbrains-ide-bridge/session-open.test.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import sinon from 'sinon';
 import * as launchSetupService from '../../core/services/AgentLaunchSetupService';
+import * as PreflightService from '../../core/services/PreflightService';
 import * as tmuxService from '../../core/services/TmuxService';
 import { ConfigStore } from '../../jetbrains-ide-bridge/config';
 import { NotificationEmitter } from '../../jetbrains-ide-bridge/notifications';
@@ -15,6 +16,7 @@ suite('Bridge session.open', () => {
     let tempDir: string;
     let prepareLaunchContextStub: sinon.SinonStub;
     let buildLaunchCommandStub: sinon.SinonStub;
+    let preflightStub: sinon.SinonStub;
     let isTmuxInstalledStub: sinon.SinonStub;
     let launchInTmuxStub: sinon.SinonStub;
 
@@ -36,6 +38,7 @@ suite('Bridge session.open', () => {
             mode: 'start',
             command: 'claude --settings "/tmp/claude-settings.json"'
         });
+        preflightStub = sinon.stub(PreflightService, 'assertSessionLaunchPrerequisites').resolves();
         isTmuxInstalledStub = sinon.stub(tmuxService, 'isTmuxInstalled').resolves(false);
         launchInTmuxStub = sinon.stub(tmuxService, 'launchInTmux').resolves({
             tmuxSessionName: 'feat-open',
@@ -47,6 +50,7 @@ suite('Bridge session.open', () => {
     teardown(() => {
         prepareLaunchContextStub.restore();
         buildLaunchCommandStub.restore();
+        preflightStub.restore();
         isTmuxInstalledStub.restore();
         launchInTmuxStub.restore();
         fs.rmSync(tempDir, { recursive: true, force: true });
@@ -167,5 +171,19 @@ suite('Bridge session.open', () => {
         assert.strictEqual(result.terminalMode, 'vscode');
         assert.strictEqual(result.attachCommand, undefined);
         sinon.assert.notCalled(launchInTmuxStub);
+    });
+
+    test('fails before launch preparation when preflight detects missing prerequisites', async () => {
+        preflightStub.rejects(new Error('tmux is required when lanes.terminalMode is set to tmux.'));
+
+        await assert.rejects(
+            handleRequest('session.open', {
+                sessionName: 'feat-missing-tmux'
+            }),
+            /tmux is required/
+        );
+
+        sinon.assert.notCalled(prepareLaunchContextStub);
+        sinon.assert.notCalled(buildLaunchCommandStub);
     });
 });


### PR DESCRIPTION
Adds first-run preflight validation so missing prerequisites are surfaced before session creation or startup begins.

  This change introduces shared dependency checks for:

  - jq
  - the selected agent CLI
  - tmux when tmux mode is enabled

  The checks now run before session side effects in both shared handler flows and CLI create/open commands.

  ## What Changed

  - Added a shared preflight service to validate launch prerequisites.
  - Wired preflight into shared session.create and session.open handling before worktree creation or launch prep.
  - Wired preflight into CLI lanes create and lanes open before session creation/startup.
  - Tightened tmux handling so tmux mode errors clearly instead of silently falling back.
  - Added focused tests for:
      - preflight dependency detection
      - bridge create/open failing before side effects
      - CLI create/open failing before startup when prerequisites are missing

  ## Files

  - src/core/services/PreflightService.ts
  - src/core/services/SessionHandlerService.ts
  - src/cli/commands/create.ts
  - src/cli/commands/open.ts

  ## Test Coverage

  Added/updated tests in:

  - src/test/core/services/PreflightService.test.ts
  - src/test/jetbrains-ide-bridge/session-create.test.ts
  - src/test/jetbrains-ide-bridge/session-open.test.ts
  - src/test/cli/commands/create.test.ts
  - src/test/cli/commands/open.test.ts

  ## Verification

  Ran:

  npx tsc -p ./
  npm run lint -- src/core/services/PreflightService.ts src/core/services/SessionHandlerService.ts src/cli/commands/create.ts src/cli/commands/open.ts
  src/test/core/services/PreflightService.test.ts src/test/jetbrains-ide-bridge/session-create.test.ts src/test/jetbrains-ide-bridge/session-open.test.ts
  src/test/cli/commands/create.test.ts src/test/cli/commands/open.test.ts
  npx mocha --ui tdd out/test/core/services/PreflightService.test.js out/test/jetbrains-ide-bridge/session-create.test.js out/test/jetbrains-ide-bridge/
  session-open.test.js out/test/cli/commands/create.test.js out/test/cli/commands/open.test.js

  ## Notes

  There is a known follow-up from review: the current jq preflight is broader than ideal and should be narrowed to agents/paths that actually require jq.