### PR TITLE
fix: restore codex status updates in vscode

### DIFF
--- a/src/core/services/SessionHandlerService.ts
+++ b/src/core/services/SessionHandlerService.ts
@@ -50,7 +50,7 @@ import { discoverWorkflows } from '../workflow/discovery';
 import { validateWorkflow } from './WorkflowService';
 import { assemblePrompt, writePromptFile } from './PromptService';
 import { getAgent, getAvailableAgents } from '../codeAgents';
-import { readJson } from './FileService';
+import { readJson, writeJson } from './FileService';
 import { buildAgentLaunchCommand, prepareAgentLaunchContext } from './AgentLaunchSetupService';
 import * as PreflightService from './PreflightService';
 import { IHandlerContext } from '../interfaces/IHandlerContext';
@@ -205,7 +205,8 @@ export class SessionHandlerService {
         sessionName: string,
         worktreePath: string,
         agentCommand: string,
-        preferredTerminalMode?: string | null
+        preferredTerminalMode?: string | null,
+        codeAgent?: ReturnType<typeof getAgent>
     ): Promise<{
         terminalMode: 'vscode' | 'tmux';
         command: string;
@@ -222,6 +223,7 @@ export class SessionHandlerService {
                 throw new Error('tmux is not installed. Install tmux or switch lanes.terminalMode to vscode.');
             }
 
+            const beforeLaunchTimestamp = codeAgent && !codeAgent.supportsHooks() ? new Date() : undefined;
             const tmuxResult = await TmuxService.launchInTmux({
                 sessionName,
                 worktreePath,
@@ -229,6 +231,9 @@ export class SessionHandlerService {
             });
             await saveSessionTerminalMode(worktreePath, 'tmux');
             await saveSessionTmuxName(worktreePath, tmuxResult.tmuxSessionName);
+            if (codeAgent && !codeAgent.supportsHooks() && beforeLaunchTimestamp) {
+                this.captureHooklessTmuxSession(worktreePath, codeAgent, beforeLaunchTimestamp);
+            }
             return {
                 terminalMode: 'tmux',
                 command: tmuxResult.attachCommand,
@@ -242,6 +247,37 @@ export class SessionHandlerService {
             terminalMode: 'vscode',
             command: agentCommand,
         };
+    }
+
+    private captureHooklessTmuxSession(
+        worktreePath: string,
+        codeAgent: NonNullable<ReturnType<typeof getAgent>>,
+        beforeTimestamp: Date
+    ): void {
+        void (async () => {
+            try {
+                const result = await codeAgent.captureSessionId(beforeTimestamp);
+                if (!result) {
+                    return;
+                }
+
+                const sessionFilePath = getSessionFilePath(worktreePath);
+                let existingData: Record<string, unknown> = {};
+                const parsed = await readJson<Record<string, unknown>>(sessionFilePath);
+                if (parsed) {
+                    existingData = parsed;
+                }
+
+                await writeJson(sessionFilePath, {
+                    ...existingData,
+                    sessionId: result.sessionId,
+                    logPath: result.logPath,
+                    timestamp: new Date().toISOString(),
+                });
+            } catch (err) {
+                console.warn('Lanes: Failed to capture tmux session metadata for hookless agent:', err);
+            }
+        })();
     }
 
     private buildCreateSessionPrompt(
@@ -628,7 +664,9 @@ export class SessionHandlerService {
             const terminalLaunch = await this.prepareTerminalLaunch(
                 name,
                 worktreePath,
-                launch.command
+                launch.command,
+                undefined,
+                launchContext.codeAgent
             );
 
             this.ctx.notificationEmitter.sessionCreated(name, worktreePath);
@@ -801,7 +839,8 @@ export class SessionHandlerService {
             sessionName,
             worktreePath,
             launch.command,
-            savedTerminalMode
+            savedTerminalMode,
+            launchContext.codeAgent
         );
 
         return {

--- a/src/core/session/SessionDataService.ts
+++ b/src/core/session/SessionDataService.ts
@@ -390,10 +390,24 @@ export async function getAgentStatus(worktreePath: string): Promise<AgentSession
         const exists = await fileExists(statusPath);
         if (!exists) { return null; }
         const content = await readFile(statusPath);
-        if (globalCodeAgent) {
-            const agentStatus = globalCodeAgent.parseStatus(content);
+        let statusAgent = globalCodeAgent;
+        try {
+            const sessionPath = await resolveSessionFilePath(worktreePath);
+            const sessionData = await readJson<Record<string, unknown>>(sessionPath);
+            if (typeof sessionData?.agentName === 'string' && sessionData.agentName.trim() !== '') {
+                const resolvedAgent = getAgent(sessionData.agentName);
+                if (resolvedAgent) {
+                    statusAgent = resolvedAgent;
+                }
+            }
+        } catch {
+            // Fall back to the global/default agent when session metadata is unavailable.
+        }
+
+        if (statusAgent) {
+            const agentStatus = statusAgent.parseStatus(content);
             if (!agentStatus) { return null; }
-            const validStates = globalCodeAgent.getValidStatusStates();
+            const validStates = statusAgent.getValidStatusStates();
             if (!validStates.includes(agentStatus.status)) { return null; }
             return { status: agentStatus.status as AgentStatusState, timestamp: agentStatus.timestamp, message: agentStatus.message };
         }

--- a/src/daemon/manager.ts
+++ b/src/daemon/manager.ts
@@ -1,6 +1,7 @@
 import { SessionHandlerService } from '../core/services/SessionHandlerService';
-import { getWorktreesFolder } from '../core/session/SessionDataService';
+import { getWorktreesFolder, initializeGlobalStorageContext } from '../core/session/SessionDataService';
 import type { IHandlerContext } from '../core/interfaces/IHandlerContext';
+import { getAgent } from '../core/codeAgents';
 import { DaemonConfigStore } from './config';
 import { DaemonNotificationEmitter } from './notifications';
 import { DaemonFileWatchManager } from './fileWatcher';
@@ -43,6 +44,8 @@ export class GlobalDaemonProjectManager {
         const project = await this.getProject(projectId);
         const configStore = new DaemonConfigStore(project.workspaceRoot);
         await configStore.initialize();
+        const defaultAgentName = (configStore.get('lanes.defaultAgent') as string | undefined) ?? 'claude';
+        initializeGlobalStorageContext('', project.workspaceRoot, getAgent(defaultAgentName) ?? getAgent('claude') ?? undefined);
 
         const notificationEmitter = new DaemonNotificationEmitter();
         const fileWatchManager = new DaemonFileWatchManager(notificationEmitter);

--- a/src/test/core/services/SessionHandlerService.test.ts
+++ b/src/test/core/services/SessionHandlerService.test.ts
@@ -23,6 +23,7 @@ import {
 import {
     getSessionChimeEnabled,
     getWorktreesFolder,
+    initializeGlobalStorageContext,
 } from '../../../core/session/SessionDataService';
 import type {
     IHandlerContext,
@@ -211,6 +212,7 @@ suite('SessionHandlerService', () => {
         const service = new SessionHandlerService(ctx);
         const worktreePath = path.join(tempDir, '.worktrees', 'codex-lane');
         const sessionFilePath = path.join(tempDir, '.lanes', 'current-sessions', 'codex-lane', '.claude-session');
+        initializeGlobalStorageContext('', tempDir);
         fs.mkdirSync(path.dirname(sessionFilePath), { recursive: true });
         fs.writeFileSync(sessionFilePath, JSON.stringify({ agentName: 'codex', sessionId: 'placeholder' }));
 
@@ -239,9 +241,15 @@ suite('SessionHandlerService', () => {
 
         assert.strictEqual(result.terminalMode, 'tmux');
 
-        await new Promise((resolve) => setTimeout(resolve, 0));
+        let savedSession = JSON.parse(fs.readFileSync(sessionFilePath, 'utf-8'));
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+            if (savedSession.sessionId === '12345678-abcd-1234-ef00-123456789abc') {
+                break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            savedSession = JSON.parse(fs.readFileSync(sessionFilePath, 'utf-8'));
+        }
 
-        const savedSession = JSON.parse(fs.readFileSync(sessionFilePath, 'utf-8'));
         assert.strictEqual(savedSession.sessionId, '12345678-abcd-1234-ef00-123456789abc');
         assert.strictEqual(savedSession.logPath, '/tmp/codex-session.jsonl');
         assert.ok(fakeAgent.captureSessionId.calledOnce, 'captureSessionId should be called for hookless tmux launches');

--- a/src/test/core/services/SessionHandlerService.test.ts
+++ b/src/test/core/services/SessionHandlerService.test.ts
@@ -14,6 +14,7 @@ import * as assert from 'assert';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import sinon from 'sinon';
 import {
     SessionHandlerService,
     JsonRpcHandlerError,
@@ -31,6 +32,7 @@ import type {
 } from '../../../core/interfaces/IHandlerContext';
 import { getAvailableAgents } from '../../../core/codeAgents';
 import type { SettingsScope, SettingsView } from '../../../core/services/UnifiedSettingsService';
+import * as TmuxService from '../../../core/services/TmuxService';
 
 // ---------------------------------------------------------------------------
 // Minimal stub implementations
@@ -134,6 +136,7 @@ suite('SessionHandlerService', () => {
     });
 
     teardown(() => {
+        sinon.restore();
         fs.rmSync(tempDir, { recursive: true, force: true });
     });
 
@@ -201,6 +204,47 @@ suite('SessionHandlerService', () => {
             31,
             'Expected exactly 31 handler methods'
         );
+    });
+
+    test('prepareTerminalLaunch captures hookless session metadata for tmux launches', async () => {
+        const ctx = makeContext(tempDir, { 'lanes.terminalMode': 'tmux' });
+        const service = new SessionHandlerService(ctx);
+        const worktreePath = path.join(tempDir, '.worktrees', 'codex-lane');
+        const sessionFilePath = path.join(tempDir, '.lanes', 'current-sessions', 'codex-lane', '.claude-session');
+        fs.mkdirSync(path.dirname(sessionFilePath), { recursive: true });
+        fs.writeFileSync(sessionFilePath, JSON.stringify({ agentName: 'codex', sessionId: 'placeholder' }));
+
+        sinon.stub(TmuxService, 'isTmuxInstalled').resolves(true);
+        sinon.stub(TmuxService, 'launchInTmux').resolves({
+            tmuxSessionName: 'codex-lane',
+            attachCommand: 'tmux attach-session -t codex-lane',
+            wasExisting: false,
+        });
+
+        const fakeAgent = {
+            supportsHooks: () => false,
+            captureSessionId: sinon.stub().resolves({
+                sessionId: '12345678-abcd-1234-ef00-123456789abc',
+                logPath: '/tmp/codex-session.jsonl',
+            }),
+        };
+
+        const result = await (service as any).prepareTerminalLaunch(
+            'codex-lane',
+            worktreePath,
+            'codex',
+            'tmux',
+            fakeAgent
+        );
+
+        assert.strictEqual(result.terminalMode, 'tmux');
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const savedSession = JSON.parse(fs.readFileSync(sessionFilePath, 'utf-8'));
+        assert.strictEqual(savedSession.sessionId, '12345678-abcd-1234-ef00-123456789abc');
+        assert.strictEqual(savedSession.logPath, '/tmp/codex-session.jsonl');
+        assert.ok(fakeAgent.captureSessionId.calledOnce, 'captureSessionId should be called for hookless tmux launches');
     });
 });
 

--- a/src/test/session/session-status.test.ts
+++ b/src/test/session/session-status.test.ts
@@ -134,17 +134,10 @@ suite('Session Status', () => {
 			createSessionFile(tempDir, { agentName: 'codex', sessionId: 'placeholder-session' });
 			createStatusFile(tempDir, { status: 'codex-special' });
 
-			const fakeCodexAgent = {
-				parseStatus: (content: string) => JSON.parse(content),
-				getValidStatusStates: () => ['codex-special'],
-			};
-
-			sinon.stub(codeAgents, 'getAgent').callsFake((agentName: string) => {
-				if (agentName === 'codex') {
-					return fakeCodexAgent as any;
-				}
-				return null;
-			});
+			const codexAgent = codeAgents.getAgent('codex');
+			assert.ok(codexAgent, 'Codex agent should exist');
+			sinon.stub(codexAgent!, 'parseStatus').callsFake((content: string) => JSON.parse(content));
+			sinon.stub(codexAgent!, 'getValidStatusStates').returns(['codex-special']);
 
 			const result = await getAgentStatus(tempDir);
 

--- a/src/test/session/session-status.test.ts
+++ b/src/test/session/session-status.test.ts
@@ -3,10 +3,11 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import sinon from 'sinon';
+import * as codeAgents from '../../core/codeAgents';
 import { getAgentStatus, initializeGlobalStorageContext } from '../../vscode/providers/AgentSessionProvider';
 
 suite('Session Status', () => {
-
 	let tempDir: string;
 	let globalStorageDir: string;
 
@@ -17,6 +18,7 @@ suite('Session Status', () => {
 	});
 
 	teardown(() => {
+		sinon.restore();
 		fs.rmSync(tempDir, { recursive: true, force: true });
 		fs.rmSync(globalStorageDir, { recursive: true, force: true });
 	});
@@ -27,6 +29,13 @@ suite('Session Status', () => {
 		const statusDir = path.join(tempDir, '.lanes', 'current-sessions', sessionName);
 		fs.mkdirSync(statusDir, { recursive: true });
 		fs.writeFileSync(path.join(statusDir, '.claude-status'), JSON.stringify(statusData));
+	}
+
+	function createSessionFile(worktreePath: string, sessionData: Record<string, unknown>): void {
+		const sessionName = path.basename(worktreePath);
+		const sessionDir = path.join(tempDir, '.lanes', 'current-sessions', sessionName);
+		fs.mkdirSync(sessionDir, { recursive: true });
+		fs.writeFileSync(path.join(sessionDir, '.claude-session'), JSON.stringify(sessionData));
 	}
 
 	suite('getAgentStatus', () => {
@@ -113,6 +122,34 @@ suite('Session Status', () => {
 			assert.strictEqual(result.status, 'waiting_for_user');
 			assert.strictEqual(result.timestamp, '2025-12-21T10:30:00Z');
 			assert.strictEqual(result.message, 'Waiting for user confirmation');
+		});
+
+		test('should prefer the session agent parser over the global agent when agentName is stored', async () => {
+			initializeGlobalStorageContext(
+				vscode.Uri.file(globalStorageDir),
+				tempDir,
+				codeAgents.getAgent('claude') ?? undefined
+			);
+
+			createSessionFile(tempDir, { agentName: 'codex', sessionId: 'placeholder-session' });
+			createStatusFile(tempDir, { status: 'codex-special' });
+
+			const fakeCodexAgent = {
+				parseStatus: (content: string) => JSON.parse(content),
+				getValidStatusStates: () => ['codex-special'],
+			};
+
+			sinon.stub(codeAgents, 'getAgent').callsFake((agentName: string) => {
+				if (agentName === 'codex') {
+					return fakeCodexAgent as any;
+				}
+				return null;
+			});
+
+			const result = await getAgentStatus(tempDir);
+
+			assert.ok(result, 'Result should not be null');
+			assert.strictEqual(result?.status, 'codex-special');
 		});
 	});
 });

--- a/src/vscode/services/TerminalService.ts
+++ b/src/vscode/services/TerminalService.ts
@@ -12,7 +12,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { fileExists, ensureDir, writeJson, readJson } from '../../core/services/FileService';
-import { SessionItem, getStatusFilePath, getSessionFilePath } from '../providers/AgentSessionProvider';
+import { SessionItem, getStatusFilePath, getSessionFilePath, getSessionId } from '../providers/AgentSessionProvider';
 import { PermissionMode, isValidPermissionMode } from '../providers/SessionFormProvider';
 import { CodeAgent, McpConfig } from '../../core/codeAgents';
 import * as TmuxService from '../../core/services/TmuxService';
@@ -35,6 +35,8 @@ export interface DaemonSessionLaunchResult {
     terminalMode?: string;
     attachCommand?: string;
     tmuxSessionName?: string;
+    sessionId?: string;
+    success?: true;
 }
 
 // Track hookless agent terminals for lifecycle-based status updates
@@ -101,6 +103,56 @@ export async function trackHooklessTerminal(terminal: vscode.Terminal, worktreeP
     }
 }
 
+async function restoreHooklessPolling(
+    terminal: vscode.Terminal,
+    worktreePath: string,
+    codeAgent: CodeAgent,
+    options?: {
+        beforeStartTimestamp?: Date;
+        waitForPersistedLogPath?: boolean;
+    }
+): Promise<void> {
+    await trackHooklessTerminal(terminal, worktreePath);
+
+    const sessionData = await getSessionId(worktreePath, codeAgent);
+    if (sessionData?.logPath) {
+        startPolling(terminal, sessionData.logPath, worktreePath);
+        return;
+    }
+
+    if (options?.beforeStartTimestamp) {
+        void captureHooklessSessionId(codeAgent, worktreePath, options.beforeStartTimestamp, terminal);
+        return;
+    }
+
+    if (options?.waitForPersistedLogPath) {
+        void waitForHooklessLogPath(worktreePath, codeAgent, terminal);
+    }
+}
+
+async function waitForHooklessLogPath(
+    worktreePath: string,
+    codeAgent: CodeAgent,
+    terminal: vscode.Terminal,
+    timeoutMs: number = 15000,
+    pollIntervalMs: number = 500
+): Promise<void> {
+    const startedAt = Date.now();
+
+    while (Date.now() - startedAt < timeoutMs) {
+        try {
+            const sessionData = await getSessionId(worktreePath, codeAgent);
+            if (sessionData?.logPath) {
+                startPolling(terminal, sessionData.logPath, worktreePath);
+                return;
+            }
+        } catch {
+            // Best effort retry while session metadata settles.
+        }
+
+        await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+}
 
 /**
  * Count existing terminals for a session to determine the next terminal number.
@@ -229,6 +281,12 @@ export async function openDaemonSessionTerminal(
             color: iconConfig.color ? new vscode.ThemeColor(iconConfig.color) : new vscode.ThemeColor('terminal.ansiGreen')
         });
         terminal.show();
+
+        if (codeAgent && !codeAgent.supportsHooks()) {
+            await restoreHooklessPolling(terminal, worktreePath, codeAgent, {
+                waitForPersistedLogPath: true,
+            });
+        }
         return;
     }
 
@@ -244,7 +302,13 @@ export async function openDaemonSessionTerminal(
     terminal.show();
 
     if (codeAgent && !codeAgent.supportsHooks()) {
-        await trackHooklessTerminal(terminal, worktreePath);
+        const shouldCaptureAfterStart = Boolean(launchResult.sessionId) && launchResult.success !== true;
+        const beforeStartTimestamp = shouldCaptureAfterStart ? new Date() : undefined;
+
+        await restoreHooklessPolling(terminal, worktreePath, codeAgent, {
+            beforeStartTimestamp,
+            waitForPersistedLogPath: !shouldCaptureAfterStart,
+        });
     }
 
     if (launchResult.command) {
@@ -300,6 +364,12 @@ async function openClaudeTerminalTmux(
             color: iconConfig.color ? new vscode.ThemeColor(iconConfig.color) : new vscode.ThemeColor('terminal.ansiGreen')
         });
         terminal.show();
+
+        if (codeAgent && !codeAgent.supportsHooks()) {
+            await restoreHooklessPolling(terminal, worktreePath, codeAgent, {
+                waitForPersistedLogPath: true,
+            });
+        }
         return;
     }
 
@@ -332,11 +402,16 @@ async function openClaudeTerminalTmux(
         });
 
         let shouldStartFresh = true;
+        let hooklessBeforeStartTimestamp: Date | undefined;
 
         if (launch.sessionData?.sessionId) {
             // Try to resume existing session
             if (codeAgent) {
                 try {
+                    if (!codeAgent.supportsHooks()) {
+                        hooklessBeforeStartTimestamp = new Date();
+                    }
+
                     // Use CodeAgent to build resume command
                     const resumeCommand = codeAgent.buildResumeCommand(launch.sessionData.sessionId, {
                         settingsPath: launch.settingsPath,
@@ -359,6 +434,10 @@ async function openClaudeTerminalTmux(
         }
 
         if (shouldStartFresh) {
+            if (codeAgent && !codeAgent.supportsHooks()) {
+                hooklessBeforeStartTimestamp = new Date();
+            }
+
             // Validate permissionMode to prevent command injection from untrusted webview input
             const validatedMode = isValidPermissionMode(launch.effectivePermissionMode) ? launch.effectivePermissionMode : 'acceptEdits';
 
@@ -427,6 +506,13 @@ async function openClaudeTerminalTmux(
         });
 
         terminal.show();
+
+        if (codeAgent && !codeAgent.supportsHooks()) {
+            await restoreHooklessPolling(terminal, worktreePath, codeAgent, {
+                beforeStartTimestamp: hooklessBeforeStartTimestamp,
+                waitForPersistedLogPath: !hooklessBeforeStartTimestamp,
+            });
+        }
     } catch (err) {
         // Clean up orphaned tmux session on failure
         await TmuxService.killSession(tmuxSessionName).catch(() => {});
@@ -523,7 +609,7 @@ export async function openAgentTerminal(
 
     // B2. Track hookless agent terminals for lifecycle-based status updates
     if (codeAgent && !codeAgent.supportsHooks()) {
-        await trackHooklessTerminal(terminal, worktreePath);
+        await restoreHooklessPolling(terminal, worktreePath, codeAgent);
     }
 
     const launch = await prepareAgentLaunchContext({
@@ -564,8 +650,12 @@ export async function openAgentTerminal(
                 shouldStartFresh = false;
 
                 // For hookless agents resuming, start polling if we have a saved logPath
-                if (!codeAgent.supportsHooks() && launch.sessionData.logPath) {
-                    startPolling(terminal, launch.sessionData.logPath, worktreePath);
+                if (!codeAgent.supportsHooks()) {
+                    if (launch.sessionData.logPath) {
+                        startPolling(terminal, launch.sessionData.logPath, worktreePath);
+                    } else {
+                        void waitForHooklessLogPath(worktreePath, codeAgent, terminal);
+                    }
                 }
             } catch (err) {
                 // Invalid session ID format - log and start fresh session


### PR DESCRIPTION
## Summary
- restore hookless Codex status tracking for VS Code tmux and daemon launch paths
- parse status files using the session agent instead of only the global default agent
- initialize daemon session storage so hookless tmux metadata is persisted correctly

## Testing
- npm run compile
- npm run test:hook