### PR TITLE
Finalize machine-wide daemon architecture

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -4,7 +4,7 @@
 
 import { Command } from 'commander';
 import * as path from 'path';
-import { initCli, initCliGit, resolveRepoRootFromPath, exitWithError } from '../utils';
+import { initCliGit, resolveRepoRoot, resolveRepoRootFromPath, exitWithError } from '../utils';
 import {
     startDaemon,
     stopDaemon,
@@ -30,8 +30,15 @@ export function registerDaemonCommand(program: Command): void {
         .option('--port <port>', 'Port for the daemon to listen on (default: OS-assigned)', '0')
         .action(async (options) => {
             try {
-                const { repoRoot } = await initCli();
+                await initCliGit();
                 const port = parseInt(options.port, 10);
+                let repoRoot: string | undefined;
+
+                try {
+                    repoRoot = await resolveRepoRoot();
+                } catch {
+                    repoRoot = undefined;
+                }
 
                 if (isNaN(port) || port < 0 || port > 65535) {
                     exitWithError(`Invalid port: ${options.port}. Must be a number between 0 and 65535.`);
@@ -49,9 +56,9 @@ export function registerDaemonCommand(program: Command): void {
                 // Wait briefly for the daemon to start up and write its port file
                 await new Promise<void>((resolve) => setTimeout(resolve, 500));
 
-                const running = await isDaemonRunning(repoRoot);
+                const running = await isDaemonRunning();
                 if (running) {
-                    const actualPort = await getDaemonPort(repoRoot);
+                    const actualPort = await getDaemonPort();
                     console.log(`Daemon started successfully on port ${actualPort}.`);
                 } else {
                     console.error('Daemon did not start within the expected time. Check daemon logs for details.');
@@ -130,15 +137,13 @@ export function registerDaemonCommand(program: Command): void {
         .description('Stop the running daemon process')
         .action(async () => {
             try {
-                const { repoRoot } = await initCli();
-
-                const running = await isDaemonRunning(repoRoot);
+                const running = await isDaemonRunning();
                 if (!running) {
                     console.log('Daemon is not running.');
                     return;
                 }
 
-                await stopDaemon(repoRoot);
+                await stopDaemon();
                 console.log('Daemon stopped successfully.');
             } catch (err) {
                 if ((err as NodeJS.ErrnoException).code === 'ERR_PROCESS_EXIT') {throw err;}
@@ -151,16 +156,14 @@ export function registerDaemonCommand(program: Command): void {
         .description('Show daemon status')
         .action(async () => {
             try {
-                const { repoRoot } = await initCli();
-
-                const running = await isDaemonRunning(repoRoot);
+                const running = await isDaemonRunning();
                 if (!running) {
                     console.log('Daemon status: stopped');
                     return;
                 }
 
-                const pid = await getDaemonPid(repoRoot);
-                const port = await getDaemonPort(repoRoot);
+                const pid = await getDaemonPid();
+                const port = await getDaemonPort();
                 console.log('Daemon status: running');
                 if (pid !== undefined) {
                     console.log(`  PID:  ${pid}`);

--- a/src/daemon/auth.ts
+++ b/src/daemon/auth.ts
@@ -36,7 +36,7 @@ export function generateToken(): string {
 /**
  * Write the authentication token to `~/.lanes/daemon.token`.
  */
-export async function writeTokenFile(_workspaceRoot: string | undefined, token: string): Promise<void> {
+export async function writeTokenFile(token: string): Promise<void> {
     const lanesDir = getGlobalLanesDir();
     await fs.mkdir(lanesDir, { recursive: true });
     await fs.writeFile(getGlobalTokenPath(), token, { encoding: 'utf-8', mode: 0o600 });
@@ -46,7 +46,7 @@ export async function writeTokenFile(_workspaceRoot: string | undefined, token: 
  * Read the authentication token from `~/.lanes/daemon.token`.
  * Throws if the file does not exist or cannot be read.
  */
-export async function readTokenFile(_workspaceRoot?: string): Promise<string> {
+export async function readTokenFile(): Promise<string> {
     const content = await fs.readFile(getGlobalTokenPath(), 'utf-8');
     return content.trim();
 }
@@ -55,7 +55,7 @@ export async function readTokenFile(_workspaceRoot?: string): Promise<string> {
  * Remove the token file from `~/.lanes/daemon.token`.
  * Does not throw if the file does not exist.
  */
-export async function removeTokenFile(_workspaceRoot?: string): Promise<void> {
+export async function removeTokenFile(): Promise<void> {
     try {
         await fs.unlink(getGlobalTokenPath());
     } catch (err) {

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -156,11 +156,11 @@ export class DaemonClient {
      */
     static async fromWorkspace(workspaceRoot: string): Promise<DaemonClient> {
         const resolved = await ensureProjectRegistered(workspaceRoot);
-        const port = await getDaemonPort(workspaceRoot);
+        const port = await getDaemonPort();
         if (port === undefined) {
             throw new Error('Daemon port file not found or invalid. Is the daemon running?');
         }
-        const token = await readTokenFile(workspaceRoot);
+        const token = await readTokenFile();
         return new DaemonClient({ port, token, projectId: resolved.projectId });
     }
 

--- a/src/daemon/gateway.ts
+++ b/src/daemon/gateway.ts
@@ -15,16 +15,24 @@ import * as http from 'http';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import {
-    type DaemonRegistryEntry,
     type RegisteredProjectEntry,
     listRegisteredProjects,
 } from './registry';
-import { isDaemonRunning, getDaemonPid, getDaemonPort } from './lifecycle';
-import { readTokenFile } from './auth';
+import { getMachineDaemonState } from './lifecycle';
+
+export type GatewayDaemonInfo = {
+    projectId: string;
+    workspaceRoot: string;
+    port: number;
+    pid: number;
+    token: string;
+    startedAt: string;
+    projectName: string;
+};
 
 export type GatewayProjectInfo = RegisteredProjectEntry & {
     status: 'running' | 'registered';
-    daemon: DaemonRegistryEntry | null;
+    daemon: GatewayDaemonInfo | null;
 };
 
 // ---------------------------------------------------------------------------
@@ -83,26 +91,23 @@ function sendJson(res: http.ServerResponse, status: number, body: unknown): void
 }
 
 async function listGatewayProjects(): Promise<GatewayProjectInfo[]> {
-    const [registeredProjects, running, pid, port, token] = await Promise.all([
+    const [registeredProjects, machineDaemon] = await Promise.all([
         listRegisteredProjects(),
-        isDaemonRunning(),
-        getDaemonPid(),
-        getDaemonPort(),
-        readTokenFile().catch(() => undefined),
+        getMachineDaemonState(),
     ]);
 
     return registeredProjects
         .map((project) => {
-            const daemon: DaemonRegistryEntry | null =
-                running && pid !== undefined && port !== undefined && token
+            const daemon: GatewayDaemonInfo | null =
+                machineDaemon
                     ? {
                         projectId: project.projectId,
                         workspaceRoot: project.workspaceRoot,
                         projectName: project.projectName,
-                        pid,
-                        port,
-                        token,
-                        startedAt: project.registeredAt,
+                        pid: machineDaemon.pid,
+                        port: machineDaemon.port,
+                        token: machineDaemon.token,
+                        startedAt: machineDaemon.startedAt,
                     }
                     : null;
 
@@ -195,7 +200,7 @@ export async function createGatewayServer(options: GatewayServerOptions = {}): P
                 const projects = await listGatewayProjects();
                 const daemons = projects
                     .map((project) => project.daemon)
-                    .filter((daemon): daemon is DaemonRegistryEntry => daemon !== null);
+                    .filter((daemon): daemon is GatewayDaemonInfo => daemon !== null);
                 sendJson(res, 200, daemons);
                 return;
             }

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -12,13 +12,15 @@ export {
     removeTokenFile,
     validateAuthHeader,
 } from './auth';
-export type { StartDaemonOptions } from './lifecycle';
+export type { StartDaemonOptions, MachineDaemonState } from './lifecycle';
 export {
     startDaemon,
     stopDaemon,
     isDaemonRunning,
     getDaemonPort,
     getDaemonPid,
+    getDaemonStartedAt,
+    getMachineDaemonState,
 } from './lifecycle';
 export { DaemonNotificationEmitter } from './notifications';
 export type { FileWatchOptions } from './fileWatcher';

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -9,12 +9,13 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { spawn } from 'child_process';
-import { removeTokenFile } from './auth';
+import { readTokenFile, removeTokenFile } from './auth';
 import { registerProject } from './registry';
 
 const LANES_DIR = '.lanes';
 const PID_FILE = 'daemon.pid';
 const PORT_FILE = 'daemon.port';
+const STARTED_AT_FILE = 'daemon.startedAt';
 
 function getGlobalLanesDir(): string {
     return path.join(process.env.HOME || os.homedir(), LANES_DIR);
@@ -31,6 +32,13 @@ export interface StartDaemonOptions {
     port?: number;
     /** Absolute path to the daemon server entry-point script. */
     serverPath: string;
+}
+
+export interface MachineDaemonState {
+    pid: number;
+    port: number;
+    token: string;
+    startedAt: string;
 }
 
 export async function startDaemon(options: StartDaemonOptions): Promise<void> {
@@ -58,14 +66,16 @@ export async function startDaemon(options: StartDaemonOptions): Promise<void> {
     }
 
     await fs.writeFile(getGlobalFilePath(PID_FILE), String(child.pid), 'utf-8');
-    await fs.writeFile(getGlobalFilePath(PORT_FILE), String(port), 'utf-8');
+    if (port > 0) {
+        await fs.writeFile(getGlobalFilePath(PORT_FILE), String(port), 'utf-8');
+    }
 
     if (workspaceRoot) {
         await registerProjectForDaemon(workspaceRoot);
     }
 }
 
-export async function stopDaemon(_workspaceRoot?: string): Promise<void> {
+export async function stopDaemon(): Promise<void> {
     const pid = await getDaemonPid();
     if (pid !== undefined && !isNaN(pid)) {
         try {
@@ -77,10 +87,11 @@ export async function stopDaemon(_workspaceRoot?: string): Promise<void> {
 
     await removeGlobalFile(PID_FILE);
     await removeGlobalFile(PORT_FILE);
+    await removeGlobalFile(STARTED_AT_FILE);
     await removeTokenFile();
 }
 
-export async function isDaemonRunning(_workspaceRoot?: string): Promise<boolean> {
+export async function isDaemonRunning(): Promise<boolean> {
     const pid = await getDaemonPid();
     if (pid === undefined || isNaN(pid)) {
         return false;
@@ -92,11 +103,13 @@ export async function isDaemonRunning(_workspaceRoot?: string): Promise<boolean>
     } catch {
         await removeGlobalFile(PID_FILE);
         await removeGlobalFile(PORT_FILE);
+        await removeGlobalFile(STARTED_AT_FILE);
+        await removeTokenFile();
         return false;
     }
 }
 
-export async function getDaemonPort(_workspaceRoot?: string): Promise<number | undefined> {
+export async function getDaemonPort(): Promise<number | undefined> {
     try {
         const content = await fs.readFile(getGlobalFilePath(PORT_FILE), 'utf-8');
         const port = parseInt(content.trim(), 10);
@@ -106,11 +119,58 @@ export async function getDaemonPort(_workspaceRoot?: string): Promise<number | u
     }
 }
 
-export async function getDaemonPid(_workspaceRoot?: string): Promise<number | undefined> {
+export async function getDaemonPid(): Promise<number | undefined> {
     try {
         const content = await fs.readFile(getGlobalFilePath(PID_FILE), 'utf-8');
         const pid = parseInt(content.trim(), 10);
         return isNaN(pid) ? undefined : pid;
+    } catch {
+        return undefined;
+    }
+}
+
+export async function getDaemonStartedAt(): Promise<string | undefined> {
+    try {
+        const content = await fs.readFile(getGlobalFilePath(STARTED_AT_FILE), 'utf-8');
+        const startedAt = content.trim();
+        return startedAt || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+async function getCompatibleDaemonStartedAt(): Promise<string> {
+    const startedAt = await getDaemonStartedAt();
+    if (startedAt !== undefined) {
+        return startedAt;
+    }
+
+    try {
+        const stat = await fs.stat(getGlobalFilePath(PID_FILE));
+        return stat.mtime.toISOString();
+    } catch {
+        return new Date().toISOString();
+    }
+}
+
+export async function getMachineDaemonState(): Promise<MachineDaemonState | undefined> {
+    if (!(await isDaemonRunning())) {
+        return undefined;
+    }
+
+    const [pid, port, startedAt] = await Promise.all([
+        getDaemonPid(),
+        getDaemonPort(),
+        getCompatibleDaemonStartedAt(),
+    ]);
+
+    if (pid === undefined || port === undefined) {
+        return undefined;
+    }
+
+    try {
+        const token = await readTokenFile();
+        return { pid, port, token, startedAt };
     } catch {
         return undefined;
     }

--- a/src/daemon/registry.ts
+++ b/src/daemon/registry.ts
@@ -1,9 +1,12 @@
 /**
- * Global daemon and project registries.
+ * Global registry helpers.
  *
- * `~/.lanes/daemons.json` tracks live per-workspace daemon processes.
- * `~/.lanes/projects.json` tracks known workspaces that were explicitly
- * registered with the machine-wide gateway.
+ * `~/.lanes/projects.json` is the source of truth for workspaces served by the
+ * machine-wide daemon.
+ *
+ * `~/.lanes/daemons.json` remains available only as a compatibility registry
+ * for older tooling and tests; active daemon lifecycle now lives in the
+ * machine-wide `~/.lanes/daemon.*` files instead.
  */
 
 import * as path from 'path';
@@ -16,7 +19,7 @@ import * as os from 'os';
 // ---------------------------------------------------------------------------
 
 /**
- * A single entry in the global daemon registry.
+ * A single entry in the legacy daemon registry.
  */
 export type DaemonRegistryEntry = {
     /** Optional project identifier when a daemon entry is associated with a project. */

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -50,7 +50,8 @@ async function main(): Promise<void> {
     const { port } = parseArgs(process.argv.slice(2));
     const projectManager = new GlobalDaemonProjectManager();
     const authToken = generateToken();
-    await writeTokenFile(undefined, authToken);
+    const startedAt = new Date().toISOString();
+    await writeTokenFile(authToken);
 
     const routerContext = { port: 0 };
     const requestHandler = createRouter(projectManager, authToken, routerContext);
@@ -67,6 +68,7 @@ async function main(): Promise<void> {
 
     await writeGlobalFile('daemon.pid', String(process.pid));
     await writeGlobalFile('daemon.port', String(actualPort));
+    await writeGlobalFile('daemon.startedAt', startedAt);
 
     process.stderr.write(
         `[Daemon] Started. pid=${process.pid} port=${actualPort}\n`
@@ -97,6 +99,7 @@ async function main(): Promise<void> {
         projectManager.dispose();
         await removeGlobalFile('daemon.pid');
         await removeGlobalFile('daemon.port');
+        await removeGlobalFile('daemon.startedAt');
         await removeTokenFile();
 
         process.stderr.write('[Daemon] Shutdown complete.\n');

--- a/src/test/daemon/auth.test.ts
+++ b/src/test/daemon/auth.test.ts
@@ -68,8 +68,8 @@ suite('daemon auth', () => {
         const token = generateToken();
 
         // Act
-        await writeTokenFile(tempDir, token);
-        const readBack = await readTokenFile(tempDir);
+        await writeTokenFile(token);
+        const readBack = await readTokenFile();
 
         // Assert
         assert.strictEqual(readBack, token);
@@ -81,7 +81,7 @@ suite('daemon auth', () => {
         const expectedPath = path.join(tempDir, '.lanes', 'daemon.token');
 
         // Act
-        await writeTokenFile(tempDir, token);
+        await writeTokenFile(token);
 
         // Assert
         assert.ok(fs.existsSync(expectedPath), '.lanes/daemon.token should exist after writeTokenFile');
@@ -90,12 +90,12 @@ suite('daemon auth', () => {
     test('Given a written global token file, when removeTokenFile is called, then the file no longer exists', async () => {
         // Arrange
         const token = generateToken();
-        await writeTokenFile(tempDir, token);
+        await writeTokenFile(token);
         const tokenPath = path.join(tempDir, '.lanes', 'daemon.token');
         assert.ok(fs.existsSync(tokenPath), 'Precondition: token file should exist before removal');
 
         // Act
-        await removeTokenFile(tempDir);
+        await removeTokenFile();
 
         // Assert
         assert.ok(!fs.existsSync(tokenPath), 'Token file should not exist after removeTokenFile');
@@ -103,19 +103,19 @@ suite('daemon auth', () => {
 
     test('Given no token file exists, when removeTokenFile is called, then it does not throw', async () => {
         // Act & Assert: should not throw even though the file is absent
-        await removeTokenFile(tempDir);
+        await removeTokenFile();
     });
 
     test('Given a removed token file, when readTokenFile is called, then it throws', async () => {
         // Arrange: write then remove
         const token = generateToken();
-        await writeTokenFile(tempDir, token);
-        await removeTokenFile(tempDir);
+        await writeTokenFile(token);
+        await removeTokenFile();
 
         // Act & Assert
         let thrown: unknown;
         try {
-            await readTokenFile(tempDir);
+            await readTokenFile();
         } catch (err) {
             thrown = err;
         }

--- a/src/test/daemon/client.test.ts
+++ b/src/test/daemon/client.test.ts
@@ -9,17 +9,17 @@
  *  - fromWorkspace() throws when port file is absent
  *  - health() sends GET /api/v1/health without Authorization header
  *  - All other methods include Authorization: Bearer <token>
- *  - listSessions() GET /api/v1/sessions
- *  - createSession() POST /api/v1/sessions with body
- *  - deleteSession() DELETE /api/v1/sessions/:name with URI encoding
- *  - getSessionStatus() GET /api/v1/sessions/:name/status
- *  - openSession() POST /api/v1/sessions/:name/open
- *  - clearSession() POST /api/v1/sessions/:name/clear
- *  - pinSession() POST /api/v1/sessions/:name/pin
- *  - unpinSession() DELETE /api/v1/sessions/:name/pin
+ *  - listSessions() GET /api/v1/projects/:projectId/sessions
+ *  - createSession() POST /api/v1/projects/:projectId/sessions with body
+ *  - deleteSession() DELETE /api/v1/projects/:projectId/sessions/:name with URI encoding
+ *  - getSessionStatus() GET /api/v1/projects/:projectId/sessions/:name/status
+ *  - openSession() POST /api/v1/projects/:projectId/sessions/:name/open
+ *  - clearSession() POST /api/v1/projects/:projectId/sessions/:name/clear
+ *  - pinSession() POST /api/v1/projects/:projectId/sessions/:name/pin
+ *  - unpinSession() DELETE /api/v1/projects/:projectId/sessions/:name/pin
  *  - getSessionInsights() with and without includeAnalysis query param
  *  - listBranches() with includeRemote query param
- *  - repairWorktrees() POST /api/v1/git/repair
+ *  - repairWorktrees() POST /api/v1/projects/:projectId/git/repair
  *  - getSessionDiff() with query param
  *  - getSessionDiffFiles() with query param
  *  - getWorktreeInfo()
@@ -41,7 +41,7 @@
  *  - HTTP 500 → DaemonHttpError (statusCode 500)
  *  - HTTP error message extracted from JSON body { error: '...' }
  *  - HTTP error falls back to 'HTTP <statusCode>' when no error field
- *  - subscribeEvents() connects to /api/v1/events, fires onConnected
+ *  - subscribeEvents() connects to /api/v1/projects/:projectId/events, fires onConnected
  *  - subscribeEvents() parses SSE events and calls the right callback
  *  - subscribeEvents() close() destroys the connection
  */
@@ -136,9 +136,14 @@ async function startTestServer(
 // ---------------------------------------------------------------------------
 
 const TEST_TOKEN = 'test-bearer-token-xyz';
+const TEST_PROJECT_ID = 'project-test-123';
 
 function makeClient(port: number): DaemonClient {
-    return new DaemonClient({ port, token: TEST_TOKEN });
+    return new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
+}
+
+function projectPath(suffix: string): string {
+    return `/api/v1/projects/${encodeURIComponent(TEST_PROJECT_ID)}${suffix}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -377,14 +382,14 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('listSessions()', () => {
-        test('Given a mock server, when listSessions() is called, then GET /api/v1/sessions is made', async () => {
+        test('Given a mock server, when listSessions() is called, then GET /api/v1/projects/:projectId/sessions is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { sessions: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.listSessions();
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions'));
             } finally {
                 await helper.close();
             }
@@ -409,7 +414,7 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('createSession()', () => {
-        test('Given opts, when createSession() is called, then POST /api/v1/sessions is made with that body', async () => {
+        test('Given opts, when createSession() is called, then POST /api/v1/projects/:projectId/sessions is made with that body', async () => {
             const helper = await startTestServer(() => ({
                 status: 200,
                 body: { sessionName: 'test' },
@@ -420,7 +425,7 @@ suite('DaemonClient', () => {
                 await client.createSession(opts);
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), opts);
             } finally {
                 await helper.close();
@@ -446,7 +451,7 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('deleteSession()', () => {
-        test('Given session name "my session", when deleteSession() is called, then DELETE /api/v1/sessions/my%20session is requested', async () => {
+        test('Given session name "my session", when deleteSession() is called, then DELETE /api/v1/projects/:projectId/sessions/my%20session is requested', async () => {
             const helper = await startTestServer(() => ({
                 status: 200,
                 body: { success: true },
@@ -456,7 +461,7 @@ suite('DaemonClient', () => {
                 await client.deleteSession('my session');
 
                 assert.strictEqual(helper.captured[0].method, 'DELETE');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my%20session');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my%20session'));
             } finally {
                 await helper.close();
             }
@@ -481,14 +486,14 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('getSessionStatus()', () => {
-        test('Given session name, when getSessionStatus() is called, then GET /api/v1/sessions/:name/status is made', async () => {
+        test('Given session name, when getSessionStatus() is called, then GET /api/v1/projects/:projectId/sessions/:name/status is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { status: 'idle' } }));
             try {
                 const client = makeClient(helper.port());
                 await client.getSessionStatus('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/status');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/status'));
             } finally {
                 await helper.close();
             }
@@ -496,14 +501,14 @@ suite('DaemonClient', () => {
     });
 
     suite('openSession()', () => {
-        test('Given session name, when openSession() is called, then POST /api/v1/sessions/:name/open is made', async () => {
+        test('Given session name, when openSession() is called, then POST /api/v1/projects/:projectId/sessions/:name/open is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.openSession('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/open');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/open'));
             } finally {
                 await helper.close();
             }
@@ -523,14 +528,14 @@ suite('DaemonClient', () => {
     });
 
     suite('clearSession()', () => {
-        test('Given session name, when clearSession() is called, then POST /api/v1/sessions/:name/clear is made', async () => {
+        test('Given session name, when clearSession() is called, then POST /api/v1/projects/:projectId/sessions/:name/clear is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.clearSession('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/clear');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/clear'));
             } finally {
                 await helper.close();
             }
@@ -538,27 +543,27 @@ suite('DaemonClient', () => {
     });
 
     suite('pinSession() / unpinSession()', () => {
-        test('Given session name, when pinSession() is called, then POST /api/v1/sessions/:name/pin is made', async () => {
+        test('Given session name, when pinSession() is called, then POST /api/v1/projects/:projectId/sessions/:name/pin is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.pinSession('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/pin');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/pin'));
             } finally {
                 await helper.close();
             }
         });
 
-        test('Given session name, when unpinSession() is called, then DELETE /api/v1/sessions/:name/pin is made', async () => {
+        test('Given session name, when unpinSession() is called, then DELETE /api/v1/projects/:projectId/sessions/:name/pin is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.unpinSession('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'DELETE');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/pin');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/pin'));
             } finally {
                 await helper.close();
             }
@@ -630,13 +635,13 @@ suite('DaemonClient', () => {
             }
         });
 
-        test('Given no opts, when listBranches() is called, then GET /api/v1/git/branches is requested without query string', async () => {
+        test('Given no opts, when listBranches() is called, then GET /api/v1/projects/:projectId/git/branches is requested without query string', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { branches: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.listBranches();
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/git/branches');
+                assert.strictEqual(helper.captured[0].url, projectPath('/git/branches'));
             } finally {
                 await helper.close();
             }
@@ -644,14 +649,14 @@ suite('DaemonClient', () => {
     });
 
     suite('repairWorktrees()', () => {
-        test('Given a call to repairWorktrees(), then POST /api/v1/git/repair is made', async () => {
+        test('Given a call to repairWorktrees(), then POST /api/v1/projects/:projectId/git/repair is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { repaired: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.repairWorktrees();
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/git/repair');
+                assert.strictEqual(helper.captured[0].url, projectPath('/git/repair'));
             } finally {
                 await helper.close();
             }
@@ -711,14 +716,14 @@ suite('DaemonClient', () => {
     });
 
     suite('getSessionDiffFiles()', () => {
-        test('Given a session name, when getSessionDiffFiles() is called, then GET /api/v1/sessions/:name/diff/files is made', async () => {
+        test('Given a session name, when getSessionDiffFiles() is called, then GET /api/v1/projects/:projectId/sessions/:name/diff/files is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { files: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.getSessionDiffFiles('feat-session');
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.ok(helper.captured[0].url.startsWith('/api/v1/sessions/feat-session/diff/files'));
+                assert.ok(helper.captured[0].url.startsWith(projectPath('/sessions/feat-session/diff/files')));
             } finally {
                 await helper.close();
             }
@@ -763,14 +768,14 @@ suite('DaemonClient', () => {
     });
 
     suite('getWorktreeInfo()', () => {
-        test('Given a session name, when getWorktreeInfo() is called, then GET /api/v1/sessions/:name/worktree is made', async () => {
+        test('Given a session name, when getWorktreeInfo() is called, then GET /api/v1/projects/:projectId/sessions/:name/worktree is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { path: '/tmp' } }));
             try {
                 const client = makeClient(helper.port());
                 await client.getWorktreeInfo('my-session');
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/my-session/worktree');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/my-session/worktree'));
             } finally {
                 await helper.close();
             }
@@ -796,13 +801,13 @@ suite('DaemonClient', () => {
             }
         });
 
-        test('Given no opts, when listWorkflows() is called, then GET /api/v1/workflows is requested without query string', async () => {
+        test('Given no opts, when listWorkflows() is called, then GET /api/v1/projects/:projectId/workflows is requested without query string', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { workflows: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.listWorkflows();
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows');
+                assert.strictEqual(helper.captured[0].url, projectPath('/workflows'));
             } finally {
                 await helper.close();
             }
@@ -810,7 +815,7 @@ suite('DaemonClient', () => {
     });
 
     suite('validateWorkflow()', () => {
-        test('Given workflow content, when validateWorkflow() is called, then POST /api/v1/workflows/validate is made with body', async () => {
+        test('Given workflow content, when validateWorkflow() is called, then POST /api/v1/projects/:projectId/workflows/validate is made with body', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { valid: true } }));
             try {
                 const client = makeClient(helper.port());
@@ -818,7 +823,7 @@ suite('DaemonClient', () => {
                 await client.validateWorkflow(content);
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows/validate');
+                assert.strictEqual(helper.captured[0].url, projectPath('/workflows/validate'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), content);
             } finally {
                 await helper.close();
@@ -827,14 +832,14 @@ suite('DaemonClient', () => {
     });
 
     suite('createWorkflow()', () => {
-        test('Given name and content, when createWorkflow() is called, then POST /api/v1/workflows is made with { name, content }', async () => {
+        test('Given name and content, when createWorkflow() is called, then POST /api/v1/projects/:projectId/workflows is made with { name, content }', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.createWorkflow('my-wf', { steps: ['a', 'b'] });
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/workflows');
+                assert.strictEqual(helper.captured[0].url, projectPath('/workflows'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), {
                     name: 'my-wf',
                     content: { steps: ['a', 'b'] },
@@ -846,14 +851,14 @@ suite('DaemonClient', () => {
     });
 
     suite('getWorkflowState()', () => {
-        test('Given session name, when getWorkflowState() is called, then GET /api/v1/sessions/:name/workflow is made', async () => {
+        test('Given session name, when getWorkflowState() is called, then GET /api/v1/projects/:projectId/sessions/:name/workflow is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { state: null } }));
             try {
                 const client = makeClient(helper.port());
                 await client.getWorkflowState('wf-session');
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/sessions/wf-session/workflow');
+                assert.strictEqual(helper.captured[0].url, projectPath('/sessions/wf-session/workflow'));
             } finally {
                 await helper.close();
             }
@@ -865,14 +870,14 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('listAgents()', () => {
-        test('Given a call to listAgents(), then GET /api/v1/agents is made', async () => {
+        test('Given a call to listAgents(), then GET /api/v1/projects/:projectId/agents is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { agents: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.listAgents();
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/agents');
+                assert.strictEqual(helper.captured[0].url, projectPath('/agents'));
             } finally {
                 await helper.close();
             }
@@ -886,7 +891,7 @@ suite('DaemonClient', () => {
                 const client = makeClient(helper.port());
                 await client.getAgentConfig('claude code');
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/agents/claude%20code');
+                assert.strictEqual(helper.captured[0].url, projectPath('/agents/claude%20code'));
             } finally {
                 await helper.close();
             }
@@ -898,14 +903,14 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('getAllConfig()', () => {
-        test('Given a call to getAllConfig(), then GET /api/v1/config is made', async () => {
+        test('Given a call to getAllConfig(), then GET /api/v1/projects/:projectId/config is made', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { config: {} } }));
             try {
                 const client = makeClient(helper.port());
                 await client.getAllConfig();
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/config');
+                assert.strictEqual(helper.captured[0].url, projectPath('/config'));
             } finally {
                 await helper.close();
             }
@@ -917,7 +922,7 @@ suite('DaemonClient', () => {
                 const client = makeClient(helper.port());
                 await client.getAllConfig('global');
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/config?scope=global');
+                assert.strictEqual(helper.captured[0].url, `${projectPath('/config')}?scope=global`);
             } finally {
                 await helper.close();
             }
@@ -931,7 +936,7 @@ suite('DaemonClient', () => {
                 const client = makeClient(helper.port());
                 await client.getConfig('lanes.agent/name');
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/config/lanes.agent%2Fname');
+                assert.strictEqual(helper.captured[0].url, projectPath('/config/lanes.agent%2Fname'));
             } finally {
                 await helper.close();
             }
@@ -943,7 +948,7 @@ suite('DaemonClient', () => {
                 const client = makeClient(helper.port());
                 await client.getConfig('lanes.defaultAgent', 'local');
 
-                assert.strictEqual(helper.captured[0].url, '/api/v1/config/lanes.defaultAgent?scope=local');
+                assert.strictEqual(helper.captured[0].url, `${projectPath('/config/lanes.defaultAgent')}?scope=local`);
             } finally {
                 await helper.close();
             }
@@ -951,14 +956,14 @@ suite('DaemonClient', () => {
     });
 
     suite('setConfig()', () => {
-        test('Given key and value, when setConfig() is called, then PUT /api/v1/config/:key is made with { value }', async () => {
+        test('Given key and value, when setConfig() is called, then PUT /api/v1/projects/:projectId/config/:key is made with { value }', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.setConfig('agentName', 'claude');
 
                 assert.strictEqual(helper.captured[0].method, 'PUT');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/config/agentName');
+                assert.strictEqual(helper.captured[0].url, projectPath('/config/agentName'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { value: 'claude' });
             } finally {
                 await helper.close();
@@ -983,14 +988,14 @@ suite('DaemonClient', () => {
     // -------------------------------------------------------------------------
 
     suite('listTerminals()', () => {
-        test('Given no opts, when listTerminals() is called, then GET /api/v1/terminals is requested without query string', async () => {
+        test('Given no opts, when listTerminals() is called, then GET /api/v1/projects/:projectId/terminals is requested without query string', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { terminals: [] } }));
             try {
                 const client = makeClient(helper.port());
                 await client.listTerminals();
 
                 assert.strictEqual(helper.captured[0].method, 'GET');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals');
+                assert.strictEqual(helper.captured[0].url, projectPath('/terminals'));
             } finally {
                 await helper.close();
             }
@@ -1011,7 +1016,7 @@ suite('DaemonClient', () => {
     });
 
     suite('createTerminal()', () => {
-        test('Given opts, when createTerminal() is called, then POST /api/v1/terminals is made with body', async () => {
+        test('Given opts, when createTerminal() is called, then POST /api/v1/projects/:projectId/terminals is made with body', async () => {
             const helper = await startTestServer(() => ({
                 status: 200,
                 body: { terminalName: 'term-1' },
@@ -1021,7 +1026,7 @@ suite('DaemonClient', () => {
                 await client.createTerminal({ sessionName: 'feat', shell: 'bash' });
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals');
+                assert.strictEqual(helper.captured[0].url, projectPath('/terminals'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), {
                     sessionName: 'feat',
                     shell: 'bash',
@@ -1033,14 +1038,14 @@ suite('DaemonClient', () => {
     });
 
     suite('sendToTerminal()', () => {
-        test('Given name and text, when sendToTerminal() is called, then POST /api/v1/terminals/:name/send is made with { command: text }', async () => {
+        test('Given name and text, when sendToTerminal() is called, then POST /api/v1/projects/:projectId/terminals/:name/send is made with { command: text }', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { success: true } }));
             try {
                 const client = makeClient(helper.port());
                 await client.sendToTerminal('term-1', 'ls -la');
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
-                assert.strictEqual(helper.captured[0].url, '/api/v1/terminals/term-1/send');
+                assert.strictEqual(helper.captured[0].url, projectPath('/terminals/term-1/send'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), { text: 'ls -la' });
             } finally {
                 await helper.close();
@@ -1205,10 +1210,10 @@ suite('DaemonClient SSE', () => {
     // daemon-client-subscribe-events
     // -------------------------------------------------------------------------
 
-    test('Given a mock SSE server, when subscribeEvents() is called, then a GET request to /api/v1/events is made', (done) => {
+    test('Given a mock SSE server, when subscribeEvents() is called, then a GET request to /api/v1/projects/:projectId/events is made', (done) => {
         // Create a minimal SSE server that closes immediately after receiving the request
         const server = http.createServer((req, res) => {
-            if (req.url === '/api/v1/events') {
+            if (req.url === projectPath('/events')) {
                 res.writeHead(200, {
                     'Content-Type': 'text/event-stream',
                     'Cache-Control': 'no-cache',
@@ -1224,7 +1229,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             let requestReceived = false;
 
@@ -1232,7 +1237,7 @@ suite('DaemonClient SSE', () => {
             server.once('request', (req) => {
                 requestReceived = true;
                 assert.strictEqual(req.method, 'GET');
-                assert.strictEqual(req.url, '/api/v1/events');
+                assert.strictEqual(req.url, projectPath('/events'));
             });
 
             const sub = client.subscribeEvents({
@@ -1249,7 +1254,7 @@ suite('DaemonClient SSE', () => {
             setTimeout(() => {
                 sub.close();
                 server.close(() => {
-                    assert.ok(requestReceived, 'A request to /api/v1/events should have been made');
+                    assert.ok(requestReceived, `A request to ${projectPath('/events')} should have been made`);
                     done();
                 });
             }, 500);
@@ -1269,7 +1274,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             const sub = client.subscribeEvents({});
 
@@ -1299,7 +1304,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             let callbackCalled = false;
 
@@ -1342,7 +1347,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             let callbackCalled = false;
 
@@ -1382,7 +1387,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             let callbackCalled = false;
 
@@ -1422,7 +1427,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: TEST_TOKEN });
+            const client = new DaemonClient({ port, token: TEST_TOKEN, projectId: TEST_PROJECT_ID });
 
             let callbackCalled = false;
 
@@ -1462,7 +1467,7 @@ suite('DaemonClient SSE', () => {
 
         server.listen(0, '127.0.0.1', () => {
             const port = (server.address() as { port: number }).port;
-            const client = new DaemonClient({ port, token: 'sse-token-test' });
+            const client = new DaemonClient({ port, token: 'sse-token-test', projectId: TEST_PROJECT_ID });
 
             const sub = client.subscribeEvents({
                 onConnected: () => {

--- a/src/test/daemon/gateway.test.ts
+++ b/src/test/daemon/gateway.test.ts
@@ -20,7 +20,7 @@ import * as path from 'path';
 import sinon from 'sinon';
 import { createGatewayServer } from '../../daemon/gateway';
 import { registerProject } from '../../daemon/registry';
-import type { DaemonRegistryEntry } from '../../daemon/registry';
+import type { GatewayDaemonInfo } from '../../daemon/gateway';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -57,9 +57,10 @@ function request(
     });
 }
 
-/** Create a minimal valid registry entry for testing. */
-function makeEntry(overrides: Partial<DaemonRegistryEntry> = {}): DaemonRegistryEntry {
+/** Create a minimal valid machine-wide daemon projection for testing. */
+function makeEntry(overrides: Partial<GatewayDaemonInfo> = {}): GatewayDaemonInfo {
     return {
+        projectId: 'project-test-123',
         workspaceRoot: '/tmp/test-workspace',
         port: 3000,
         pid: process.pid,
@@ -70,12 +71,13 @@ function makeEntry(overrides: Partial<DaemonRegistryEntry> = {}): DaemonRegistry
     };
 }
 
-function writeGlobalDaemonFiles(homeDir: string, entry: DaemonRegistryEntry): void {
+function writeGlobalDaemonFiles(homeDir: string, entry: GatewayDaemonInfo): void {
     const lanesDir = path.join(homeDir, '.lanes');
     fs.mkdirSync(lanesDir, { recursive: true });
     fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), String(entry.pid), 'utf-8');
     fs.writeFileSync(path.join(lanesDir, 'daemon.port'), String(entry.port), 'utf-8');
     fs.writeFileSync(path.join(lanesDir, 'daemon.token'), entry.token, 'utf-8');
+    fs.writeFileSync(path.join(lanesDir, 'daemon.startedAt'), entry.startedAt, 'utf-8');
 }
 
 // ---------------------------------------------------------------------------
@@ -141,7 +143,7 @@ suite('GatewayServer', () => {
 
         // Assert
         assert.strictEqual(res.status, 200, 'Should return HTTP 200');
-        const body = JSON.parse(res.body) as DaemonRegistryEntry[];
+        const body = JSON.parse(res.body) as GatewayDaemonInfo[];
         assert.ok(Array.isArray(body), 'Response body should be an array');
         assert.ok(body.length >= 1, 'Should contain at least one live daemon entry');
         const found = body.find((d) => d.workspaceRoot === '/workspace/running');
@@ -178,7 +180,7 @@ suite('GatewayServer', () => {
 
         // Assert
         assert.strictEqual(res.status, 200, 'Should return HTTP 200');
-        const body = JSON.parse(res.body) as DaemonRegistryEntry[];
+        const body = JSON.parse(res.body) as GatewayDaemonInfo[];
         assert.ok(Array.isArray(body), 'Response body should be an array');
         assert.strictEqual(body.length, 0, 'Stale global daemon should not produce daemon entries');
     });
@@ -205,7 +207,7 @@ suite('GatewayServer', () => {
         const body = JSON.parse(res.body) as Array<{
             workspaceRoot: string;
             status: string;
-            daemon: DaemonRegistryEntry | null;
+            daemon: GatewayDaemonInfo | null;
         }>;
         const found = body.find((project) => project.workspaceRoot === '/workspace/registered-only');
         assert.ok(found, 'Registered project should appear in the response');
@@ -233,7 +235,7 @@ suite('GatewayServer', () => {
         const body = JSON.parse(res.body) as Array<{
             workspaceRoot: string;
             status: string;
-            daemon: DaemonRegistryEntry | null;
+            daemon: GatewayDaemonInfo | null;
         }>;
         const found = body.find((project) => project.workspaceRoot === workspaceRoot);
         assert.ok(found, 'Running project should appear in the response');

--- a/src/test/daemon/lifecycle.test.ts
+++ b/src/test/daemon/lifecycle.test.ts
@@ -24,6 +24,7 @@ import {
     isDaemonRunning,
     getDaemonPort,
     getDaemonPid,
+    getMachineDaemonState,
 } from '../../daemon/lifecycle';
 
 // ---------------------------------------------------------------------------
@@ -107,7 +108,7 @@ suite('daemon lifecycle', () => {
         const killStub = sinon.stub(process, 'kill');
 
         // Act
-        await stopDaemon(tempDir);
+        await stopDaemon();
 
         // Assert
         killStub.restore();
@@ -123,7 +124,7 @@ suite('daemon lifecycle', () => {
         const killStub = sinon.stub(process, 'kill');
 
         // Act
-        await stopDaemon(tempDir);
+        await stopDaemon();
 
         // Assert
         killStub.restore();
@@ -138,7 +139,7 @@ suite('daemon lifecycle', () => {
         const killStub = sinon.stub(process, 'kill');
 
         // Act
-        await stopDaemon(tempDir);
+        await stopDaemon();
 
         // Assert
         killStub.restore();
@@ -149,7 +150,7 @@ suite('daemon lifecycle', () => {
 
     test('Given no daemon files, when stopDaemon() is called, then it does not throw', async () => {
         // Act & Assert: should be a no-op when no PID file exists
-        await stopDaemon(tempDir);
+        await stopDaemon();
     });
 
     // -------------------------------------------------------------------------
@@ -157,7 +158,7 @@ suite('daemon lifecycle', () => {
     // -------------------------------------------------------------------------
 
     test('Given no .lanes/daemon.pid file, when isDaemonRunning is called, then it returns false', async () => {
-        const running = await isDaemonRunning(tempDir);
+        const running = await isDaemonRunning();
 
         assert.strictEqual(running, false);
     });
@@ -173,7 +174,7 @@ suite('daemon lifecycle', () => {
         );
 
         // Act
-        const running = await isDaemonRunning(tempDir);
+        const running = await isDaemonRunning();
 
         // Assert
         killStub.restore();
@@ -187,7 +188,7 @@ suite('daemon lifecycle', () => {
         fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), String(process.pid), 'utf-8');
 
         // Act
-        const running = await isDaemonRunning(tempDir);
+        const running = await isDaemonRunning();
 
         // Assert
         assert.strictEqual(running, true);
@@ -198,7 +199,7 @@ suite('daemon lifecycle', () => {
     // -------------------------------------------------------------------------
 
     test('Given no port file, when getDaemonPort is called, then it returns undefined', async () => {
-        const port = await getDaemonPort(tempDir);
+        const port = await getDaemonPort();
         assert.strictEqual(port, undefined);
     });
 
@@ -209,14 +210,14 @@ suite('daemon lifecycle', () => {
         fs.writeFileSync(path.join(lanesDir, 'daemon.port'), '3000', 'utf-8');
 
         // Act
-        const port = await getDaemonPort(tempDir);
+        const port = await getDaemonPort();
 
         // Assert
         assert.strictEqual(port, 3000);
     });
 
     test('Given no PID file, when getDaemonPid is called, then it returns undefined', async () => {
-        const pid = await getDaemonPid(tempDir);
+        const pid = await getDaemonPid();
         assert.strictEqual(pid, undefined);
     });
 
@@ -227,7 +228,7 @@ suite('daemon lifecycle', () => {
         fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), '12345', 'utf-8');
 
         // Act
-        const pid = await getDaemonPid(tempDir);
+        const pid = await getDaemonPid();
 
         // Assert
         assert.strictEqual(pid, 12345);
@@ -240,7 +241,7 @@ suite('daemon lifecycle', () => {
         fs.writeFileSync(path.join(lanesDir, 'daemon.port'), 'not-a-number', 'utf-8');
 
         // Act
-        const port = await getDaemonPort(tempDir);
+        const port = await getDaemonPort();
 
         // Assert
         assert.strictEqual(port, undefined);
@@ -253,9 +254,25 @@ suite('daemon lifecycle', () => {
         fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), 'not-a-number', 'utf-8');
 
         // Act
-        const pid = await getDaemonPid(tempDir);
+        const pid = await getDaemonPid();
 
         // Assert
         assert.strictEqual(pid, undefined);
+    });
+
+    test('Given a running daemon with legacy global files but no daemon.startedAt, when getMachineDaemonState is called, then it still returns daemon metadata', async () => {
+        const lanesDir = path.join(tempDir, '.lanes');
+        fs.mkdirSync(lanesDir, { recursive: true });
+        fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), String(process.pid), 'utf-8');
+        fs.writeFileSync(path.join(lanesDir, 'daemon.port'), '3000', 'utf-8');
+        fs.writeFileSync(path.join(lanesDir, 'daemon.token'), 'legacy-token', 'utf-8');
+
+        const state = await getMachineDaemonState();
+
+        assert.ok(state, 'Expected legacy daemon files to produce a machine daemon state');
+        assert.strictEqual(state?.pid, process.pid);
+        assert.strictEqual(state?.port, 3000);
+        assert.strictEqual(state?.token, 'legacy-token');
+        assert.ok(state?.startedAt, 'Compatibility state should synthesize a startedAt value');
     });
 });

--- a/src/test/vscode/services/DaemonService.test.ts
+++ b/src/test/vscode/services/DaemonService.test.ts
@@ -24,9 +24,9 @@ import type { SseCallbacks, SseSubscription } from '../../../daemon/client';
 // Helpers
 // ---------------------------------------------------------------------------
 
-/** Write fake daemon PID/port/token files to simulate a running daemon. */
-function writeFakeDaemonFiles(workspaceRoot: string, pid: number, port: number): void {
-    const lanesDir = path.join(workspaceRoot, '.lanes');
+/** Write fake machine-wide daemon PID/port/token files to simulate a running daemon. */
+function writeFakeDaemonFiles(homeDir: string, pid: number, port: number): void {
+    const lanesDir = path.join(homeDir, '.lanes');
     fs.mkdirSync(lanesDir, { recursive: true });
     fs.writeFileSync(path.join(lanesDir, 'daemon.pid'), String(pid), 'utf-8');
     fs.writeFileSync(path.join(lanesDir, 'daemon.port'), String(port), 'utf-8');
@@ -39,15 +39,23 @@ function writeFakeDaemonFiles(workspaceRoot: string, pid: number, port: number):
 
 suite('DaemonService', () => {
     let tempDir: string;
+    let originalHome: string | undefined;
     let onRefreshStub: sinon.SinonSpy;
 
     setup(() => {
         tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lanes-daemon-service-test-'));
+        originalHome = process.env.HOME;
+        process.env.HOME = tempDir;
         onRefreshStub = sinon.spy();
     });
 
     teardown(() => {
         sinon.restore();
+        if (originalHome !== undefined) {
+            process.env.HOME = originalHome;
+        } else {
+            delete process.env.HOME;
+        }
         fs.rmSync(tempDir, { recursive: true, force: true });
     });
 
@@ -105,7 +113,7 @@ suite('DaemonService', () => {
         assert.ok(startDaemonStub.calledOnce, 'startDaemon should be called when daemon is not running');
         const callArgs = startDaemonStub.firstCall.args[0] as lifecycle.StartDaemonOptions;
         assert.strictEqual(callArgs.workspaceRoot, tempDir, 'workspaceRoot should match');
-        const expectedServerPath = path.join(extensionPath, 'out', 'daemon', 'server.js');
+        const expectedServerPath = path.join(extensionPath, 'out', 'daemon.js');
         assert.strictEqual(callArgs.serverPath, expectedServerPath, 'serverPath should point to bundled server');
         assert.ok(service.getClient() !== undefined, 'getClient() should return a client after successful init');
 

--- a/src/vscode/services/DaemonService.ts
+++ b/src/vscode/services/DaemonService.ts
@@ -48,10 +48,10 @@ export class DaemonService implements vscode.Disposable {
      */
     async initialize(): Promise<void> {
         try {
-            const running = await isDaemonRunning(this.workspaceRoot);
+            const running = await isDaemonRunning();
 
             if (!running) {
-                const serverPath = path.join(this.extensionPath, 'out', 'daemon', 'server.js');
+                const serverPath = path.join(this.extensionPath, 'out', 'daemon.js');
                 await startDaemon({ workspaceRoot: this.workspaceRoot, serverPath });
 
                 // Poll until the daemon writes its port file (it may need a moment)
@@ -106,7 +106,7 @@ export class DaemonService implements vscode.Disposable {
      */
     private async waitForPortFile(): Promise<void> {
         for (let attempt = 0; attempt < PORT_POLL_ATTEMPTS; attempt++) {
-            const port = await getDaemonPort(this.workspaceRoot);
+            const port = await getDaemonPort();
             if (port !== undefined && port > 0) {
                 return;
             }

--- a/web-ui/src/api/gateway.ts
+++ b/web-ui/src/api/gateway.ts
@@ -9,9 +9,9 @@
 import type { DaemonInfo, GatewayProjectInfo } from './types';
 
 /**
- * Fetch the list of all currently running Lanes daemons from the gateway server.
- * Returns an array of DaemonInfo objects, each containing the daemon's port,
- * token, workspace root, and project name.
+ * Fetch the legacy list of running project connections from the gateway server.
+ * Each entry contains the machine-wide daemon connection details projected onto
+ * a specific registered project.
  *
  * The gateway automatically filters out stale (dead) daemon entries.
  */

--- a/web-ui/src/api/types.ts
+++ b/web-ui/src/api/types.ts
@@ -54,7 +54,7 @@ export interface SessionInfo {
 // ---------------------------------------------------------------------------
 
 export interface DaemonInfo {
-    projectId?: string;
+    projectId: string;
     workspaceRoot: string;
     port: number;
     pid: number;

--- a/web-ui/src/test/components/ProjectCard.test.tsx
+++ b/web-ui/src/test/components/ProjectCard.test.tsx
@@ -25,6 +25,7 @@ vi.mock('react-router-dom', async (importOriginal) => {
 
 function makeDaemonInfo(overrides: Partial<DaemonInfo> = {}): DaemonInfo {
     return {
+        projectId: 'project-123',
         workspaceRoot: '/projects/my-app',
         port: 3942,
         pid: 1234,
@@ -50,13 +51,14 @@ function makeDiscovery(overrides: Partial<DiscoveryInfo> = {}): DiscoveryInfo {
 }
 
 function makeProjectInfo(overrides: Partial<GatewayProjectInfo> = {}): GatewayProjectInfo {
+    const projectId = overrides.projectId ?? 'project-123';
     return {
-        projectId: 'project-123',
+        projectId,
         workspaceRoot: '/projects/my-app',
         projectName: 'my-app',
         registeredAt: new Date().toISOString(),
         status: 'running',
-        daemon: makeDaemonInfo(),
+        daemon: makeDaemonInfo({ projectId }),
         ...overrides,
     };
 }

--- a/web-ui/src/test/hooks/useDaemonConnection.test.ts
+++ b/web-ui/src/test/hooks/useDaemonConnection.test.ts
@@ -50,13 +50,14 @@ function makeDaemonInfo(overrides: Partial<DaemonInfo> = {}): DaemonInfo {
 }
 
 function makeProjectInfo(overrides: Partial<GatewayProjectInfo> = {}): GatewayProjectInfo {
+    const projectId = overrides.projectId ?? 'project-123';
     return {
-        projectId: 'project-123',
+        projectId,
         workspaceRoot: '/projects/my-app',
         projectName: 'my-app',
         registeredAt: new Date().toISOString(),
         status: 'running',
-        daemon: makeDaemonInfo(),
+        daemon: makeDaemonInfo({ projectId }),
         ...overrides,
     };
 }

--- a/web-ui/src/test/hooks/useDaemons.test.tsx
+++ b/web-ui/src/test/hooks/useDaemons.test.tsx
@@ -32,6 +32,7 @@ import { fetchProjects } from '../../api/gateway';
 
 function makeDaemonInfo(overrides: Partial<DaemonInfo> = {}): DaemonInfo {
     return {
+        projectId: 'project-123',
         workspaceRoot: '/projects/my-app',
         port: 3942,
         pid: 1234,
@@ -43,13 +44,14 @@ function makeDaemonInfo(overrides: Partial<DaemonInfo> = {}): DaemonInfo {
 }
 
 function makeProjectInfo(overrides: Partial<GatewayProjectInfo> = {}): GatewayProjectInfo {
+    const projectId = overrides.projectId ?? 'project-123';
     return {
-        projectId: 'project-123',
+        projectId,
         workspaceRoot: '/projects/my-app',
         projectName: 'my-app',
         registeredAt: new Date().toISOString(),
         status: 'running',
-        daemon: makeDaemonInfo(),
+        daemon: makeDaemonInfo({ projectId }),
         ...overrides,
     };
 }
@@ -214,6 +216,35 @@ describe('useDaemons', () => {
         });
 
         expect(result.current.daemons).toHaveLength(2);
+    });
+
+    it('Given two projects share one machine-wide daemon, when the hook loads, then both projects remain independently addressable', async () => {
+        const sharedDaemon = makeDaemonInfo({
+            projectId: 'project-123',
+            port: 3942,
+            pid: 7777,
+            token: 'shared-token',
+        });
+        mockFetchProjects.mockResolvedValue([
+            makeProjectInfo({ projectId: 'project-123', daemon: sharedDaemon }),
+            makeProjectInfo({
+                projectId: 'project-456',
+                workspaceRoot: '/projects/my-api',
+                projectName: 'my-api',
+                daemon: { ...sharedDaemon, projectId: 'project-456', workspaceRoot: '/projects/my-api', projectName: 'my-api' },
+            }),
+        ]);
+
+        const { result } = renderHook(() => useDaemons());
+
+        await waitFor(() => {
+            expect(result.current.loading).toBe(false);
+        });
+
+        expect(result.current.daemons).toHaveLength(2);
+        expect(result.current.daemons[0].daemon?.port).toBe(3942);
+        expect(result.current.daemons[1].daemon?.port).toBe(3942);
+        expect(result.current.daemons.map((entry) => entry.project.projectId)).toEqual(['project-123', 'project-456']);
     });
 
     it('Given fetchProjects throws, then error is set in state', async () => {

--- a/web-ui/src/test/pages/Dashboard.test.tsx
+++ b/web-ui/src/test/pages/Dashboard.test.tsx
@@ -30,6 +30,7 @@ vi.mock('../../hooks/useDaemons', () => ({
 
 function makeDaemonInfo(overrides: Partial<DaemonInfo> = {}): DaemonInfo {
     return {
+        projectId: 'project-123',
         workspaceRoot: '/projects/my-app',
         port: 3942,
         pid: 1234,
@@ -55,13 +56,14 @@ function makeDiscovery(overrides: Partial<DiscoveryInfo> = {}): DiscoveryInfo {
 }
 
 function makeProjectInfo(overrides: Partial<GatewayProjectInfo> = {}): GatewayProjectInfo {
+    const projectId = overrides.projectId ?? 'project-123';
     return {
-        projectId: 'project-123',
+        projectId,
         workspaceRoot: '/projects/my-app',
         projectName: 'my-app',
         registeredAt: new Date().toISOString(),
         status: 'running',
-        daemon: makeDaemonInfo(),
+        daemon: makeDaemonInfo({ projectId }),
         ...overrides,
     };
 }


### PR DESCRIPTION
## Summary

This PR finalizes the daemon model as a single machine-wide process serving registered projects by `projectId`.

It aligns the runtime and tests around that contract by:

- making daemon lifecycle and auth state explicitly machine-wide under `~/.lanes`
- adding machine daemon state discovery, including backward-compatible handling for daemons started before `daemon.startedAt` existed
- updating the gateway to project machine-wide daemon state onto registered projects
- fixing CLI and VS Code callers to use the machine-wide lifecycle and the real bundled daemon entrypoint
- updating daemon and web-ui tests to assert project-scoped REST/SSE routes and shared-daemon behavior

## Key Changes

- `src/daemon/lifecycle.ts`
  - adds machine daemon state helpers
  - persists and reads `daemon.startedAt`
  - keeps pre-existing daemons discoverable even when `daemon.startedAt` is missing
- `src/daemon/server.ts`
  - writes machine-wide `daemon.startedAt` on startup
- `src/daemon/gateway.ts`
  - treats the machine-wide daemon as the single runtime source of truth for registered projects
- `src/cli/commands/daemon.ts`
  - makes `status` and `stop` truly machine-wide
  - allows `start` to run outside a repo while still auto-registering when a repo is available
- `src/vscode/services/DaemonService.ts`
  - starts `out/daemon.js`
  - uses machine-wide daemon state checks
- tests
  - refreshes daemon lifecycle, client, gateway, and VS Code assumptions
  - adds a regression test for legacy daemons without `daemon.startedAt`

## Verification

- `npx tsc -p ./ --noEmit`
- `npx tsc -p ./ && npx mocha "out/test/daemon/lifecycle.test.js" --ui tdd --reporter dot`
- `npx mocha "out/test/daemon/auth.test.js" --ui tdd --reporter dot`
- `npx mocha "out/test/daemon/lifecycle.test.js" "out/test/vscode/services/DaemonService.test.js" --ui tdd --reporter dot`
- `npx mocha "out/test/daemon/client.test.js" --ui tdd --reporter dot --grep "fromWorkspace\\(\\)"`

## Notes

- Full gateway/client socket-based daemon tests could not be run in this sandbox because binding to `127.0.0.1` returns `EPERM`.
- `web-ui` Vitest was not runnable in this worktree because `web-ui/node_modules` is not installed.
