### PR TITLE
feat(web): make offline project onboarding self-serve

### DIFF
--- a/web-ui/e2e/dashboard.spec.ts
+++ b/web-ui/e2e/dashboard.spec.ts
@@ -51,4 +51,26 @@ test.describe('Dashboard', () => {
         await page.getByRole('button', { name: /open project my-app/i }).click();
         await expect(page).toHaveURL(/\/project\/project-my-app$/);
     });
+
+    test('registered offline projects route to actionable setup guidance', async ({ page, mockApi }) => {
+        mockApi.withProjects([
+            makeProjectInfo({
+                projectId: 'project-offline-app',
+                projectName: 'offline-app',
+                workspaceRoot: '/home/user/projects/offline-app',
+                daemon: null,
+            }),
+        ]);
+        await mockApi.install();
+
+        await page.goto('/');
+        await expect(page.getByRole('button', { name: /open project offline-app/i })).toBeVisible();
+        await expect(page.getByText(/ready to start/i)).toBeVisible();
+
+        await page.getByRole('button', { name: /open project offline-app/i }).click();
+
+        await expect(page).toHaveURL(/\/project\/project-offline-app$/);
+        await expect(page.getByText(/daemon is offline/i)).toBeVisible();
+        await expect(page.getByRole('button', { name: /refresh connection/i })).toBeVisible();
+    });
 });

--- a/web-ui/e2e/project-detail.spec.ts
+++ b/web-ui/e2e/project-detail.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, makeSessionInfo } from './fixtures/base';
+import { test, expect, makeProjectInfo, makeSessionInfo } from './fixtures/base';
 
 test.describe('Project Detail', () => {
     test('shows session list', async ({ page, mockApi }) => {
@@ -60,5 +60,24 @@ test.describe('Project Detail', () => {
         await page.goto(`/project/${mockApi.defaultProjectId}`);
         await page.getByRole('link', { name: 'Projects' }).click();
         await expect(page).toHaveURL('/');
+    });
+
+    test('registered offline projects show start, connect, and recovery guidance', async ({ page, mockApi }) => {
+        mockApi.withProjects([
+            makeProjectInfo({
+                projectId: 'project-offline-app',
+                projectName: 'offline-app',
+                workspaceRoot: '/home/user/projects/offline-app',
+                daemon: null,
+            }),
+        ]);
+        await mockApi.install();
+
+        await page.goto('/project/project-offline-app');
+
+        await expect(page.getByText(/daemon is offline/i)).toBeVisible();
+        await expect(page.getByText(/launch the project daemon/i)).toBeVisible();
+        await expect(page.getByText(/reconnect this page/i)).toBeVisible();
+        await expect(page.getByText(/repair stale registration/i)).toBeVisible();
     });
 });

--- a/web-ui/src/components/ProjectCard.tsx
+++ b/web-ui/src/components/ProjectCard.tsx
@@ -1,5 +1,5 @@
 /**
- * ProjectCard — displays a summary card for a single running Lanes daemon.
+ * ProjectCard — displays a summary card for a registered Lanes project.
  *
  * Shows the project name, git remote, session count, uptime, and a colour-coded
  * health indicator. Clicking the card navigates to the project detail view.
@@ -50,23 +50,20 @@ export function ProjectCard({ enrichedDaemon }: ProjectCardProps) {
     const navigate = useNavigate();
 
     const projectName = discovery?.projectName ?? daemon?.projectName ?? project.projectName;
-    const gitRemote = discovery?.gitRemote ?? null;
+    const secondaryLabel = discovery?.gitRemote ?? project.workspaceRoot;
     const sessionCount = discovery?.sessionCount ?? 0;
     const uptime = daemon ? formatUptime(uptimeSeconds(daemon.startedAt)) : 'Not running';
     const portLabel = daemon ? String(daemon.port) : 'Offline';
-    const isRunning = daemon !== null;
+    const statusLabel = daemon ? 'Live daemon' : 'Ready to start';
+    const statusDescription = daemon
+        ? 'Open this project to manage sessions.'
+        : 'Open setup, run lanes daemon start, then refresh the project.';
 
     function handleClick() {
-        if (!daemon) {
-            return;
-        }
         void navigate(`/project/${project.projectId}`);
     }
 
     function handleKeyDown(e: React.KeyboardEvent) {
-        if (!daemon) {
-            return;
-        }
         if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             void navigate(`/project/${project.projectId}`);
@@ -76,11 +73,11 @@ export function ProjectCard({ enrichedDaemon }: ProjectCardProps) {
     return (
         <div
             className={styles.card}
-            role={isRunning ? 'button' : 'article'}
-            tabIndex={isRunning ? 0 : undefined}
+            role="button"
+            tabIndex={0}
             onClick={handleClick}
             onKeyDown={handleKeyDown}
-            aria-label={isRunning ? `Open project ${projectName}` : `Registered project ${projectName}`}
+            aria-label={`Open project ${projectName}`}
         >
             <div className={styles.cardHeader}>
                 <h2 className={styles.projectName}>{projectName}</h2>
@@ -92,11 +89,16 @@ export function ProjectCard({ enrichedDaemon }: ProjectCardProps) {
                 />
             </div>
 
-            {gitRemote && (
-                <p className={styles.gitRemote} title={gitRemote}>
-                    {gitRemote}
+            {secondaryLabel && (
+                <p className={styles.gitRemote} title={secondaryLabel}>
+                    {secondaryLabel}
                 </p>
             )}
+
+            <div className={styles.actionBanner}>
+                <span className={styles.actionTitle}>{statusLabel}</span>
+                <span className={styles.actionDescription}>{statusDescription}</span>
+            </div>
 
             <div className={styles.cardMeta}>
                 <span className={styles.metaItem}>

--- a/web-ui/src/components/ProjectConnectionState.tsx
+++ b/web-ui/src/components/ProjectConnectionState.tsx
@@ -1,0 +1,151 @@
+import { Link } from 'react-router-dom';
+import type { ProjectConnectionState as ConnectionState } from '../hooks/useDaemonConnection';
+import styles from '../styles/ProjectConnectionState.module.css';
+
+interface ProjectConnectionStateProps {
+    state: Extract<ConnectionState, 'offline' | 'missing'>;
+    projectId?: string;
+    projectName: string;
+    workspaceRoot?: string;
+    registeredAt?: string;
+    onRefresh?: () => void;
+}
+
+function shellQuote(value: string): string {
+    return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function formatCommand(workspaceRoot: string | undefined, command: string): string {
+    if (!workspaceRoot) {
+        return command;
+    }
+
+    return `cd ${shellQuote(workspaceRoot)} && ${command}`;
+}
+
+function formatRegisteredAt(registeredAt: string | undefined): string | null {
+    if (!registeredAt) {
+        return null;
+    }
+
+    const parsed = new Date(registeredAt);
+    if (Number.isNaN(parsed.getTime())) {
+        return null;
+    }
+
+    return parsed.toLocaleString(undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    });
+}
+
+export function ProjectConnectionState({
+    state,
+    projectId,
+    projectName,
+    workspaceRoot,
+    registeredAt,
+    onRefresh,
+}: ProjectConnectionStateProps) {
+    const isOffline = state === 'offline';
+    const formattedRegisteredAt = formatRegisteredAt(registeredAt);
+    const startCommand = formatCommand(workspaceRoot, 'lanes daemon start');
+    const registerCommand = formatCommand(workspaceRoot, 'lanes daemon register .');
+    const unregisterCommand = workspaceRoot
+        ? `lanes daemon unregister ${shellQuote(workspaceRoot)}`
+        : 'lanes daemon unregister /absolute/path/to/repo';
+    const stepOneTitle = isOffline ? 'Launch the project daemon' : 'Re-register the project';
+    const stepOneDescription = isOffline
+        ? 'Run this inside the project root so Lanes can attach the daemon to the correct repo.'
+        : 'Run this from the repo root to restore the machine-wide project entry before reconnecting.';
+    const stepOneCommand = isOffline ? startCommand : registerCommand;
+    const stepTwoTitle = isOffline ? 'Reconnect this page' : 'Reconnect after registration';
+    const stepTwoDescription = isOffline
+        ? 'Once the daemon is running, refresh the connection here to load sessions, workflows, and settings.'
+        : 'Once the project is registered again, refresh this page or return to the dashboard to confirm it is available.';
+    const recoveryDescription = workspaceRoot
+        ? 'Re-register the repo if it moved, or remove the stale machine-wide entry if you no longer need it.'
+        : 'Re-register from the repo root, or replace /absolute/path/to/repo below with the stale workspace path to remove it.';
+
+    return (
+        <section className={styles.panel} aria-label="Project connection guide">
+            <div className={styles.hero}>
+                <span className={styles.eyebrow}>
+                    {isOffline ? 'Start And Connect' : 'Recover Registration'}
+                </span>
+                <h2 className={styles.title}>
+                    {isOffline ? 'This project is registered, but its daemon is offline.' : 'This project link is no longer connected.'}
+                </h2>
+                <p className={styles.description}>
+                    {isOffline
+                        ? 'Start the daemon from the project root, then reconnect this page. If the repo moved or was removed, use the recovery commands below.'
+                        : 'Re-register the repo from its root or remove the stale entry if this workspace no longer exists on this machine.'}
+                </p>
+
+                <div className={styles.facts}>
+                    <div className={styles.fact}>
+                        <span className={styles.factLabel}>Project</span>
+                        <span className={styles.factValue}>{projectName}</span>
+                    </div>
+                    {workspaceRoot && (
+                        <div className={styles.fact}>
+                            <span className={styles.factLabel}>Workspace</span>
+                            <code className={styles.factCode}>{workspaceRoot}</code>
+                        </div>
+                    )}
+                    {formattedRegisteredAt && (
+                        <div className={styles.fact}>
+                            <span className={styles.factLabel}>Registered</span>
+                            <span className={styles.factValue}>{formattedRegisteredAt}</span>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            <div className={styles.cardGrid}>
+                <article className={styles.card}>
+                    <span className={styles.cardStep}>{isOffline ? '1. Start' : '1. Restore'}</span>
+                    <h3 className={styles.cardTitle}>{stepOneTitle}</h3>
+                    <p className={styles.cardDescription}>{stepOneDescription}</p>
+                    <code className={styles.command}>{stepOneCommand}</code>
+                </article>
+
+                <article className={styles.card}>
+                    <span className={styles.cardStep}>2. Connect</span>
+                    <h3 className={styles.cardTitle}>{stepTwoTitle}</h3>
+                    <p className={styles.cardDescription}>{stepTwoDescription}</p>
+                    {onRefresh ? (
+                        <button
+                            type="button"
+                            className={styles.primaryButton}
+                            onClick={onRefresh}
+                        >
+                            Refresh Connection
+                        </button>
+                    ) : (
+                        <span className={styles.helperText}>Use the refresh control after the daemon starts.</span>
+                    )}
+                </article>
+
+                <article className={styles.card}>
+                    <span className={styles.cardStep}>3. Recover</span>
+                    <h3 className={styles.cardTitle}>Repair stale registration</h3>
+                    <p className={styles.cardDescription}>{recoveryDescription}</p>
+                    <code className={styles.command}>{registerCommand}</code>
+                    <code className={styles.command}>{unregisterCommand}</code>
+                </article>
+            </div>
+
+            {projectId && (
+                <div className={styles.footer}>
+                    <Link to={`/project/${projectId}`} className={styles.secondaryLink}>
+                        Back to project
+                    </Link>
+                    <Link to="/" className={styles.secondaryLink}>
+                        Back to projects
+                    </Link>
+                </div>
+            )}
+        </section>
+    );
+}

--- a/web-ui/src/hooks/useDaemonConnection.ts
+++ b/web-ui/src/hooks/useDaemonConnection.ts
@@ -2,11 +2,11 @@
  * useDaemonConnection — resolves a DaemonApiClient and DaemonSseClient for a
  * specific project ID by looking it up in the gateway project list.
  *
- * Returns null for both clients while the gateway list is being fetched, or
- * when the project does not correspond to a known registered project.
+ * Returns null clients while the gateway list is being fetched, when the
+ * project is registered but offline, or when the project is unknown.
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { fetchProjects } from '../api/gateway';
 import { DaemonApiClient } from '../api/client';
 import { DaemonSseClient } from '../api/sse';
@@ -16,6 +16,8 @@ import type { GatewayProjectInfo } from '../api/types';
 // Types
 // ---------------------------------------------------------------------------
 
+export type ProjectConnectionState = 'connected' | 'offline' | 'missing';
+
 export interface DaemonConnection {
     /** Typed REST client for the daemon at the given port */
     apiClient: DaemonApiClient | null;
@@ -23,10 +25,14 @@ export interface DaemonConnection {
     sseClient: DaemonSseClient | null;
     /** True while the gateway lookup is in progress */
     loading: boolean;
-    /** Set when the gateway fetch fails or the port is not found */
+    /** Set when the gateway project fetch fails */
     error: Error | null;
     /** Matching project entry from gateway registry, if found */
     daemonInfo: GatewayProjectInfo | null;
+    /** Project availability within the gateway registry */
+    projectState: ProjectConnectionState;
+    /** Force the gateway lookup to run again, bypassing cache */
+    refresh: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -36,6 +42,7 @@ export interface DaemonConnection {
 const DAEMON_LIST_CACHE_TTL_MS = 30_000;
 let daemonListCache: { data: GatewayProjectInfo[]; expiresAt: number } | null = null;
 let daemonListInFlight: Promise<GatewayProjectInfo[]> | null = null;
+const refreshListeners = new Set<() => void>();
 
 async function getDaemonsCached(): Promise<GatewayProjectInfo[]> {
     const now = Date.now();
@@ -59,6 +66,27 @@ async function getDaemonsCached(): Promise<GatewayProjectInfo[]> {
 export function __resetDaemonConnectionCacheForTests(): void {
     daemonListCache = null;
     daemonListInFlight = null;
+    refreshListeners.clear();
+}
+
+function invalidateDaemonConnectionCache(): void {
+    daemonListCache = null;
+    daemonListInFlight = null;
+}
+
+function subscribeToRefresh(listener: () => void): () => void {
+    refreshListeners.add(listener);
+    return () => {
+        refreshListeners.delete(listener);
+    };
+}
+
+function broadcastRefresh(): void {
+    invalidateDaemonConnectionCache();
+
+    for (const listener of refreshListeners) {
+        listener();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -77,17 +105,31 @@ export function useDaemonConnection(projectId: string | undefined): DaemonConnec
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
     const [daemonInfo, setDaemonInfo] = useState<GatewayProjectInfo | null>(null);
+    const [projectState, setProjectState] = useState<ProjectConnectionState>('missing');
+    const [refreshCounter, setRefreshCounter] = useState(0);
 
     // Keep refs so cleanup does not need to re-run when state changes
     const sseClientRef = useRef<DaemonSseClient | null>(null);
+    const refresh = useCallback(() => {
+        broadcastRefresh();
+    }, []);
+
+    useEffect(() => {
+        return subscribeToRefresh(() => {
+            setRefreshCounter((count) => count + 1);
+        });
+    }, []);
 
     useEffect(() => {
         if (projectId === undefined) {
+            sseClientRef.current?.disconnect();
+            sseClientRef.current = null;
             setLoading(false);
             setError(null);
             setApiClient(null);
             setSseClient(null);
             setDaemonInfo(null);
+            setProjectState('missing');
             return;
         }
 
@@ -103,19 +145,25 @@ export function useDaemonConnection(projectId: string | undefined): DaemonConnec
 
                 const project = projects.find((entry) => entry.projectId === projectId);
                 if (!project) {
-                    setError(new Error(`Unknown project: ${projectId}`));
+                    sseClientRef.current?.disconnect();
+                    sseClientRef.current = null;
+                    setError(null);
                     setApiClient(null);
                     setSseClient(null);
                     setDaemonInfo(null);
+                    setProjectState('missing');
                     return;
                 }
 
                 const daemon = project.daemon;
                 if (!daemon) {
-                    setError(new Error(`Global daemon is not running for project ${project.projectName}`));
+                    sseClientRef.current?.disconnect();
+                    sseClientRef.current = null;
+                    setError(null);
                     setApiClient(null);
                     setSseClient(null);
                     setDaemonInfo(project);
+                    setProjectState('offline');
                     return;
                 }
 
@@ -133,12 +181,16 @@ export function useDaemonConnection(projectId: string | undefined): DaemonConnec
                 setApiClient(client);
                 setSseClient(sse);
                 setDaemonInfo(project);
+                setProjectState('connected');
             } catch (err) {
                 if (cancelled) return;
+                sseClientRef.current?.disconnect();
+                sseClientRef.current = null;
                 setError(err instanceof Error ? err : new Error(String(err)));
                 setApiClient(null);
                 setSseClient(null);
                 setDaemonInfo(null);
+                setProjectState('missing');
             } finally {
                 if (!cancelled) {
                     setLoading(false);
@@ -152,7 +204,7 @@ export function useDaemonConnection(projectId: string | undefined): DaemonConnec
             cancelled = true;
             sseClientRef.current?.disconnect();
         };
-    }, [projectId]);
+    }, [projectId, refreshCounter]);
 
     // Disconnect SSE on unmount
     useEffect(() => {
@@ -162,5 +214,5 @@ export function useDaemonConnection(projectId: string | undefined): DaemonConnec
         };
     }, []);
 
-    return { apiClient, sseClient, loading, error, daemonInfo };
+    return { apiClient, sseClient, loading, error, daemonInfo, projectState, refresh };
 }

--- a/web-ui/src/pages/ProjectDetail.tsx
+++ b/web-ui/src/pages/ProjectDetail.tsx
@@ -6,6 +6,7 @@ import { CreateSessionDialog } from '../components/CreateSessionDialog';
 import { ConfirmDialog } from '../components/ConfirmDialog';
 import { SessionDetailPanel } from '../components/SessionDetailPanel';
 import { StatusBadge } from '../components/StatusBadge';
+import { ProjectConnectionState } from '../components/ProjectConnectionState';
 import { useProjectNotifications } from '../components/ProjectNotificationsProvider';
 import type { CreateSessionRequest, SessionInfo } from '../api/types';
 import { prepareSessionNotifications } from '../utils/sessionNotifications';
@@ -25,14 +26,21 @@ export function ProjectDetail() {
     const notifications = useProjectNotifications();
     const decodedName = name ? decodeURIComponent(name) : '';
 
-    const { apiClient, sseClient, daemonInfo, loading: connectionLoading, error: connectionError } =
+    const {
+        apiClient,
+        sseClient,
+        daemonInfo,
+        loading: connectionLoading,
+        error: connectionError,
+        projectState,
+        refresh: refreshConnection,
+    } =
         useDaemonConnection(projectId);
 
     const {
         sessions,
         loading: sessionsLoading,
         error: sessionsError,
-        refresh,
         createSession,
         improveSessionPrompt,
         uploadSessionAttachments,
@@ -55,6 +63,13 @@ export function ProjectDetail() {
     const error = connectionError ?? sessionsError;
     const sortedSessions = sortSessions(sessions);
     const firstSession = sortedSessions[0] ?? null;
+    const projectName = daemonInfo?.projectName ?? projectId ?? 'project';
+    const workspaceRoot = daemonInfo?.workspaceRoot;
+    const registeredAt = daemonInfo?.registeredAt;
+
+    const handleRefresh = useCallback(() => {
+        refreshConnection();
+    }, [refreshConnection]);
 
     useEffect(() => {
         if (!projectId || isLoading || error || decodedName || !firstSession) {
@@ -191,7 +206,7 @@ export function ProjectDetail() {
                             Projects
                         </Link>
                         <span className={styles.breadcrumbSep} aria-hidden="true">/</span>
-                        <span>{daemonInfo?.projectName ?? projectId}</span>
+                        <span>{projectName}</span>
                     </nav>
                     <h1 className={styles.title}>Session Workspace</h1>
                     {daemonInfo?.daemon?.port && (
@@ -213,7 +228,7 @@ export function ProjectDetail() {
                     <button
                         type="button"
                         className={styles.secondaryButton}
-                        onClick={refresh}
+                        onClick={handleRefresh}
                         aria-label="Refresh session list"
                     >
                         Refresh
@@ -257,189 +272,202 @@ export function ProjectDetail() {
                 </div>
             )}
 
-            <div className={styles.workspace}>
-                <aside className={styles.sidebar} aria-label="Sessions navigation">
-                    <div className={styles.sidebarHeader}>
-                        <div>
-                            <div className={styles.sidebarEyebrow}>Sessions</div>
-                            <div className={styles.sidebarTitle}>
-                                {sortedSessions.length} {sortedSessions.length === 1 ? 'session' : 'sessions'}
+            {!connectionError && !connectionLoading && (projectState === 'offline' || projectState === 'missing') && (
+                <ProjectConnectionState
+                    state={projectState}
+                    projectId={projectId}
+                    projectName={projectName}
+                    workspaceRoot={workspaceRoot}
+                    registeredAt={registeredAt}
+                    onRefresh={handleRefresh}
+                />
+            )}
+
+            {projectState === 'connected' && (
+                <div className={styles.workspace}>
+                    <aside className={styles.sidebar} aria-label="Sessions navigation">
+                        <div className={styles.sidebarHeader}>
+                            <div>
+                                <div className={styles.sidebarEyebrow}>Sessions</div>
+                                <div className={styles.sidebarTitle}>
+                                    {sortedSessions.length} {sortedSessions.length === 1 ? 'session' : 'sessions'}
+                                </div>
                             </div>
+                            {apiClient && (
+                                <button
+                                    type="button"
+                                    className={styles.sidebarCreateButton}
+                                    onClick={() => setShowCreateDialog(true)}
+                                >
+                                    New
+                                </button>
+                            )}
                         </div>
-                        {apiClient && (
-                            <button
-                                type="button"
-                                className={styles.sidebarCreateButton}
-                                onClick={() => setShowCreateDialog(true)}
-                            >
-                                New
-                            </button>
+
+                        {isLoading && sortedSessions.length === 0 && (
+                            <div className={styles.loadingContainer} role="status" aria-label="Loading sessions">
+                                <div className={styles.spinner} aria-hidden="true" />
+                                <span>Loading sessions&hellip;</span>
+                            </div>
                         )}
-                    </div>
 
-                    {isLoading && sortedSessions.length === 0 && (
-                        <div className={styles.loadingContainer} role="status" aria-label="Loading sessions">
-                            <div className={styles.spinner} aria-hidden="true" />
-                            <span>Loading sessions&hellip;</span>
-                        </div>
-                    )}
+                        {!isLoading && !error && sortedSessions.length === 0 && (
+                            <div className={styles.emptyState}>
+                                <div className={styles.emptyStateTitle}>No sessions yet</div>
+                                <p className={styles.emptyStateDescription}>
+                                    Create a session to start working from this daemon.
+                                </p>
+                            </div>
+                        )}
 
-                    {!isLoading && !error && sortedSessions.length === 0 && (
-                        <div className={styles.emptyState}>
-                            <div className={styles.emptyStateTitle}>No sessions yet</div>
-                            <p className={styles.emptyStateDescription}>
-                                Create a session to start working from this daemon.
-                            </p>
-                        </div>
-                    )}
+                        {sortedSessions.length > 0 && (
+                            <ul className={styles.sessionList}>
+                                {sortedSessions.map((session) => {
+                                    const isSelected = session.name === decodedName;
+                                    const notificationEnabled = session.notificationsEnabled ?? false;
 
-                    {sortedSessions.length > 0 && (
-                        <ul className={styles.sessionList}>
-                            {sortedSessions.map((session) => {
-                                const isSelected = session.name === decodedName;
-                                const notificationEnabled = session.notificationsEnabled ?? false;
-
-                                return (
-                                    <li
-                                        key={session.name}
-                                        className={`${styles.sessionItem} ${
-                                            isSelected ? styles.sessionItemActive : ''
-                                        }`}
-                                    >
-                                        <button
-                                            type="button"
-                                            className={styles.sessionButton}
-                                            onClick={() => {
-                                                if (projectId) {
-                                                    void navigate(
-                                                        `/project/${projectId}/session/${encodeURIComponent(session.name)}`
-                                                    );
-                                                }
-                                            }}
-                                            aria-current={isSelected ? 'page' : undefined}
+                                    return (
+                                        <li
+                                            key={session.name}
+                                            className={`${styles.sessionItem} ${
+                                                isSelected ? styles.sessionItemActive : ''
+                                            }`}
                                         >
-                                            <div className={styles.sessionButtonTop}>
-                                                <span className={styles.sessionName}>{session.name}</span>
-                                                {session.isPinned && (
-                                                    <span className={styles.sessionPinned}>Pinned</span>
-                                                )}
-                                            </div>
-                                            <div className={styles.sessionMeta}>
-                                                <StatusBadge status={session.status?.status ?? 'idle'} />
-                                                <span className={styles.sessionBranch}>
-                                                    {session.branch || 'No branch'}
-                                                </span>
-                                            </div>
-                                            <div className={styles.sessionIndicators}>
-                                                <span className={styles.sessionIndicator}>
-                                                    {notificationEnabled ? 'Notifications on' : 'Notifications off'}
-                                                </span>
-                                                {session.workflowStatus?.active && (
-                                                    <span className={styles.sessionWorkflow}>
-                                                        {session.workflowStatus.step ?? session.workflowStatus.workflow}
+                                            <button
+                                                type="button"
+                                                className={styles.sessionButton}
+                                                onClick={() => {
+                                                    if (projectId) {
+                                                        void navigate(
+                                                            `/project/${projectId}/session/${encodeURIComponent(session.name)}`
+                                                        );
+                                                    }
+                                                }}
+                                                aria-current={isSelected ? 'page' : undefined}
+                                            >
+                                                <div className={styles.sessionButtonTop}>
+                                                    <span className={styles.sessionName}>{session.name}</span>
+                                                    {session.isPinned && (
+                                                        <span className={styles.sessionPinned}>Pinned</span>
+                                                    )}
+                                                </div>
+                                                <div className={styles.sessionMeta}>
+                                                    <StatusBadge status={session.status?.status ?? 'idle'} />
+                                                    <span className={styles.sessionBranch}>
+                                                        {session.branch || 'No branch'}
                                                     </span>
-                                                )}
+                                                </div>
+                                                <div className={styles.sessionIndicators}>
+                                                    <span className={styles.sessionIndicator}>
+                                                        {notificationEnabled ? 'Notifications on' : 'Notifications off'}
+                                                    </span>
+                                                    {session.workflowStatus?.active && (
+                                                        <span className={styles.sessionWorkflow}>
+                                                            {session.workflowStatus.step ?? session.workflowStatus.workflow}
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </button>
+
+                                            <div className={styles.sessionActions}>
+                                                <button
+                                                    type="button"
+                                                    className={`${styles.iconButton} ${
+                                                        session.isPinned ? styles.iconButtonActive : ''
+                                                    }`}
+                                                    onClick={() =>
+                                                        void (session.isPinned
+                                                            ? handleUnpin(session.name)
+                                                            : handlePin(session.name))
+                                                    }
+                                                    disabled={pendingPinName === session.name}
+                                                    aria-label={
+                                                        session.isPinned
+                                                            ? `Unpin session ${session.name}`
+                                                            : `Pin session ${session.name}`
+                                                    }
+                                                >
+                                                    {session.isPinned ? '\u2605' : '\u2606'}
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className={`${styles.iconButton} ${
+                                                        notificationEnabled ? styles.iconButtonActive : ''
+                                                    }`}
+                                                    onClick={() =>
+                                                        void (notificationEnabled
+                                                            ? handleDisableNotifications(session.name)
+                                                            : handleEnableNotifications(session.name))
+                                                    }
+                                                    disabled={pendingNotificationName === session.name}
+                                                    aria-label={
+                                                        notificationEnabled
+                                                            ? `Disable notifications for session ${session.name}`
+                                                            : `Enable notifications for session ${session.name}`
+                                                    }
+                                                >
+                                                    {notificationEnabled ? '\u{1F514}' : '\u{1F515}'}
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    className={styles.iconButton}
+                                                    onClick={() => handleDeleteRequest(session.name)}
+                                                    disabled={pendingDeleteName === session.name && isDeleting}
+                                                    aria-label={`Delete session ${session.name}`}
+                                                >
+                                                    &#x1F5D1;
+                                                </button>
                                             </div>
-                                        </button>
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        )}
+                    </aside>
 
-                                        <div className={styles.sessionActions}>
-                                            <button
-                                                type="button"
-                                                className={`${styles.iconButton} ${
-                                                    session.isPinned ? styles.iconButtonActive : ''
-                                                }`}
-                                                onClick={() =>
-                                                    void (session.isPinned
-                                                        ? handleUnpin(session.name)
-                                                        : handlePin(session.name))
-                                                }
-                                                disabled={pendingPinName === session.name}
-                                                aria-label={
-                                                    session.isPinned
-                                                        ? `Unpin session ${session.name}`
-                                                        : `Pin session ${session.name}`
-                                                }
-                                            >
-                                                {session.isPinned ? '\u2605' : '\u2606'}
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className={`${styles.iconButton} ${
-                                                    notificationEnabled ? styles.iconButtonActive : ''
-                                                }`}
-                                                onClick={() =>
-                                                    void (notificationEnabled
-                                                        ? handleDisableNotifications(session.name)
-                                                        : handleEnableNotifications(session.name))
-                                                }
-                                                disabled={pendingNotificationName === session.name}
-                                                aria-label={
-                                                    notificationEnabled
-                                                        ? `Disable notifications for session ${session.name}`
-                                                        : `Enable notifications for session ${session.name}`
-                                                }
-                                            >
-                                                {notificationEnabled ? '\u{1F514}' : '\u{1F515}'}
-                                            </button>
-                                            <button
-                                                type="button"
-                                                className={styles.iconButton}
-                                                onClick={() => handleDeleteRequest(session.name)}
-                                                disabled={pendingDeleteName === session.name && isDeleting}
-                                                aria-label={`Delete session ${session.name}`}
-                                            >
-                                                &#x1F5D1;
-                                            </button>
-                                        </div>
-                                    </li>
-                                );
-                            })}
-                        </ul>
-                    )}
-                </aside>
+                    <section className={styles.detailPane} aria-label="Selected session">
+                        {!isLoading && !error && sortedSessions.length === 0 && (
+                            <div className={styles.detailEmptyState}>
+                                <div className={styles.detailEmptyTitle}>No session selected</div>
+                                <p className={styles.detailEmptyDescription}>
+                                    Create a session from the sidebar to populate the workspace.
+                                </p>
+                            </div>
+                        )}
 
-                <section className={styles.detailPane} aria-label="Selected session">
-                    {!isLoading && !error && sortedSessions.length === 0 && (
-                        <div className={styles.detailEmptyState}>
-                            <div className={styles.detailEmptyTitle}>No session selected</div>
-                            <p className={styles.detailEmptyDescription}>
-                                Create a session from the sidebar to populate the workspace.
-                            </p>
-                        </div>
-                    )}
+                        {sortedSessions.length > 0 && !decodedName && (
+                            <div className={styles.detailEmptyState}>
+                                <div className={styles.detailEmptyTitle}>Opening first session</div>
+                                <p className={styles.detailEmptyDescription}>
+                                    Routing the workspace to the first available session.
+                                </p>
+                            </div>
+                        )}
 
-                    {sortedSessions.length > 0 && !decodedName && (
-                        <div className={styles.detailEmptyState}>
-                            <div className={styles.detailEmptyTitle}>Opening first session</div>
-                            <p className={styles.detailEmptyDescription}>
-                                Routing the workspace to the first available session.
-                            </p>
-                        </div>
-                    )}
+                        {decodedName && projectId && (
+                            <SessionDetailPanel
+                                projectId={projectId}
+                                sessionName={decodedName}
+                                apiClient={apiClient}
+                                sseClient={sseClient}
+                                daemonInfo={daemonInfo}
+                                connectionLoading={connectionLoading}
+                                connectionError={connectionError}
+                                subscribeToSse={false}
+                            />
+                        )}
 
-                    {decodedName && projectId && (
-                        <SessionDetailPanel
-                            projectId={projectId}
-                            sessionName={decodedName}
-                            apiClient={apiClient}
-                            sseClient={sseClient}
-                            daemonInfo={daemonInfo}
-                            connectionLoading={connectionLoading}
-                            connectionError={connectionError}
-                            subscribeToSse={false}
-                        />
-                    )}
-
-                    {decodedName && !sortedSessions.some((session) => session.name === decodedName) && !isLoading && !error && (
-                        <div className={styles.detailEmptyState}>
-                            <div className={styles.detailEmptyTitle}>Session not found</div>
-                            <p className={styles.detailEmptyDescription}>
-                                Choose an existing session from the left navigation.
-                            </p>
-                        </div>
-                    )}
-                </section>
-            </div>
+                        {decodedName && !sortedSessions.some((session) => session.name === decodedName) && !isLoading && !error && (
+                            <div className={styles.detailEmptyState}>
+                                <div className={styles.detailEmptyTitle}>Session not found</div>
+                                <p className={styles.detailEmptyDescription}>
+                                    Choose an existing session from the left navigation.
+                                </p>
+                            </div>
+                        )}
+                    </section>
+                </div>
+            )}
 
             {apiClient && (
                 <CreateSessionDialog

--- a/web-ui/src/pages/ProjectSettings.tsx
+++ b/web-ui/src/pages/ProjectSettings.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useDaemonConnection } from '../hooks/useDaemonConnection';
+import { ProjectConnectionState } from '../components/ProjectConnectionState';
 import styles from '../styles/ProjectSettings.module.css';
 
 type InputType = 'string' | 'number' | 'boolean' | 'select';
@@ -190,7 +191,14 @@ function renderInput(
 
 export function ProjectSettings() {
     const { projectId } = useParams<{ projectId: string }>();
-    const { apiClient, daemonInfo, loading: connectionLoading, error: connectionError } =
+    const {
+        apiClient,
+        daemonInfo,
+        loading: connectionLoading,
+        error: connectionError,
+        projectState,
+        refresh: refreshConnection,
+    } =
         useDaemonConnection(projectId);
 
     const [loading, setLoading] = useState(false);
@@ -252,6 +260,10 @@ export function ProjectSettings() {
         () => daemonInfo?.projectName ?? projectId ?? 'project',
         [daemonInfo?.projectName, projectId],
     );
+
+    const handleRefresh = useCallback(() => {
+        refreshConnection();
+    }, [refreshConnection]);
 
     const saveSetting = useCallback(async (definition: SettingDefinition, scope: 'global' | 'local') => {
         if (!apiClient) {
@@ -333,7 +345,7 @@ export function ProjectSettings() {
                     <button
                         type="button"
                         className={styles.secondaryButton}
-                        onClick={() => void loadSettings()}
+                        onClick={handleRefresh}
                     >
                         Refresh
                     </button>
@@ -377,7 +389,18 @@ export function ProjectSettings() {
                 </div>
             )}
 
-            {!isLoading && !pageError && (
+            {!connectionError && !connectionLoading && (projectState === 'offline' || projectState === 'missing') && (
+                <ProjectConnectionState
+                    state={projectState}
+                    projectId={projectId}
+                    projectName={projectName}
+                    workspaceRoot={daemonInfo?.workspaceRoot}
+                    registeredAt={daemonInfo?.registeredAt}
+                    onRefresh={handleRefresh}
+                />
+            )}
+
+            {!isLoading && !pageError && projectState === 'connected' && (
                 <div className={styles.settingsList}>
                     {SETTINGS.map((definition) => {
                         const localOverrideActive = Object.prototype.hasOwnProperty.call(localConfig, definition.key);

--- a/web-ui/src/pages/WorkflowBrowser.tsx
+++ b/web-ui/src/pages/WorkflowBrowser.tsx
@@ -16,6 +16,7 @@ import { useParams, Link } from 'react-router-dom';
 import { useDaemonConnection } from '../hooks/useDaemonConnection';
 import { useWorkflows } from '../hooks/useWorkflows';
 import { WorkflowDetail } from '../components/WorkflowDetail';
+import { ProjectConnectionState } from '../components/ProjectConnectionState';
 import type { WorkflowInfo } from '../api/types';
 import styles from '../styles/WorkflowBrowser.module.css';
 
@@ -32,7 +33,14 @@ type FilterMode = 'all' | 'builtin' | 'custom';
 export function WorkflowBrowser() {
     const { projectId } = useParams<{ projectId: string }>();
 
-    const { apiClient, daemonInfo, loading: connectionLoading, error: connectionError } =
+    const {
+        apiClient,
+        daemonInfo,
+        loading: connectionLoading,
+        error: connectionError,
+        projectState,
+        refresh: refreshConnection,
+    } =
         useDaemonConnection(projectId);
 
     const [filterMode, setFilterMode] = useState<FilterMode>('all');
@@ -49,7 +57,6 @@ export function WorkflowBrowser() {
         workflows,
         loading: workflowsLoading,
         error: workflowsError,
-        refresh,
     } = useWorkflows(apiClient, workflowOptions);
 
     // Filter by search query
@@ -65,6 +72,10 @@ export function WorkflowBrowser() {
 
     const isLoading = connectionLoading || workflowsLoading;
     const error = connectionError ?? workflowsError;
+    const projectName = daemonInfo?.projectName ?? projectId ?? 'project';
+    const handleRefresh = () => {
+        refreshConnection();
+    };
 
     // ---------------------------------------------------------------------------
     // Render
@@ -82,7 +93,7 @@ export function WorkflowBrowser() {
                     </nav>
                     <h1 className={styles.title}>Workflows</h1>
                     <span className={styles.subtitle}>
-                        {daemonInfo?.projectName ?? projectId}
+                        {projectName}
                     </span>
                 </div>
 
@@ -113,7 +124,7 @@ export function WorkflowBrowser() {
                     <button
                         type="button"
                         className={styles.secondaryButton}
-                        onClick={() => refresh()}
+                        onClick={handleRefresh}
                         disabled={isLoading}
                         aria-label="Refresh workflow list"
                     >
@@ -138,8 +149,19 @@ export function WorkflowBrowser() {
                 </div>
             )}
 
+            {!connectionError && !connectionLoading && (projectState === 'offline' || projectState === 'missing') && (
+                <ProjectConnectionState
+                    state={projectState}
+                    projectId={projectId}
+                    projectName={projectName}
+                    workspaceRoot={daemonInfo?.workspaceRoot}
+                    registeredAt={daemonInfo?.registeredAt}
+                    onRefresh={handleRefresh}
+                />
+            )}
+
             {/* Content */}
-            {!isLoading && !error && (
+            {!isLoading && !error && projectState === 'connected' && (
                 <div className={styles.contentLayout}>
                     {/* Left panel: workflow list */}
                     <div className={styles.listPanel}>

--- a/web-ui/src/styles/ProjectCard.module.css
+++ b/web-ui/src/styles/ProjectCard.module.css
@@ -80,6 +80,30 @@
     white-space: nowrap;
 }
 
+.actionBanner {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+    padding: var(--spacing-3);
+    border-radius: var(--radius-lg);
+    background:
+        linear-gradient(180deg, rgba(56, 139, 253, 0.12), rgba(56, 139, 253, 0.04)),
+        var(--color-bg-overlay);
+    border: 1px solid rgba(88, 166, 255, 0.18);
+}
+
+.actionTitle {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.actionDescription {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-secondary);
+    line-height: var(--line-height-relaxed);
+}
+
 /* Meta row */
 .cardMeta {
     display: flex;

--- a/web-ui/src/styles/ProjectConnectionState.module.css
+++ b/web-ui/src/styles/ProjectConnectionState.module.css
@@ -1,0 +1,187 @@
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-5);
+    padding: var(--spacing-6);
+    border: 1px solid rgba(88, 166, 255, 0.18);
+    border-radius: var(--radius-xl);
+    background:
+        radial-gradient(circle at top right, rgba(56, 139, 253, 0.16), transparent 30%),
+        linear-gradient(180deg, rgba(13, 17, 23, 0.88), rgba(13, 17, 23, 0.96));
+}
+
+.hero {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+}
+
+.eyebrow {
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: #7ee787;
+}
+
+.title {
+    font-size: 30px;
+    line-height: 1.08;
+    letter-spacing: -0.03em;
+    color: var(--color-text-primary);
+    max-width: 22ch;
+}
+
+.description {
+    max-width: 64ch;
+    color: var(--color-text-secondary);
+    line-height: var(--line-height-relaxed);
+}
+
+.facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: var(--spacing-3);
+}
+
+.fact {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-1);
+    padding: var(--spacing-3);
+    border-radius: var(--radius-lg);
+    background-color: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.factLabel {
+    font-size: var(--font-size-xs);
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.factValue {
+    color: var(--color-text-primary);
+    font-weight: var(--font-weight-medium);
+}
+
+.factCode {
+    color: var(--color-text-primary);
+    font-family: var(--font-family-mono);
+    overflow-wrap: anywhere;
+}
+
+.cardGrid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--spacing-4);
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-3);
+    padding: var(--spacing-4);
+    border-radius: var(--radius-xl);
+    background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)),
+        var(--color-bg-surface);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cardStep {
+    font-size: var(--font-size-xs);
+    color: var(--color-accent-primary-hover);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+}
+
+.cardTitle {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text-primary);
+}
+
+.cardDescription {
+    color: var(--color-text-secondary);
+    line-height: var(--line-height-relaxed);
+}
+
+.command {
+    display: block;
+    padding: var(--spacing-3);
+    border-radius: var(--radius-lg);
+    background-color: rgba(13, 17, 23, 0.7);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-text-primary);
+    font-family: var(--font-family-mono);
+    font-size: var(--font-size-sm);
+    overflow-wrap: anywhere;
+}
+
+.primaryButton,
+.secondaryLink {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--spacing-2);
+    border-radius: var(--radius-md);
+    font-size: var(--font-size-sm);
+    text-decoration: none;
+}
+
+.primaryButton {
+    padding: var(--spacing-2) var(--spacing-4);
+    border: none;
+    background: linear-gradient(135deg, #7ee787, #56d364);
+    color: #04130b;
+    font-weight: var(--font-weight-semibold);
+    cursor: pointer;
+}
+
+.helperText {
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.footer {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-2);
+    flex-wrap: wrap;
+}
+
+.secondaryLink {
+    padding: var(--spacing-2) var(--spacing-3);
+    background-color: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--color-border-default);
+    color: var(--color-text-secondary);
+}
+
+.secondaryLink:hover {
+    color: var(--color-text-primary);
+    border-color: var(--color-border-emphasis);
+    background-color: var(--color-bg-hover);
+}
+
+@media (max-width: 1024px) {
+    .cardGrid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .panel {
+        padding: var(--spacing-4);
+    }
+
+    .title {
+        font-size: 24px;
+    }
+
+    .footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/web-ui/src/test/hooks/useDaemonConnection.test.ts
+++ b/web-ui/src/test/hooks/useDaemonConnection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { useDaemonConnection, __resetDaemonConnectionCacheForTests } from '../../hooks/useDaemonConnection';
 import type { DaemonInfo, GatewayProjectInfo } from '../../api/types';
 
@@ -85,6 +85,7 @@ describe('useDaemonConnection', () => {
         });
 
         expect(result.current.apiClient).not.toBeNull();
+        expect(result.current.projectState).toBe('connected');
     });
 
     it('Given a project ID that matches a known project, when the hook runs, then it returns a non-null sseClient', async () => {
@@ -110,6 +111,8 @@ describe('useDaemonConnection', () => {
 
         expect(result.current.apiClient).toBeNull();
         expect(result.current.sseClient).toBeNull();
+        expect(result.current.error).toBeNull();
+        expect(result.current.projectState).toBe('missing');
     });
 
     it('Given no project ID provided, when the hook runs, then no error is set and fetchProjects is not called', async () => {
@@ -120,6 +123,7 @@ describe('useDaemonConnection', () => {
         });
 
         expect(result.current.error).toBeNull();
+        expect(result.current.projectState).toBe('missing');
         expect(vi.mocked(fetchProjects)).not.toHaveBeenCalled();
     });
 
@@ -135,6 +139,24 @@ describe('useDaemonConnection', () => {
         });
 
         expect(result.current.daemonInfo?.projectName).toBe('api-service');
+    });
+
+    it('Given a registered project without a daemon, when the hook resolves, then it returns an offline state without an error', async () => {
+        vi.mocked(fetchProjects).mockResolvedValue([
+            makeProjectInfo({ status: 'registered', daemon: null }),
+        ]);
+
+        const { result } = renderHook(() => useDaemonConnection('project-123'));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.apiClient).toBeNull();
+        expect(result.current.sseClient).toBeNull();
+        expect(result.current.error).toBeNull();
+        expect(result.current.projectState).toBe('offline');
+        expect(result.current.daemonInfo?.projectName).toBe('my-app');
     });
 
     it('Given two hook mounts for the same project ID, when the second mount occurs within cache TTL, then fetchProjects is called once', async () => {
@@ -153,5 +175,55 @@ describe('useDaemonConnection', () => {
         second.unmount();
 
         expect(vi.mocked(fetchProjects)).toHaveBeenCalledTimes(1);
+    });
+
+    it('Given refresh() is called, when the project registry changed, then the hook refetches and updates the connection state', async () => {
+        vi.mocked(fetchProjects)
+            .mockResolvedValueOnce([makeProjectInfo({ status: 'registered', daemon: null })])
+            .mockResolvedValueOnce([makeProjectInfo()]);
+
+        const { result } = renderHook(() => useDaemonConnection('project-123'));
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.projectState).toBe('offline');
+
+        result.current.refresh();
+
+        await waitFor(() => {
+            expect(result.current.projectState).toBe('connected');
+        });
+
+        expect(vi.mocked(fetchProjects)).toHaveBeenCalledTimes(2);
+    });
+
+    it('Given two mounted consumers, when one refreshes, then both hook instances reconnect from the shared invalidation', async () => {
+        vi.mocked(fetchProjects)
+            .mockResolvedValueOnce([makeProjectInfo({ status: 'registered', daemon: null })])
+            .mockResolvedValueOnce([makeProjectInfo()]);
+
+        const first = renderHook(() => useDaemonConnection('project-123'));
+        const second = renderHook(() => useDaemonConnection('project-123'));
+
+        await waitFor(() => {
+            expect(first.result.current.loading).toBe(false);
+            expect(second.result.current.loading).toBe(false);
+        });
+
+        expect(first.result.current.projectState).toBe('offline');
+        expect(second.result.current.projectState).toBe('offline');
+
+        act(() => {
+            first.result.current.refresh();
+        });
+
+        await waitFor(() => {
+            expect(first.result.current.projectState).toBe('connected');
+            expect(second.result.current.projectState).toBe('connected');
+        });
+
+        expect(vi.mocked(fetchProjects)).toHaveBeenCalledTimes(2);
     });
 });

--- a/web-ui/src/test/pages/Dashboard.test.tsx
+++ b/web-ui/src/test/pages/Dashboard.test.tsx
@@ -76,6 +76,22 @@ function makeEnrichedDaemon(port: number, projectName: string): EnrichedDaemon {
     };
 }
 
+function makeRegisteredProject(projectName: string): EnrichedDaemon {
+    return {
+        project: makeProjectInfo({
+            projectId: `project-${projectName}`,
+            workspaceRoot: `/projects/${projectName}`,
+            projectName,
+            status: 'registered',
+            daemon: null,
+        }),
+        daemon: null,
+        discovery: null,
+        health: 'registered',
+        healthResponse: null,
+    };
+}
+
 function renderDashboard() {
     return render(
         <MemoryRouter>
@@ -176,6 +192,23 @@ describe('Dashboard', () => {
 
         const projectCards = screen.getAllByRole('button', { name: /open project/i });
         expect(projectCards).toHaveLength(1);
+    });
+
+    it('Given a registered offline project, then its card still opens the guided setup route', async () => {
+        const user = userEvent.setup();
+        mockUseDaemons.mockReturnValue({
+            daemons: [makeRegisteredProject('project-a')],
+            loading: false,
+            error: null,
+            refresh: vi.fn(),
+        });
+
+        renderDashboard();
+
+        expect(screen.getByText(/ready to start/i)).toBeInTheDocument();
+        await user.click(screen.getByRole('button', { name: /open project project-a/i }));
+
+        expect(mockNavigate).toHaveBeenCalledWith('/project/project-project-a');
     });
 
     it('Given useDaemons returns an error, then an error message is displayed', () => {

--- a/web-ui/src/test/pages/ProjectDetail.test.tsx
+++ b/web-ui/src/test/pages/ProjectDetail.test.tsx
@@ -68,8 +68,11 @@ function setupDefaultMocks(sessions: SessionInfo[] = []) {
     mockUseDaemonConnection.mockReturnValue({
         apiClient,
         sseClient: null,
+        daemonInfo: { projectName: 'my-app', workspaceRoot: '/projects/my-app', registeredAt: new Date().toISOString() },
         loading: false,
         error: null,
+        projectState: 'connected',
+        refresh: vi.fn(),
     });
 
     mockUseSessions.mockReturnValue({
@@ -157,8 +160,11 @@ describe('ProjectDetail', () => {
         mockUseDaemonConnection.mockReturnValue({
             apiClient,
             sseClient: null,
+            daemonInfo: { projectName: 'my-app', workspaceRoot: '/projects/my-app', registeredAt: new Date().toISOString() },
             loading: false,
             error: null,
+            projectState: 'connected',
+            refresh: vi.fn(),
         });
 
         mockUseSessions.mockReturnValue({
@@ -191,6 +197,116 @@ describe('ProjectDetail', () => {
         renderProjectDetail('project-123');
 
         expect(screen.getByText(/no sessions yet/i)).toBeInTheDocument();
+    });
+
+    it('Given a registered project without a running daemon, then onboarding guidance is shown instead of a hard error', () => {
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient: null,
+            sseClient: null,
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
+            loading: false,
+            error: null,
+            projectState: 'offline',
+            refresh: vi.fn(),
+        });
+
+        mockUseSessions.mockReturnValue({
+            sessions: [],
+            loading: false,
+            error: null,
+            refresh: vi.fn(),
+            createSession: vi.fn(),
+            improveSessionPrompt: vi.fn(),
+            uploadSessionAttachments: vi.fn(),
+            deleteSession: vi.fn(),
+            pinSession: vi.fn(),
+            unpinSession: vi.fn(),
+            enableSessionNotifications: vi.fn(),
+            disableSessionNotifications: vi.fn(),
+        });
+
+        renderProjectDetail('project-123');
+
+        expect(screen.getByText(/daemon is offline/i)).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /refresh connection/i })).toBeInTheDocument();
+        expect(screen.queryByText(/failed to load sessions/i)).not.toBeInTheDocument();
+    });
+
+    it('Given the refresh action is used, then only the connection refresh runs immediately', async () => {
+        const user = userEvent.setup();
+        const refreshConnection = vi.fn();
+        const refreshSessions = vi.fn();
+
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient: makeApiClient(),
+            sseClient: null,
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
+            loading: false,
+            error: null,
+            projectState: 'connected',
+            refresh: refreshConnection,
+        });
+
+        mockUseSessions.mockReturnValue({
+            sessions: [],
+            loading: false,
+            error: null,
+            refresh: refreshSessions,
+            createSession: vi.fn(),
+            improveSessionPrompt: vi.fn(),
+            uploadSessionAttachments: vi.fn(),
+            deleteSession: vi.fn(),
+            pinSession: vi.fn(),
+            unpinSession: vi.fn(),
+            enableSessionNotifications: vi.fn(),
+            disableSessionNotifications: vi.fn(),
+        });
+
+        renderProjectDetail('project-123');
+
+        await user.click(screen.getByRole('button', { name: /refresh session list/i }));
+
+        expect(refreshConnection).toHaveBeenCalledTimes(1);
+        expect(refreshSessions).not.toHaveBeenCalled();
+    });
+
+    it('Given a stale project route without workspace information, then the recovery command remains actionable', () => {
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient: null,
+            sseClient: null,
+            daemonInfo: null,
+            loading: false,
+            error: null,
+            projectState: 'missing',
+            refresh: vi.fn(),
+        });
+
+        mockUseSessions.mockReturnValue({
+            sessions: [],
+            loading: false,
+            error: null,
+            refresh: vi.fn(),
+            createSession: vi.fn(),
+            improveSessionPrompt: vi.fn(),
+            uploadSessionAttachments: vi.fn(),
+            deleteSession: vi.fn(),
+            pinSession: vi.fn(),
+            unpinSession: vi.fn(),
+            enableSessionNotifications: vi.fn(),
+            disableSessionNotifications: vi.fn(),
+        });
+
+        renderProjectDetail('project-123');
+
+        expect(screen.getByText('lanes daemon unregister /absolute/path/to/repo')).toBeInTheDocument();
     });
 
     it('When user clicks Create Session, then the CreateSessionDialog opens', async () => {

--- a/web-ui/src/test/pages/ProjectSettings.test.tsx
+++ b/web-ui/src/test/pages/ProjectSettings.test.tsx
@@ -55,9 +55,15 @@ describe('ProjectSettings', () => {
         const apiClient = makeApiClient();
         mockUseDaemonConnection.mockReturnValue({
             apiClient,
-            daemonInfo: { projectName: 'my-app' },
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
             loading: false,
             error: null,
+            projectState: 'connected',
+            refresh: vi.fn(),
         });
 
         renderProjectSettings();
@@ -95,9 +101,15 @@ describe('ProjectSettings', () => {
 
         mockUseDaemonConnection.mockReturnValue({
             apiClient,
-            daemonInfo: { projectName: 'my-app' },
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
             loading: false,
             error: null,
+            projectState: 'connected',
+            refresh: vi.fn(),
         });
 
         renderProjectSettings();
@@ -110,5 +122,25 @@ describe('ProjectSettings', () => {
         await waitFor(() => {
             expect(apiClient.setConfig).toHaveBeenCalledWith('lanes.defaultAgent', 'gemini', 'global');
         });
+    });
+
+    it('shows onboarding guidance when the project is registered but offline', () => {
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient: null,
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
+            loading: false,
+            error: null,
+            projectState: 'offline',
+            refresh: vi.fn(),
+        });
+
+        renderProjectSettings();
+
+        expect(screen.getByText(/daemon is offline/i)).toBeInTheDocument();
+        expect(screen.queryByText(/failed to load settings/i)).not.toBeInTheDocument();
     });
 });

--- a/web-ui/src/test/pages/WorkflowBrowser.test.tsx
+++ b/web-ui/src/test/pages/WorkflowBrowser.test.tsx
@@ -41,6 +41,22 @@ function makeApiClient(workflows: WorkflowInfo[] = [builtinWorkflow, customWorkf
     } as unknown as DaemonApiClient;
 }
 
+function makeConnectedDaemonConnection(apiClient: DaemonApiClient) {
+    return {
+        apiClient,
+        sseClient: null,
+        daemonInfo: {
+            projectName: 'my-app',
+            workspaceRoot: '/projects/my-app',
+            registeredAt: new Date().toISOString(),
+        },
+        loading: false,
+        error: null,
+        projectState: 'connected',
+        refresh: vi.fn(),
+    };
+}
+
 function renderWithProject(projectId: string = 'project-123') {
     return render(
         <MemoryRouter initialEntries={[`/project/${projectId}/workflows`]}>
@@ -62,12 +78,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given a project param and workflows returned from API, then workflow cards are rendered', async () => {
         const apiClient = makeApiClient();
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -79,12 +90,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given workflow cards rendered, then their names are visible', async () => {
         const apiClient = makeApiClient();
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -96,12 +102,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given a builtin workflow, then the builtin badge is shown on its card', async () => {
         const apiClient = makeApiClient([builtinWorkflow]);
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -113,12 +114,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given a workflow card is clicked, then its detail panel is shown', async () => {
         const apiClient = makeApiClient();
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -138,8 +134,11 @@ describe('WorkflowBrowser', () => {
         mockUseDaemonConnection.mockReturnValue({
             apiClient: null,
             sseClient: null,
+            daemonInfo: null,
             loading: true,
             error: null,
+            projectState: 'missing',
+            refresh: vi.fn(),
         });
 
         renderWithProject('project-123');
@@ -151,8 +150,11 @@ describe('WorkflowBrowser', () => {
         mockUseDaemonConnection.mockReturnValue({
             apiClient: null,
             sseClient: null,
+            daemonInfo: null,
             loading: false,
             error: new Error('Connection refused'),
+            projectState: 'missing',
+            refresh: vi.fn(),
         });
 
         renderWithProject('project-123');
@@ -163,12 +165,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given a search query entered, then only matching workflows are shown', async () => {
         const apiClient = makeApiClient();
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -187,12 +184,7 @@ describe('WorkflowBrowser', () => {
 
     it('Given clicking a selected workflow card again, then the detail panel is closed', async () => {
         const apiClient = makeApiClient();
-        mockUseDaemonConnection.mockReturnValue({
-            apiClient,
-            sseClient: null,
-            loading: false,
-            error: null,
-        });
+        mockUseDaemonConnection.mockReturnValue(makeConnectedDaemonConnection(apiClient));
 
         renderWithProject('project-123');
 
@@ -213,5 +205,26 @@ describe('WorkflowBrowser', () => {
         await waitFor(() => {
             expect(screen.queryByTestId('workflow-detail')).not.toBeInTheDocument();
         });
+    });
+
+    it('Given a registered project without a running daemon, then onboarding guidance is shown', () => {
+        mockUseDaemonConnection.mockReturnValue({
+            apiClient: null,
+            sseClient: null,
+            daemonInfo: {
+                projectName: 'my-app',
+                workspaceRoot: '/projects/my-app',
+                registeredAt: new Date().toISOString(),
+            },
+            loading: false,
+            error: null,
+            projectState: 'offline',
+            refresh: vi.fn(),
+        });
+
+        renderWithProject('project-123');
+
+        expect(screen.getByText(/daemon is offline/i)).toBeInTheDocument();
+        expect(screen.queryByText(/failed to load workflows/i)).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

This PR improves the web onboarding flow for registered projects that are not currently connected to a running daemon.

Instead of showing dead cards on the dashboard or hard errors inside project pages, the web UI now presents actionable self-serve states for:

- starting a daemon for a registered-but-offline project
- reconnecting the page after the daemon comes online
- recovering from stale or missing project registrations

## What Changed

- Added explicit project connection states in the web UI: `connected`, `offline`, and `missing`
- Updated `useDaemonConnection` to support shared refresh invalidation across all hook consumers
- Replaced fatal offline handling with guided recovery UI in:
  - dashboard project cards
  - project workspace
  - workflows page
  - settings page
- Added a reusable `ProjectConnectionState` component for start/connect/recovery guidance
- Made registered offline projects clickable from the dashboard instead of inert
- Avoided stale-client refresh behavior that could surface misleading session load errors during daemon drop/reconnect transitions
- Improved recovery commands for missing-project routes so the fallback remains actionable

## User Impact

Before:
- Offline projects looked dead on the dashboard
- Opening a registered-but-offline project could result in hard errors
- Reconnect/recovery guidance was unclear or missing

After:
- Offline projects clearly indicate they are ready to start
- Opening them leads to guided onboarding/recovery instead of failure states
- Refreshing the connection updates all consumers consistently
- Recovery copy includes concrete commands for re-registering or unregistering stale entries

## Testing

Added/updated coverage for:

- shared `useDaemonConnection` refresh propagation
- offline and missing project states in project pages
- dashboard navigation for registered offline projects
- recovery command rendering
- e2e coverage for offline dashboard and project-detail flows

## Notes

I was not able to run the web test suite in this worktree because `web-ui/node_modules` is missing, so local `vitest` execution was unavailable.
