### PR TITLE
refactor(cli): route workflow commands through daemon api

### DIFF
--- a/src/cli/commands/workflow.ts
+++ b/src/cli/commands/workflow.ts
@@ -3,12 +3,9 @@
  */
 
 import { Command } from 'commander';
-import * as path from 'path';
 import * as fsPromises from 'fs/promises';
-import { initCli, exitWithError, getPackageRoot } from '../utils';
+import { initCli, exitWithError } from '../utils';
 import { withCliOperations } from '../operations';
-import { discoverWorkflows, loadWorkflowTemplateFromString, WorkflowValidationError } from '../../core/workflow';
-import { BLANK_WORKFLOW_TEMPLATE } from '../../core/services/WorkflowService';
 import { getErrorMessage } from '../../core/utils';
 
 export function registerWorkflowCommand(program: Command): void {
@@ -59,44 +56,13 @@ export function registerWorkflowCommand(program: Command): void {
         .action(async (options) => {
             try {
                 const { config, repoRoot } = await initCli();
-                const customWorkflowsFolder = config.get('lanes', 'customWorkflowsFolder', '.lanes/workflows');
-
-                // Validate name
-                if (!/^[a-zA-Z0-9_-]+$/.test(options.name)) {
-                    exitWithError('Workflow name must contain only letters, numbers, hyphens, and underscores.');
-                }
-
-                const customPath = path.join(repoRoot, customWorkflowsFolder);
-                await fsPromises.mkdir(customPath, { recursive: true });
-
-                const targetPath = path.join(customPath, `${options.name}.yaml`);
-
-                // Check if already exists
-                try {
-                    await fsPromises.access(targetPath);
-                    exitWithError(`Workflow '${options.name}' already exists at ${targetPath}`);
-                } catch { /* doesn't exist — good */ }
-
-                let content: string;
-                if (options.from) {
-                    // Copy from existing template
-                    const templates = await discoverWorkflows({
-                        extensionPath: getPackageRoot(),
-                        workspaceRoot: repoRoot,
-                        customWorkflowsFolder,
+                await withCliOperations(repoRoot, config, options, async (operations) => {
+                    const result = await operations.createWorkflow({
+                        name: options.name,
+                        from: options.from,
                     });
-                    const source = templates.find(t => t.name === options.from);
-                    if (!source) {
-                        exitWithError(`Template '${options.from}' not found. Run 'lanes workflow list' to see available templates.`);
-                    }
-                    const sourceContent = await fsPromises.readFile(source.path, 'utf-8');
-                    content = sourceContent.replace(/^name:\s*.+$/m, `name: ${options.name}`);
-                } else {
-                    content = BLANK_WORKFLOW_TEMPLATE.replace('name: my-workflow', `name: ${options.name}`);
-                }
-
-                await fsPromises.writeFile(targetPath, content, 'utf-8');
-                console.log(`Created workflow template: ${targetPath}`);
+                    console.log(`Created workflow template: ${result.path}`);
+                });
             } catch (err) {
                 if ((err as NodeJS.ErrnoException).code === 'ERR_PROCESS_EXIT') {throw err;}
                 exitWithError(getErrorMessage(err));
@@ -106,17 +72,26 @@ export function registerWorkflowCommand(program: Command): void {
     workflow
         .command('validate <file>')
         .description('Validate a workflow YAML file')
-        .action(async (file: string) => {
+        .action(async (file: string, options) => {
             try {
+                const { config, repoRoot } = await initCli();
                 const content = await fsPromises.readFile(file, 'utf-8');
-                const template = loadWorkflowTemplateFromString(content);
-                console.log(`Workflow "${template.name}" is valid.`);
-            } catch (error) {
-                if (error instanceof WorkflowValidationError) {
-                    exitWithError(`Validation failed: ${error.message}`);
-                } else {
-                    exitWithError(`Invalid YAML: ${error instanceof Error ? error.message : String(error)}`);
-                }
+                await withCliOperations(repoRoot, config, options, async (operations) => {
+                    const result = await operations.validateWorkflow({ content });
+                    if (!result.isValid) {
+                        exitWithError(`Validation failed: ${result.errors.join('; ')}`);
+                    }
+
+                    if (result.workflowName) {
+                        console.log(`Workflow "${result.workflowName}" is valid.`);
+                        return;
+                    }
+
+                    console.log(`Workflow file "${file}" is valid.`);
+                });
+            } catch (err) {
+                if ((err as NodeJS.ErrnoException).code === 'ERR_PROCESS_EXIT') {throw err;}
+                exitWithError(getErrorMessage(err));
             }
         });
 }

--- a/src/cli/operations.ts
+++ b/src/cli/operations.ts
@@ -45,6 +45,16 @@ export interface CliWorkflowSummary {
     isBuiltin: boolean;
 }
 
+export interface CliWorkflowCreateResult {
+    path: string;
+}
+
+export interface CliWorkflowValidateResult {
+    isValid: boolean;
+    errors: string[];
+    workflowName?: string;
+}
+
 export interface CliRepairResult {
     broken: Array<{ sessionName: string; reason: string }>;
     repaired: string[];
@@ -73,6 +83,8 @@ export interface CliOperations {
     getSessionInsights(sessionName: string, input?: { includeJson?: boolean }): Promise<CliInsightsResult>;
     repairWorktrees(input?: { dryRun?: boolean }): Promise<CliRepairResult>;
     listWorkflows(): Promise<CliWorkflowSummary[]>;
+    createWorkflow(input: { name: string; from?: string }): Promise<CliWorkflowCreateResult>;
+    validateWorkflow(input: { content: string }): Promise<CliWorkflowValidateResult>;
     listConfig(view: SettingsView): Promise<Record<string, unknown>>;
     getConfig(key: string, view: SettingsView): Promise<unknown>;
     setConfig(key: string, value: unknown, scope: SettingsScope): Promise<void>;
@@ -191,6 +203,25 @@ function createDaemonCliOperations(target: CliDaemonTarget): CliOperations {
                 description: workflow.description,
                 isBuiltin: workflow.isBuiltin,
             }));
+        },
+        async createWorkflow(input) {
+            const response = await target.client.createWorkflow({
+                name: input.name,
+                from: input.from,
+            });
+            return {
+                path: response.path,
+            };
+        },
+        async validateWorkflow(input) {
+            const response = await target.client.validateWorkflow({
+                content: input.content,
+            });
+            return {
+                isValid: response.isValid,
+                errors: response.errors,
+                workflowName: response.workflowName,
+            };
         },
         async listConfig(view) {
             const response = await target.client.getAllConfig(view);

--- a/src/cli/targeting.ts
+++ b/src/cli/targeting.ts
@@ -36,6 +36,8 @@ const DAEMON_TARGET_COMMAND_PATHS = [
     ['repair'],
     ['config'],
     ['workflow', 'list'],
+    ['workflow', 'create'],
+    ['workflow', 'validate'],
 ] as const;
 
 function sanitizeGitRemoteUrl(remote: string): string {

--- a/src/core/services/SessionHandlerService.ts
+++ b/src/core/services/SessionHandlerService.ts
@@ -47,7 +47,8 @@ import { TmuxTerminalIOProvider } from './TmuxTerminalIOProvider';
 import * as DiffService from './DiffService';
 import * as BrokenWorktreeService from './BrokenWorktreeService';
 import { discoverWorkflows } from '../workflow/discovery';
-import { validateWorkflow } from './WorkflowService';
+import { loadWorkflowTemplateFromString, WorkflowValidationError } from '../workflow';
+import { BLANK_WORKFLOW_TEMPLATE, validateWorkflow } from './WorkflowService';
 import { assemblePrompt, writePromptFile } from './PromptService';
 import { getAgent, getAvailableAgents } from '../codeAgents';
 import { readJson, writeJson } from './FileService';
@@ -1154,10 +1155,30 @@ export class SessionHandlerService {
     }
 
     async handleWorkflowValidate(params: Record<string, unknown>): Promise<unknown> {
-        const workflowPath = params.workflowPath as string;
+        const workflowPath = params.workflowPath as string | undefined;
+        const content = params.content as string | undefined;
+
+        if (content !== undefined) {
+            try {
+                const template = loadWorkflowTemplateFromString(content);
+                return {
+                    isValid: true,
+                    errors: [],
+                    workflowName: template.name,
+                };
+            } catch (error) {
+                const message = error instanceof WorkflowValidationError
+                    ? error.message
+                    : `Invalid YAML: ${error instanceof Error ? error.message : String(error)}`;
+                return {
+                    isValid: false,
+                    errors: [message],
+                };
+            }
+        }
 
         if (!workflowPath) {
-            throw new Error('Missing required parameter: workflowPath');
+            throw new Error('Missing required parameter: workflowPath or content');
         }
 
         if (path.isAbsolute(workflowPath)) {
@@ -1187,10 +1208,11 @@ export class SessionHandlerService {
 
     async handleWorkflowCreate(params: Record<string, unknown>): Promise<unknown> {
         const name = params.name as string;
-        const content = params.content as string;
+        const sourceWorkflowName = params.from as string | undefined;
+        let content = params.content as string | undefined;
 
-        if (!name || !content) {
-            throw new Error('Missing required parameters: name and content');
+        if (!name) {
+            throw new Error('Missing required parameter: name');
         }
         validateWorkflowName(name);
 
@@ -1199,7 +1221,37 @@ export class SessionHandlerService {
         const workflowsDir = path.join(this.ctx.workspaceRoot, customWorkflowsFolder);
         const workflowPath = path.join(workflowsDir, `${name}.yaml`);
 
+        if (!content && sourceWorkflowName) {
+            const extensionPath = await this.resolveExtensionPath();
+            const templates = await discoverWorkflows({
+                extensionPath,
+                workspaceRoot: this.ctx.workspaceRoot,
+                customWorkflowsFolder,
+            });
+            const source = templates.find((template) => template.name === sourceWorkflowName);
+            if (!source) {
+                throw new Error(
+                    `Template '${sourceWorkflowName}' not found. Run 'lanes workflow list' to see available templates.`
+                );
+            }
+            const sourceContent = await fs.readFile(source.path, 'utf-8');
+            content = sourceContent.replace(/^name:\s*.+$/m, `name: ${name}`);
+        }
+
+        if (!content) {
+            content = BLANK_WORKFLOW_TEMPLATE.replace('name: my-workflow', `name: ${name}`);
+        }
+
         await fs.mkdir(workflowsDir, { recursive: true });
+        try {
+            await fs.access(workflowPath);
+            throw new Error(`Workflow '${name}' already exists at ${workflowPath}`);
+        } catch (error) {
+            const maybeNodeError = error as NodeJS.ErrnoException;
+            if (maybeNodeError.code !== 'ENOENT') {
+                throw error;
+            }
+        }
         await fs.writeFile(workflowPath, content, 'utf-8');
 
         return { path: workflowPath };

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -467,18 +467,18 @@ export class DaemonClient {
     }
 
     /** POST /api/v1/workflows/validate */
-    validateWorkflow(content: Record<string, unknown>): Promise<DaemonWorkflowValidateResponse> {
+    validateWorkflow(input: { workflowPath?: string; content?: string }): Promise<DaemonWorkflowValidateResponse> {
         return this.request<DaemonWorkflowValidateResponse>(
             'POST',
             this.projectUrl('/workflows/validate'),
-            { body: content }
+            { body: input }
         );
     }
 
     /** POST /api/v1/workflows */
-    createWorkflow(name: string, content: Record<string, unknown>): Promise<DaemonWorkflowCreateResponse> {
+    createWorkflow(input: { name: string; content?: string; from?: string }): Promise<DaemonWorkflowCreateResponse> {
         return this.request<DaemonWorkflowCreateResponse>('POST', this.projectUrl('/workflows'), {
-            body: { name, content },
+            body: input,
         });
     }
 

--- a/src/daemon/contracts.ts
+++ b/src/daemon/contracts.ts
@@ -153,6 +153,7 @@ export interface DaemonWorkflowListResponse {
 export interface DaemonWorkflowValidateResponse {
     isValid: boolean;
     errors: string[];
+    workflowName?: string;
 }
 
 export interface DaemonWorkflowCreateResponse {

--- a/src/test/cli/cli-daemon-host-options.test.ts
+++ b/src/test/cli/cli-daemon-host-options.test.ts
@@ -138,4 +138,24 @@ suite('CLI daemon host options', () => {
         assert.ok(command);
         assertCommandHasHostOption(command, 'workflow list');
     });
+
+    test('workflow create exposes --host', () => {
+        const program = makeTargetedProgram();
+
+        const workflow = program.commands.find((entry) => entry.name() === 'workflow');
+        assert.ok(workflow);
+        const command = workflow.commands.find((entry) => entry.name() === 'create');
+        assert.ok(command);
+        assertCommandHasHostOption(command, 'workflow create');
+    });
+
+    test('workflow validate exposes --host', () => {
+        const program = makeTargetedProgram();
+
+        const workflow = program.commands.find((entry) => entry.name() === 'workflow');
+        assert.ok(workflow);
+        const command = workflow.commands.find((entry) => entry.name() === 'validate');
+        assert.ok(command);
+        assertCommandHasHostOption(command, 'workflow validate');
+    });
 });

--- a/src/test/cli/cli-operations.test.ts
+++ b/src/test/cli/cli-operations.test.ts
@@ -62,6 +62,64 @@ suite('CLI operations', () => {
         sinon.assert.calledOnce(client.listWorkflows);
     });
 
+    test('workflow create is served through the shared daemon operations facade', async () => {
+        const client = {
+            createWorkflow: sinon.stub().resolves({
+                path: '/repo/.lanes/workflows/ship-it.yaml',
+            }),
+        };
+
+        sinon.stub(targeting, 'resolveCliDaemonTarget').resolves({
+            kind: 'local',
+            client: client as unknown as targeting.CliLocalDaemonTarget['client'],
+        });
+
+        const result = await withCliOperations('/repo', {}, {}, async (operations) => {
+            return operations.createWorkflow({
+                name: 'ship-it',
+                from: 'starter',
+            });
+        });
+
+        assert.deepStrictEqual(result, {
+            path: '/repo/.lanes/workflows/ship-it.yaml',
+        });
+        sinon.assert.calledOnceWithExactly(client.createWorkflow, {
+            name: 'ship-it',
+            from: 'starter',
+        });
+    });
+
+    test('workflow validate is served through the shared daemon operations facade', async () => {
+        const client = {
+            validateWorkflow: sinon.stub().resolves({
+                isValid: true,
+                errors: [],
+                workflowName: 'ship-it',
+            }),
+        };
+
+        sinon.stub(targeting, 'resolveCliDaemonTarget').resolves({
+            kind: 'local',
+            client: client as unknown as targeting.CliLocalDaemonTarget['client'],
+        });
+
+        const result = await withCliOperations('/repo', {}, {}, async (operations) => {
+            return operations.validateWorkflow({
+                content: 'name: ship-it\nsteps: []\n',
+            });
+        });
+
+        assert.deepStrictEqual(result, {
+            isValid: true,
+            errors: [],
+            workflowName: 'ship-it',
+        });
+        sinon.assert.calledOnceWithExactly(client.validateWorkflow, {
+            content: 'name: ship-it\nsteps: []\n',
+        });
+    });
+
     test('createSession returns a daemon launch request for the local daemon target', async () => {
         const codeAgent = codeAgents.getAgent('claude');
         assert.ok(codeAgent);

--- a/src/test/daemon/client.test.ts
+++ b/src/test/daemon/client.test.ts
@@ -909,12 +909,12 @@ suite('DaemonClient', () => {
             const helper = await startTestServer(() => ({ status: 200, body: { isValid: true, errors: [] } }));
             try {
                 const client = makeClient(helper.port());
-                const content = { name: 'my-workflow', steps: [] };
-                await client.validateWorkflow(content);
+                const body = { content: 'name: my-workflow\nsteps: []\n' };
+                await client.validateWorkflow(body);
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
                 assert.strictEqual(helper.captured[0].url, projectPath('/workflows/validate'));
-                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), content);
+                assert.deepStrictEqual(JSON.parse(helper.captured[0].body), body);
             } finally {
                 await helper.close();
             }
@@ -922,17 +922,17 @@ suite('DaemonClient', () => {
     });
 
     suite('createWorkflow()', () => {
-        test('Given name and content, when createWorkflow() is called, then POST /api/v1/projects/:projectId/workflows is made with { name, content }', async () => {
+        test('Given name and source template, when createWorkflow() is called, then POST /api/v1/projects/:projectId/workflows is made with { name, from }', async () => {
             const helper = await startTestServer(() => ({ status: 200, body: { path: '/tmp/my-wf.yaml' } }));
             try {
                 const client = makeClient(helper.port());
-                await client.createWorkflow('my-wf', { steps: ['a', 'b'] });
+                await client.createWorkflow({ name: 'my-wf', from: 'starter' });
 
                 assert.strictEqual(helper.captured[0].method, 'POST');
                 assert.strictEqual(helper.captured[0].url, projectPath('/workflows'));
                 assert.deepStrictEqual(JSON.parse(helper.captured[0].body), {
                     name: 'my-wf',
-                    content: { steps: ['a', 'b'] },
+                    from: 'starter',
                 });
             } finally {
                 await helper.close();


### PR DESCRIPTION
## Summary
- route CLI workflow create and validate through the daemon-backed CLI operations facade
- move workflow template creation and YAML validation behavior into daemon handlers and client contracts
- add host-targeting coverage and daemon/client tests for the new workflow API path

## Testing
- npm run compile
- npm run lint -- --quiet
- npx mocha --ui tdd out/test/cli/cli-operations.test.js out/test/cli/cli-daemon-host-options.test.js out/test/daemon/client.test.js