### PR TITLE
Fix VS Code daemon mode reliability

### DIFF
--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -8,6 +8,7 @@
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
+import * as syncFs from 'fs';
 import { spawn } from 'child_process';
 import { removeTokenFile } from './auth';
 import { registerProject } from './registry';
@@ -15,6 +16,8 @@ import { registerProject } from './registry';
 const LANES_DIR = '.lanes';
 const PID_FILE = 'daemon.pid';
 const PORT_FILE = 'daemon.port';
+const LOG_FILE = 'daemon.log';
+const EARLY_EXIT_GRACE_MS = 300;
 
 function getGlobalLanesDir(): string {
     return path.join(process.env.HOME || os.homedir(), LANES_DIR);
@@ -22,6 +25,10 @@ function getGlobalLanesDir(): string {
 
 function getGlobalFilePath(fileName: string): string {
     return path.join(getGlobalLanesDir(), fileName);
+}
+
+export function getDaemonLogPath(): string {
+    return getGlobalFilePath(LOG_FILE);
 }
 
 export interface StartDaemonOptions {
@@ -46,19 +53,28 @@ export async function startDaemon(options: StartDaemonOptions): Promise<void> {
     await fs.mkdir(getGlobalLanesDir(), { recursive: true });
 
     const args = [serverPath, '--port', String(port)];
+    const logFd = syncFs.openSync(getDaemonLogPath(), 'a');
     const child = spawn(process.execPath, args, {
         detached: true,
-        stdio: 'ignore',
+        stdio: ['ignore', logFd, logFd],
         env: { ...process.env },
     });
-    child.unref();
+
+    syncFs.closeSync(logFd);
 
     if (child.pid === undefined) {
         throw new Error('Failed to start daemon: child process has no PID');
     }
 
     await fs.writeFile(getGlobalFilePath(PID_FILE), String(child.pid), 'utf-8');
-    await fs.writeFile(getGlobalFilePath(PORT_FILE), String(port), 'utf-8');
+    try {
+        await waitForEarlyExit(child.pid, child);
+    } catch (err) {
+        await removeGlobalFile(PID_FILE);
+        throw err;
+    }
+
+    child.unref();
 
     if (workspaceRoot) {
         await registerProjectForDaemon(workspaceRoot);
@@ -94,6 +110,23 @@ export async function isDaemonRunning(_workspaceRoot?: string): Promise<boolean>
         await removeGlobalFile(PORT_FILE);
         return false;
     }
+}
+
+export async function waitForDaemonReady(timeoutMs = 5000, pollDelayMs = 200): Promise<number> {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+        const port = await getDaemonPort();
+        if (port !== undefined && port > 0) {
+            return port;
+        }
+
+        await delay(pollDelayMs);
+    }
+
+    throw new Error(
+        `Daemon did not become ready within ${timeoutMs}ms. Check ${getDaemonLogPath()} for details.`
+    );
 }
 
 export async function getDaemonPort(_workspaceRoot?: string): Promise<number | undefined> {
@@ -134,4 +167,41 @@ async function removeGlobalFile(fileName: string): Promise<void> {
             throw err;
         }
     }
+}
+
+async function waitForEarlyExit(pid: number, child: import('child_process').ChildProcess): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            cleanup();
+            resolve();
+        }, EARLY_EXIT_GRACE_MS);
+
+        const handleError = (err: Error) => {
+            cleanup();
+            reject(err);
+        };
+
+        const handleExit = (code: number | null, signal: NodeJS.Signals | null) => {
+            cleanup();
+            reject(
+                new Error(
+                    `Daemon process ${pid} exited before startup completed ` +
+                    `(code=${code ?? 'null'}, signal=${signal ?? 'null'}). Check ${getDaemonLogPath()} for details.`
+                )
+            );
+        };
+
+        const cleanup = () => {
+            clearTimeout(timer);
+            child.off('error', handleError);
+            child.off('exit', handleExit);
+        };
+
+        child.once('error', handleError);
+        child.once('exit', handleExit);
+    });
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/test/daemon/lifecycle.test.ts
+++ b/src/test/daemon/lifecycle.test.ts
@@ -24,6 +24,7 @@ import {
     isDaemonRunning,
     getDaemonPort,
     getDaemonPid,
+    getDaemonLogPath,
 } from '../../daemon/lifecycle';
 
 // ---------------------------------------------------------------------------
@@ -67,13 +68,11 @@ suite('daemon lifecycle', () => {
     // -------------------------------------------------------------------------
 
     test('Given a call to startDaemon(), when the daemon starts, then .lanes/daemon.pid is created', async () => {
-        // Use "node --version" as a server that immediately exits — we just
-        // need spawn to succeed and return a PID.
-        const serverPath = process.execPath; // node binary itself
+        const serverPath = path.join(tempDir, 'fake-daemon.js');
+        fs.writeFileSync(serverPath, 'setTimeout(() => process.exit(0), 5000);\n', 'utf-8');
         await startDaemon({
             workspaceRoot: tempDir,
             port: 4242,
-            // Pass "--version" as the "server" — it exits immediately which is fine
             serverPath,
         });
 
@@ -81,20 +80,35 @@ suite('daemon lifecycle', () => {
         assert.ok(fs.existsSync(pidPath), '.lanes/daemon.pid should be created by startDaemon()');
         const pid = parseInt(fs.readFileSync(pidPath, 'utf-8').trim(), 10);
         assert.ok(!isNaN(pid) && pid > 0, 'PID file should contain a positive integer');
+
+        await stopDaemon(tempDir);
     });
 
-    test('Given a call to startDaemon(), when the daemon starts, then .lanes/daemon.port is created', async () => {
-        const serverPath = process.execPath;
+    test('Given a call to startDaemon(), when the daemon starts, then the log file is created', async () => {
+        const serverPath = path.join(tempDir, 'fake-daemon.js');
+        fs.writeFileSync(serverPath, 'setTimeout(() => process.exit(0), 5000);\n', 'utf-8');
         await startDaemon({
             workspaceRoot: tempDir,
             port: 4242,
             serverPath,
         });
 
-        const portPath = path.join(tempDir, '.lanes', 'daemon.port');
-        assert.ok(fs.existsSync(portPath), '.lanes/daemon.port should be created by startDaemon()');
-        const port = parseInt(fs.readFileSync(portPath, 'utf-8').trim(), 10);
-        assert.strictEqual(port, 4242, 'Port file should contain the port passed to startDaemon()');
+        assert.ok(fs.existsSync(getDaemonLogPath()), 'daemon log should be created by startDaemon()');
+
+        await stopDaemon(tempDir);
+    });
+
+    test('Given the daemon process exits immediately, when startDaemon() is called, then it rejects with a startup error', async () => {
+        const serverPath = path.join(tempDir, 'failing-daemon.js');
+        fs.writeFileSync(serverPath, 'process.exit(1);\n', 'utf-8');
+
+        await assert.rejects(
+            () => startDaemon({ workspaceRoot: tempDir, port: 4242, serverPath }),
+            /exited before startup completed/
+        );
+
+        const pidPath = path.join(tempDir, '.lanes', 'daemon.pid');
+        assert.ok(!fs.existsSync(pidPath), 'daemon.pid should be cleaned up when startup fails');
     });
 
     test('Given running daemon files, when stopDaemon() is called, then the PID file is removed', async () => {

--- a/src/test/session/session-provider.test.ts
+++ b/src/test/session/session-provider.test.ts
@@ -119,6 +119,7 @@ suite('AgentSessionProvider', () => {
 
 	test('should use daemon session payload without filesystem-backed status reads', async () => {
 		const provider = new AgentSessionProvider(tempDir);
+		provider.setDaemonModeEnabled(true);
 		const getAgentStatusStub = sinon.stub(SessionDataService, 'getAgentStatus').rejects(new Error('unexpected status read'));
 		const getWorkflowStatusStub = sinon.stub(SessionDataService, 'getWorkflowStatus').rejects(new Error('unexpected workflow read'));
 		const getSessionChimeEnabledStub = sinon.stub(SessionDataService, 'getSessionChimeEnabled').rejects(new Error('unexpected chime read'));
@@ -150,5 +151,34 @@ suite('AgentSessionProvider', () => {
 		assert.ok(getAgentStatusStub.notCalled);
 		assert.ok(getWorkflowStatusStub.notCalled);
 		assert.ok(getSessionChimeEnabledStub.notCalled);
+	});
+
+	test('should show an error and avoid filesystem fallback when daemon mode is enabled but no client is available', async () => {
+		const provider = new AgentSessionProvider(tempDir);
+		provider.setDaemonModeEnabled(true);
+		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+
+		const children = await provider.getChildren();
+
+		assert.deepStrictEqual(children, []);
+		assert.ok(showErrorStub.calledOnce);
+	});
+
+	test('should show an error when daemon session loading fails', async () => {
+		const provider = new AgentSessionProvider(tempDir);
+		provider.setDaemonModeEnabled(true);
+		const showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').resolves(undefined);
+
+		provider.setDaemonClient({
+			listSessions: async () => {
+				throw new Error('connection refused');
+			},
+		} as any);
+
+		const children = await provider.getChildren();
+
+		assert.deepStrictEqual(children, []);
+		assert.ok(showErrorStub.calledOnce);
+		assert.match(showErrorStub.firstCall.args[0], /Failed to list sessions from daemon: connection refused/);
 	});
 });

--- a/src/test/vscode/services/DaemonService.test.ts
+++ b/src/test/vscode/services/DaemonService.test.ts
@@ -63,6 +63,7 @@ suite('DaemonService', () => {
 
         // Stub DaemonClient.fromWorkspace to return a minimal mock client
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().returns({ close: () => {} }),
         } as unknown as clientModule.DaemonClient;
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
@@ -87,15 +88,17 @@ suite('DaemonService', () => {
         // Arrange
         sinon.stub(lifecycle, 'isDaemonRunning').resolves(false);
         const startDaemonStub = sinon.stub(lifecycle, 'startDaemon').resolves();
-        // getDaemonPort returns a valid port immediately on first poll
-        sinon.stub(lifecycle, 'getDaemonPort').resolves(4300);
+        sinon.stub(lifecycle, 'waitForDaemonReady').resolves(4300);
 
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().returns({ close: () => {} }),
         } as unknown as clientModule.DaemonClient;
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
 
-        const extensionPath = '/fake/extension';
+        const extensionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-daemon-service-ext-'));
+        fs.mkdirSync(path.join(extensionPath, 'out'), { recursive: true });
+        fs.writeFileSync(path.join(extensionPath, 'out', 'daemon.js'), '', 'utf-8');
 
         // Act
         const service = new DaemonService(tempDir, extensionPath, onRefreshStub);
@@ -105,7 +108,7 @@ suite('DaemonService', () => {
         assert.ok(startDaemonStub.calledOnce, 'startDaemon should be called when daemon is not running');
         const callArgs = startDaemonStub.firstCall.args[0] as lifecycle.StartDaemonOptions;
         assert.strictEqual(callArgs.workspaceRoot, tempDir, 'workspaceRoot should match');
-        const expectedServerPath = path.join(extensionPath, 'out', 'daemon', 'server.js');
+        const expectedServerPath = path.join(extensionPath, 'out', 'daemon.js');
         assert.strictEqual(callArgs.serverPath, expectedServerPath, 'serverPath should point to bundled server');
         assert.ok(service.getClient() !== undefined, 'getClient() should return a client after successful init');
 
@@ -122,6 +125,7 @@ suite('DaemonService', () => {
 
         let capturedCallbacks: SseCallbacks = {};
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
                 capturedCallbacks = callbacks;
                 return { close: () => {} };
@@ -129,7 +133,10 @@ suite('DaemonService', () => {
         } as unknown as clientModule.DaemonClient;
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
 
-        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        const extensionPath = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-daemon-service-ext-'));
+        fs.mkdirSync(path.join(extensionPath, 'out'), { recursive: true });
+        fs.writeFileSync(path.join(extensionPath, 'out', 'daemon.js'), '', 'utf-8');
+        const service = new DaemonService(tempDir, extensionPath, onRefreshStub);
         await service.initialize();
 
         // Act: simulate SSE event
@@ -147,6 +154,7 @@ suite('DaemonService', () => {
 
         let capturedCallbacks: SseCallbacks = {};
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
                 capturedCallbacks = callbacks;
                 return { close: () => {} };
@@ -172,6 +180,7 @@ suite('DaemonService', () => {
 
         let capturedCallbacks: SseCallbacks = {};
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().callsFake((callbacks: SseCallbacks) => {
                 capturedCallbacks = callbacks;
                 return { close: () => {} };
@@ -202,6 +211,7 @@ suite('DaemonService', () => {
         let closeCalled = false;
         const fakeSubscription: SseSubscription = { close: () => { closeCalled = true; } };
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().returns(fakeSubscription),
         } as unknown as clientModule.DaemonClient;
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
@@ -223,32 +233,37 @@ suite('DaemonService', () => {
     // daemon-service-graceful-error
     // -------------------------------------------------------------------------
 
-    test('Given startDaemon throws, when initialize() is called, then error is handled gracefully', async () => {
+    test('Given startDaemon throws, when initialize() is called, then it rejects and leaves the service disabled', async () => {
         // Arrange
         sinon.stub(lifecycle, 'isDaemonRunning').resolves(false);
         sinon.stub(lifecycle, 'startDaemon').rejects(new Error('startDaemon failed'));
 
-        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+        const extensionPath = path.join(tempDir, 'extension');
+        fs.mkdirSync(path.join(extensionPath, 'out'), { recursive: true });
+        fs.writeFileSync(path.join(extensionPath, 'out', 'daemon.js'), '', 'utf-8');
+        const service = new DaemonService(tempDir, extensionPath, onRefreshStub);
 
-        // Act: should not throw
-        await assert.doesNotReject(async () => {
-            await service.initialize();
-        }, 'initialize() should not throw even if daemon fails to start');
+        await assert.rejects(
+            () => service.initialize(),
+            /Daemon initialization failed: startDaemon failed/
+        );
 
         // Assert
         assert.strictEqual(service.getClient(), undefined, 'getClient() should be undefined after failed init');
         assert.strictEqual(service.isEnabled(), false, 'isEnabled() should be false after failed init');
     });
 
-    test('Given DaemonClient.fromWorkspace throws, when initialize() is called, then error is handled gracefully', async () => {
+    test('Given DaemonClient.fromWorkspace throws, when initialize() is called, then it rejects and leaves the service disabled', async () => {
         // Arrange
         sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').rejects(new Error('port file not found'));
 
         const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
 
-        // Act
-        await service.initialize();
+        await assert.rejects(
+            () => service.initialize(),
+            /Daemon initialization failed: port file not found/
+        );
 
         // Assert
         assert.strictEqual(service.getClient(), undefined, 'getClient() should be undefined after failed init');
@@ -270,6 +285,7 @@ suite('DaemonService', () => {
         sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
 
         const fakeClient = {
+            discovery: sinon.stub().resolves({ projectId: 'proj-1' }),
             subscribeEvents: sinon.stub().returns({ close: () => {} }),
         } as unknown as clientModule.DaemonClient;
         sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
@@ -302,10 +318,29 @@ suite('DaemonService', () => {
             baseRepoPath: '/tmp/test',
             extensionPath: '/fake/ext',
             codeAgent: {} as import('../../../core/codeAgents').CodeAgent,
+            daemonModeEnabled: false,
             // daemonClient intentionally omitted
         };
 
         // No daemonClient — accessing it should return undefined
         assert.strictEqual((container as Record<string, unknown>).daemonClient, undefined);
+    });
+
+    test('Given the daemon client cannot complete discovery, when initialize() is called, then it rejects', async () => {
+        sinon.stub(lifecycle, 'isDaemonRunning').resolves(true);
+
+        const fakeClient = {
+            discovery: sinon.stub().rejects(new Error('Unauthorized: invalid token')),
+            subscribeEvents: sinon.stub().returns({ close: () => {} }),
+        } as unknown as clientModule.DaemonClient;
+        sinon.stub(clientModule.DaemonClient, 'fromWorkspace').resolves(fakeClient);
+
+        const service = new DaemonService(tempDir, '/fake/ext', onRefreshStub);
+
+        await assert.rejects(
+            () => service.initialize(),
+            /Daemon initialization failed: Unauthorized: invalid token/
+        );
+        assert.strictEqual(service.isEnabled(), false);
     });
 });

--- a/src/types/serviceContainer.d.ts
+++ b/src/types/serviceContainer.d.ts
@@ -28,6 +28,9 @@ export interface ServiceContainer {
     // Code agent
     codeAgent: CodeAgent;
 
+    // Whether daemon mode is configured on for this window.
+    daemonModeEnabled: boolean;
+
     // Optional daemon client (present only when lanes.useDaemon is true and daemon is reachable)
     daemonClient?: DaemonClient;
 }

--- a/src/vscode/commands/sessionCommands.ts
+++ b/src/vscode/commands/sessionCommands.ts
@@ -48,10 +48,27 @@ export function registerSessionCommands(
         sessionProvider,
         baseRepoPath,
         codeAgent,
-        daemonClient
+        daemonClient,
+        daemonModeEnabled,
     } = services;
 
     const warnedMergeBaseBranches = new Set<string>();
+
+    function getActiveDaemonClient() {
+        if (!daemonModeEnabled) {
+            return daemonClient;
+        }
+
+        if (daemonClient) {
+            return daemonClient;
+        }
+
+        void vscode.window.showErrorMessage(
+            'Lanes daemon mode is enabled, but the daemon is unavailable. ' +
+            'Reload the window after fixing daemon startup, or disable "Lanes: Use Daemon".'
+        );
+        return undefined;
+    }
 
     /**
      * Helper: Check if branch exists in git
@@ -152,14 +169,17 @@ export function registerSessionCommands(
             return;
         }
 
-        if (daemonClient) {
+        const activeDaemonClient = getActiveDaemonClient();
+        if (activeDaemonClient) {
             try {
-                const result = await daemonClient.createSession({ name, agent: codeAgent.name });
+                const result = await activeDaemonClient.createSession({ name, agent: codeAgent.name });
                 sessionProvider.refresh();
                 await openDaemonSessionTerminal(result.sessionName, result.worktreePath, result, codeAgent);
             } catch (err) {
                 vscode.window.showErrorMessage(`Failed to create session via daemon: ${getErrorMessage(err)}`);
             }
+        } else if (daemonModeEnabled) {
+            return;
         } else {
             await createSession(name, '', 'acceptEdits', '', null, [], baseRepoPath, sessionProvider, codeAgent);
         }
@@ -169,9 +189,10 @@ export function registerSessionCommands(
     const openDisposable = vscode.commands.registerCommand('lanes.openSession', async (item: SessionItem) => {
         const agentName = await getSessionAgentName(item.worktreePath);
         const sessionAgent = getAgent(agentName) || codeAgent;
-        if (daemonClient) {
+        const activeDaemonClient = getActiveDaemonClient();
+        if (activeDaemonClient) {
             try {
-                const result = await daemonClient.openSession(item.label);
+                const result = await activeDaemonClient.openSession(item.label);
                 await openDaemonSessionTerminal(
                     item.label,
                     result.worktreePath,
@@ -181,6 +202,9 @@ export function registerSessionCommands(
             } catch (err) {
                 vscode.window.showErrorMessage(`Failed to open session via daemon: ${getErrorMessage(err)}`);
             }
+            return;
+        }
+        if (daemonModeEnabled) {
             return;
         }
         await openAgentTerminal(item.label, item.worktreePath, undefined, undefined, undefined, sessionAgent, baseRepoPath);
@@ -216,9 +240,12 @@ export function registerSessionCommands(
             // Remove from Project Manager
             await removeProject(item.worktreePath);
 
-            if (daemonClient) {
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
                 // Route git/fs deletion through the daemon
-                await daemonClient.deleteSession(item.label);
+                await activeDaemonClient.deleteSession(item.label);
+            } else if (daemonModeEnabled) {
+                return;
             } else {
                 // Direct path: remove worktree via git
                 if (baseRepoPath) {
@@ -291,12 +318,15 @@ export function registerSessionCommands(
             let diffContent: string;
             let baseBranch: string;
 
-            if (daemonClient) {
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
                 const config = vscode.workspace.getConfiguration('lanes');
                 const includeUncommitted = config.get<boolean>('includeUncommittedChanges', true);
-                const diffResult = await daemonClient.getSessionDiff(item.label, { includeUncommitted });
+                const diffResult = await activeDaemonClient.getSessionDiff(item.label, { includeUncommitted });
                 diffContent = diffResult.diff;
                 baseBranch = diffResult.baseBranch;
+            } else if (daemonModeEnabled) {
+                return;
             } else {
                 baseBranch = await DiffService.getBaseBranch(item.worktreePath, vscode.workspace.getConfiguration('lanes').get<string>('baseBranch', ''));
                 diffContent = await generateDiffContent(item.worktreePath, baseBranch);
@@ -541,14 +571,15 @@ export function registerSessionCommands(
             return;
         }
 
-        if (!daemonClient && !(await fileExists(item.worktreePath))) {
+        if (!daemonModeEnabled && !daemonClient && !(await fileExists(item.worktreePath))) {
             vscode.window.showErrorMessage(`Worktree path does not exist: ${item.worktreePath}`);
             return;
         }
 
         try {
-            if (daemonClient) {
-                const result = await daemonClient.getWorkflowState(item.label) as { state?: unknown } | undefined;
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
+                const result = await activeDaemonClient.getWorkflowState(item.label) as { state?: unknown } | undefined;
                 const state = result?.state ?? null;
                 if (!state) {
                     vscode.window.showInformationMessage(`No active workflow for session '${item.label}'. The workflow state is created when a workflow is started.`);
@@ -560,6 +591,9 @@ export function registerSessionCommands(
                     language: 'json',
                 });
                 await vscode.window.showTextDocument(document, { preview: false });
+                return;
+            }
+            if (daemonModeEnabled) {
                 return;
             }
 
@@ -613,16 +647,19 @@ export function registerSessionCommands(
         }
 
         try {
-            if (daemonClient) {
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
                 const insightsResult = await vscode.window.withProgress(
                     { location: vscode.ProgressLocation.Notification, title: 'Generating insights...' },
-                    () => daemonClient.getSessionInsights(item.label, { includeAnalysis: true })
+                    () => activeDaemonClient.getSessionInsights(item.label, { includeAnalysis: true })
                 );
                 const document = await vscode.workspace.openTextDocument({
                     content: insightsResult.insights,
                     language: 'markdown'
                 });
                 await vscode.window.showTextDocument(document, { preview: false });
+            } else if (daemonModeEnabled) {
+                return;
             } else {
                 const insights = await vscode.window.withProgress(
                     { location: vscode.ProgressLocation.Notification, title: 'Generating insights...' },
@@ -652,8 +689,11 @@ export function registerSessionCommands(
         }
 
         try {
-            if (daemonClient) {
-                await daemonClient.pinSession(item.label);
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
+                await activeDaemonClient.pinSession(item.label);
+            } else if (daemonModeEnabled) {
+                return;
             } else {
                 await sessionProvider.pinSession(item.worktreePath);
             }
@@ -671,8 +711,11 @@ export function registerSessionCommands(
         }
 
         try {
-            if (daemonClient) {
-                await daemonClient.unpinSession(item.label);
+            const activeDaemonClient = getActiveDaemonClient();
+            if (activeDaemonClient) {
+                await activeDaemonClient.unpinSession(item.label);
+            } else if (daemonModeEnabled) {
+                return;
             } else {
                 await sessionProvider.unpinSession(item.worktreePath);
             }

--- a/src/vscode/extension.ts
+++ b/src/vscode/extension.ts
@@ -43,9 +43,10 @@ import { registerAllCommands } from './commands';
 import { registerWatchers } from './watchers';
 import { validateWorkflow as validateWorkflowService } from '../core/services/WorkflowService';
 import { createSession } from './services/SessionService';
-import { openAgentTerminal } from './services/TerminalService';
+import { openAgentTerminal, openDaemonSessionTerminal } from './services/TerminalService';
 import { VscodeConfigProvider } from './adapters/VscodeConfigProvider';
 import { DaemonService } from './services/DaemonService';
+import { getDaemonLogPath } from '../daemon/lifecycle';
 
 /**
  * Activate the extension.
@@ -174,6 +175,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // Initialize Tree Data Provider with the base repo path
     // This ensures sessions are always listed from the main repository
     const sessionProvider = new AgentSessionProvider(workspaceRoot, baseRepoPath, codeAgent, context);
+    sessionProvider.setDaemonModeEnabled(useDaemon);
     const sessionTreeView = vscode.window.createTreeView('lanesSessionsView', {
         treeDataProvider: sessionProvider,
         showCollapseAll: false
@@ -193,9 +195,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             // Wire daemon client into the session tree provider
             if (daemonService.isEnabled()) {
                 sessionProvider.setDaemonClient(daemonService.getClient());
+                sessionProvider.refresh();
             }
         } catch (err) {
-            console.error('Lanes: Failed to initialize daemon service:', getErrorMessage(err));
+            const message = `Lanes daemon mode is enabled, but startup failed: ${getErrorMessage(err)}`;
+            console.error(message);
+            void vscode.window.showErrorMessage(
+                `${message}. Check ${getDaemonLogPath()} and reload the window after fixing it, or disable "Lanes: Use Daemon".`
+            );
             daemonService = undefined;
         }
         if (daemonService) {
@@ -234,6 +241,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         )
     );
 
+    const getActiveDaemonClient = () => daemonService?.getClient();
+
     // Set default agent for the form dropdown
     sessionFormProvider.setDefaultAgent(defaultAgentName);
 
@@ -252,6 +261,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 `Tip: You can change the default agent in Settings > Lanes > Default Agent.`
             );
             throw new Error(`CLI not available`);
+        }
+
+        if (useDaemon) {
+            const daemonClient = getActiveDaemonClient();
+            if (!daemonClient) {
+                vscode.window.showErrorMessage(
+                    'Lanes daemon mode is enabled, but the daemon is unavailable. ' +
+                    'Reload the window after fixing daemon startup, or disable "Lanes: Use Daemon".'
+                );
+                throw new Error('Daemon mode enabled but daemon client is unavailable');
+            }
+
+            const result = await daemonClient.createSession({
+                name,
+                agent: selectedAgent.name,
+                prompt,
+                sourceBranch,
+                permissionMode,
+                workflow,
+                attachments,
+            });
+            sessionProvider.refresh();
+            await openDaemonSessionTerminal(result.sessionName, result.worktreePath, result, selectedAgent);
+            return;
         }
 
         await createSession(name, prompt, permissionMode, sourceBranch, workflow, attachments, baseRepoPath, sessionProvider, selectedAgent);
@@ -324,6 +357,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         baseRepoPath,
         extensionPath: context.extensionPath,
         codeAgent,
+        daemonModeEnabled: useDaemon,
         daemonClient: daemonService?.getClient()
     };
 

--- a/src/vscode/providers/AgentSessionProvider.ts
+++ b/src/vscode/providers/AgentSessionProvider.ts
@@ -214,6 +214,8 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
     readonly onDidChangeTreeData: vscode.Event<SessionItem | SessionDetailItem | undefined | null | void> = this._onDidChangeTreeData.event;
     private readonly sessionsRoot: string | undefined;
     private daemonClient: DaemonClient | undefined;
+    private daemonModeEnabled = false;
+    private lastDaemonError: string | undefined;
 
     constructor(private workspaceRoot: string | undefined, baseRepoPath?: string, private codeAgent?: CodeAgent, private extensionContext?: vscode.ExtensionContext) {
         this.sessionsRoot = baseRepoPath || workspaceRoot;
@@ -225,6 +227,10 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
      */
     setDaemonClient(client: DaemonClient | undefined): void {
         this.daemonClient = client;
+    }
+
+    setDaemonModeEnabled(enabled: boolean): void {
+        this.daemonModeEnabled = enabled;
     }
 
     dispose(): void { this._onDidChangeTreeData.dispose(); }
@@ -260,7 +266,14 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
             return [];
         }
 
-        if (this.daemonClient) {
+        if (this.daemonModeEnabled) {
+            if (!this.daemonClient) {
+                this.reportDaemonError(
+                    'Lanes daemon mode is enabled, but the daemon client is unavailable. ' +
+                    'Reload the window after fixing daemon startup, or disable "Lanes: Use Daemon".'
+                );
+                return [];
+            }
             return this.getSessionsFromDaemon();
         }
 
@@ -281,6 +294,7 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
 
         try {
             const result = await this.daemonClient.listSessions();
+            this.lastDaemonError = undefined;
             const items: SessionItem[] = [];
 
             for (const session of result.sessions) {
@@ -310,9 +324,20 @@ export class AgentSessionProvider implements vscode.TreeDataProvider<SessionItem
             const unpinnedItems = items.filter(item => item.contextValue !== 'sessionItemPinned');
             return [...pinnedItems, ...unpinnedItems];
         } catch (err) {
-            console.error('Lanes: Failed to list sessions from daemon:', err);
+            const message = `Failed to list sessions from daemon: ${err instanceof Error ? err.message : String(err)}`;
+            console.error(`Lanes: ${message}`);
+            this.reportDaemonError(message);
             return [];
         }
+    }
+
+    private reportDaemonError(message: string): void {
+        if (this.lastDaemonError === message) {
+            return;
+        }
+
+        this.lastDaemonError = message;
+        void vscode.window.showErrorMessage(message);
     }
 
     private async getSessionsInDir(dirPath: string): Promise<SessionItem[]> {

--- a/src/vscode/services/DaemonService.ts
+++ b/src/vscode/services/DaemonService.ts
@@ -10,14 +10,15 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs/promises';
 import { DaemonClient, type SseSubscription } from '../../daemon/client';
-import { startDaemon, isDaemonRunning, getDaemonPort } from '../../daemon/lifecycle';
+import {
+    startDaemon,
+    isDaemonRunning,
+    waitForDaemonReady,
+    getDaemonLogPath,
+} from '../../daemon/lifecycle';
 import { getErrorMessage } from '../../core/utils';
-
-/** Maximum number of attempts to poll for the daemon port file after starting. */
-const PORT_POLL_ATTEMPTS = 10;
-/** Delay in milliseconds between each port-file poll attempt. */
-const PORT_POLL_DELAY_MS = 300;
 
 export class DaemonService implements vscode.Disposable {
     private client: DaemonClient | undefined;
@@ -43,29 +44,31 @@ export class DaemonService implements vscode.Disposable {
      * 4. Creates a DaemonClient from workspace files.
      * 5. Subscribes to SSE events that trigger onRefresh().
      *
-     * Errors are logged but not re-thrown — a failure leaves the service
-     * disabled so the extension can fall back to direct service calls.
      */
     async initialize(): Promise<void> {
         try {
             const running = await isDaemonRunning(this.workspaceRoot);
 
             if (!running) {
-                const serverPath = path.join(this.extensionPath, 'out', 'daemon', 'server.js');
+                const serverPath = await this.resolveBundledServerPath();
                 await startDaemon({ workspaceRoot: this.workspaceRoot, serverPath });
-
-                // Poll until the daemon writes its port file (it may need a moment)
-                await this.waitForPortFile();
+                await waitForDaemonReady();
             }
 
             this.client = await DaemonClient.fromWorkspace(this.workspaceRoot);
+            await this.client.discovery();
             this.enabled = true;
 
             this.subscribeToEvents();
         } catch (err) {
-            console.error('Lanes: DaemonService initialization failed:', getErrorMessage(err));
             this.client = undefined;
             this.enabled = false;
+            this.sseSubscription?.close();
+            this.sseSubscription = undefined;
+            throw new Error(
+                `Daemon initialization failed: ${getErrorMessage(err)}. ` +
+                `Check ${getDaemonLogPath()} for details.`
+            );
         }
     }
 
@@ -101,24 +104,6 @@ export class DaemonService implements vscode.Disposable {
     // -------------------------------------------------------------------------
 
     /**
-     * Poll for the daemon port file up to PORT_POLL_ATTEMPTS times.
-     * Resolves when a valid port is found; rejects if the timeout is exceeded.
-     */
-    private async waitForPortFile(): Promise<void> {
-        for (let attempt = 0; attempt < PORT_POLL_ATTEMPTS; attempt++) {
-            const port = await getDaemonPort(this.workspaceRoot);
-            if (port !== undefined && port > 0) {
-                return;
-            }
-            await delay(PORT_POLL_DELAY_MS);
-        }
-        throw new Error(
-            `Daemon port file not available after ${PORT_POLL_ATTEMPTS * PORT_POLL_DELAY_MS}ms. ` +
-            'The daemon may have failed to start.'
-        );
-    }
-
-    /**
      * Subscribe to SSE events from the daemon.
      * Fires onRefresh() for session lifecycle events (created, deleted, status changed).
      */
@@ -145,9 +130,24 @@ export class DaemonService implements vscode.Disposable {
             },
         });
     }
-}
 
-/** Simple promise-based delay. */
-function delay(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    private async resolveBundledServerPath(): Promise<string> {
+        const candidatePaths = [
+            path.join(this.extensionPath, 'out', 'daemon.js'),
+            path.join(this.extensionPath, 'out', 'daemon', 'server.js'),
+        ];
+
+        for (const candidate of candidatePaths) {
+            try {
+                await fs.access(candidate);
+                return candidate;
+            } catch {
+                // Try the next known bundle location.
+            }
+        }
+
+        throw new Error(
+            `Bundled daemon entrypoint not found. Tried: ${candidatePaths.join(', ')}`
+        );
+    }
 }


### PR DESCRIPTION
## Summary

This PR makes VS Code daemon mode behave reliably instead of degrading silently.

- Fix VS Code daemon auto-start path resolution to use the bundled daemon entrypoint.
- Make daemon initialization explicit: validate readiness and discovery before enabling daemon mode.
- Remove silent fallback behavior when `lanes.useDaemon` is enabled but the daemon is unavailable.
- Refresh the sessions tree immediately after successful daemon initialization so existing sessions appear without waiting for another event.
- Restore early `daemon.pid` publication during startup to preserve singleton behavior across concurrent windows/processes, while still cleaning up failed startups.
- Capture daemon startup logs in `~/.lanes/daemon.log` and surface actionable errors to the user.

## Testing

- `npx tsc -p ./ --noEmit`
- `npx eslint src/daemon/lifecycle.ts src/vscode/services/DaemonService.ts src/vscode/providers/AgentSessionProvider.ts src/types/serviceContainer.d.ts src/vscode/commands/sessionCommands.ts src/vscode/extension.ts src/test/vscode/services/DaemonService.test.ts src/test/session/session-provider.test.ts src/test/daemon/lifecycle.test.ts`
- `npx tsc -p ./ && node /home/filipe/Documents/repos/lanes/node_modules/mocha/bin/mocha --ui tdd out/test/daemon/lifecycle.test.js`
- `node /home/filipe/Documents/repos/lanes/node_modules/mocha/bin/mocha --ui tdd out/test/vscode/services/DaemonService.test.js`

## Notes

- I could not run the full `vscode-test` extension-host suite in this environment because the test harness attempted to download VS Code from `update.code.visualstudio.com`, and network access is restricted here.
