### PR TITLE
feat(cli): add verbose daemon tracing

### DIFF
--- a/src/cli/commands/daemon.ts
+++ b/src/cli/commands/daemon.ts
@@ -71,7 +71,8 @@ export function registerDaemonCommand(program: Command): void {
         .argument('[workspace]', 'Workspace to register (default: current directory)', '.')
         .option('--host <url>', 'Register a remote daemon by base URL instead of a local workspace')
         .option('--token <token>', 'Bearer token for the remote daemon when using --host')
-        .action(async (workspaceArg: string, options: { host?: string; token?: string }) => {
+        .option('--verbose', 'Show verbose daemon API tracing output')
+        .action(async (workspaceArg: string, options: { host?: string; token?: string; verbose?: boolean }) => {
             try {
                 if (isRemoteRegistration(options)) {
                     if (!options.token) {
@@ -80,6 +81,7 @@ export function registerDaemonCommand(program: Command): void {
                     const client = new DaemonClient({
                         baseUrl: options.host!,
                         token: options.token,
+                        verbose: options.verbose,
                     });
                     const { projects } = await client.listProjects();
                     await registerRemoteDaemon({

--- a/src/cli/targeting.ts
+++ b/src/cli/targeting.ts
@@ -9,6 +9,8 @@ import { execGit } from '../core/gitService';
 
 export interface CliDaemonTargetOptions {
     host?: string;
+    verbose?: boolean;
+    trace?: (message: string) => void;
 }
 
 export interface CliLocalDaemonTarget {
@@ -40,6 +42,20 @@ const DAEMON_TARGET_COMMAND_PATHS = [
     ['workflow', 'validate'],
 ] as const;
 
+function createVerboseTraceWriter(options: CliDaemonTargetOptions) {
+    if (options.trace) {
+        return options.trace;
+    }
+
+    if (!options.verbose) {
+        return undefined;
+    }
+
+    return (message: string) => {
+        console.error(`[lanes verbose] ${message}`);
+    };
+}
+
 function sanitizeGitRemoteUrl(remote: string): string {
     const trimmed = remote.trim();
     try {
@@ -50,7 +66,11 @@ function sanitizeGitRemoteUrl(remote: string): string {
             return parsed.toString();
         }
     } catch {
-        // SCP-like git remotes (git@github.com:org/repo.git) are already token-free.
+        const scpLikeMatch = trimmed.match(/^([^@]+)@([^:]+):(.+)$/);
+        if (scpLikeMatch) {
+            const [, , host, remotePath] = scpLikeMatch;
+            return `${host}:${remotePath}`;
+        }
     }
     return trimmed;
 }
@@ -58,16 +78,20 @@ function sanitizeGitRemoteUrl(remote: string): string {
 function normalizeGitRemoteForMatching(remote: string): string {
     const sanitized = sanitizeGitRemoteUrl(remote);
 
+    const scpLikeMatch = !sanitized.includes('://')
+        ? sanitized.match(/^(?:[^@]+@)?([^:]+):(.+)$/)
+        : null;
+    if (scpLikeMatch) {
+        const [, host, remotePath] = scpLikeMatch;
+        return `${host.toLowerCase()}/${remotePath.replace(/^\/+/, '').replace(/\.git$/i, '')}`;
+    }
+
     try {
         const parsed = new URL(sanitized);
         const normalizedPath = parsed.pathname.replace(/^\/+/, '').replace(/\.git$/i, '');
         return `${parsed.hostname.toLowerCase()}/${normalizedPath}`;
     } catch {
-        const scpLikeMatch = sanitized.match(/^(?:[^@]+@)?([^:]+):(.+)$/);
-        if (scpLikeMatch) {
-            const [, host, remotePath] = scpLikeMatch;
-            return `${host.toLowerCase()}/${remotePath.replace(/^\/+/, '').replace(/\.git$/i, '')}`;
-        }
+        // Fall through to the sanitized string for unknown remote formats.
     }
 
     return sanitized;
@@ -99,25 +123,35 @@ async function getRegisteredRemoteDaemon(host: string): Promise<RegisteredRemote
 
 async function resolveRemoteProjectId(
     registration: RegisteredRemoteDaemonEntry,
-    workspaceRoot: string
+    workspaceRoot: string,
+    options: CliDaemonTargetOptions = {}
 ): Promise<string> {
+    const trace = createVerboseTraceWriter(options);
+    trace?.(`Resolving remote daemon project on ${registration.baseUrl} for workspace ${workspaceRoot}`);
     const localGitRemote = await getOriginRemoteUrl(workspaceRoot);
     const normalizedLocalGitRemote = normalizeGitRemoteForMatching(localGitRemote);
+    trace?.(`Local git remote for matching: ${localGitRemote}`);
     const rootClient = new DaemonClient({
         baseUrl: registration.baseUrl,
         token: registration.token,
+        verbose: options.verbose,
+        trace,
     });
     const { projects } = await rootClient.listProjects();
+    trace?.(`Inspecting ${projects.length} project(s) exposed by ${registration.baseUrl}`);
 
     const matches: Array<{ projectId: string; projectName: string }> = [];
     const discoveryFailures: Error[] = [];
     await Promise.all(
         projects.map(async (project) => {
             try {
+                trace?.(`Checking remote project ${project.projectName} (${project.projectId})`);
                 const projectClient = new DaemonClient({
                     baseUrl: registration.baseUrl,
                     token: registration.token,
                     projectId: project.projectId,
+                    verbose: options.verbose,
+                    trace,
                 });
                 const discovery = await projectClient.discovery();
                 if (discovery.gitRemote) {
@@ -127,9 +161,15 @@ async function resolveRemoteProjectId(
                             projectId: project.projectId,
                             projectName: project.projectName,
                         });
+                        trace?.(`Matched remote project ${project.projectName} (${project.projectId})`);
                     }
                 }
             } catch (err) {
+                trace?.(
+                    `Remote project discovery failed for ${project.projectName} (${project.projectId}): ${
+                        err instanceof Error ? err.message : String(err)
+                    }`
+                );
                 discoveryFailures.push(err instanceof Error ? err : new Error(String(err)));
             }
         })
@@ -180,6 +220,14 @@ export function applyCliDaemonTargeting(program: Command): void {
                 'Target a registered remote daemon by base URL instead of the local daemon'
             );
         }
+
+        const hasVerboseOption = command.options.some((option) => option.long === '--verbose');
+        if (!hasVerboseOption) {
+            command.option(
+                '--verbose',
+                'Show verbose daemon API tracing output'
+            );
+        }
     }
 }
 
@@ -187,16 +235,24 @@ export async function createCliDaemonClient(
     workspaceRoot: string,
     options: CliDaemonTargetOptions = {}
 ): Promise<DaemonClient> {
+    const trace = createVerboseTraceWriter(options);
     if (!options.host) {
-        return DaemonClient.fromWorkspace(workspaceRoot);
+        trace?.(`Using local daemon target for ${workspaceRoot}`);
+        if (!options.verbose && !options.trace) {
+            return DaemonClient.fromWorkspace(workspaceRoot);
+        }
+        return DaemonClient.fromWorkspace(workspaceRoot, { verbose: options.verbose, trace });
     }
 
+    trace?.(`Using remote daemon target ${options.host}`);
     const registration = await getRegisteredRemoteDaemon(options.host);
-    const projectId = await resolveRemoteProjectId(registration, workspaceRoot);
+    const projectId = await resolveRemoteProjectId(registration, workspaceRoot, options);
     return new DaemonClient({
         baseUrl: registration.baseUrl,
         token: registration.token,
         projectId,
+        verbose: options.verbose,
+        trace,
     });
 }
 

--- a/src/daemon/client.ts
+++ b/src/daemon/client.ts
@@ -101,12 +101,53 @@ interface RequestOpts {
     query?: Record<string, string | boolean | undefined>;
 }
 
-async function ensureProjectRegistered(workspaceRoot: string) {
+type TraceWriter = (message: string) => void;
+
+function createTraceWriter(
+    options: Pick<DaemonClientOptions, 'verbose' | 'trace'>
+): TraceWriter | undefined {
+    if (options.trace) {
+        return options.trace;
+    }
+    if (!options.verbose) {
+        return undefined;
+    }
+    return (message: string) => {
+        console.error(`[lanes verbose] ${message}`);
+    };
+}
+
+function formatTraceValue(value: unknown): string {
+    if (value === undefined) {
+        return 'undefined';
+    }
+    if (typeof value === 'string') {
+        return value;
+    }
+
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+}
+
+function redactHeaders(headers: Record<string, string>): Record<string, string> {
+    const sanitized: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+        sanitized[key] = key.toLowerCase() === 'authorization' ? 'Bearer [redacted]' : value;
+    }
+    return sanitized;
+}
+
+async function ensureProjectRegistered(workspaceRoot: string, trace?: TraceWriter) {
     const existing = await getRegisteredProjectByWorkspace(workspaceRoot);
     if (existing) {
+        trace?.(`Using existing local daemon registration ${existing.projectId} for ${workspaceRoot}`);
         return existing;
     }
 
+    trace?.(`Registering workspace ${workspaceRoot} with the local daemon registry`);
     await registerProject({
         projectId: '',
         workspaceRoot,
@@ -118,6 +159,7 @@ async function ensureProjectRegistered(workspaceRoot: string) {
     if (!registered) {
         throw new Error(`Failed to register project for workspace ${workspaceRoot}`);
     }
+    trace?.(`Created local daemon registration ${registered.projectId} for ${workspaceRoot}`);
     return registered;
 }
 
@@ -131,6 +173,8 @@ export interface DaemonClientOptions {
     token: string;
     projectId?: string;
     timeoutMs?: number;
+    verbose?: boolean;
+    trace?: TraceWriter;
 }
 
 export class DaemonClient {
@@ -138,6 +182,7 @@ export class DaemonClient {
     private readonly token: string;
     private readonly projectPath: string;
     private readonly timeoutMs: number;
+    private readonly trace?: TraceWriter;
 
     constructor(options: DaemonClientOptions) {
         if (options.baseUrl !== undefined) {
@@ -152,14 +197,20 @@ export class DaemonClient {
         this.projectPath = options.projectId
             ? `/api/v1/projects/${encodeURIComponent(options.projectId)}`
             : '';
+        this.trace = createTraceWriter(options);
     }
 
     /**
      * Create a DaemonClient by reading the machine-wide daemon port and token.
      * Reads `~/.lanes/daemon.port` and `~/.lanes/daemon.token`.
      */
-    static async fromWorkspace(workspaceRoot: string): Promise<DaemonClient> {
-        const resolved = await ensureProjectRegistered(workspaceRoot);
+    static async fromWorkspace(
+        workspaceRoot: string,
+        options: Pick<DaemonClientOptions, 'verbose' | 'trace'> = {}
+    ): Promise<DaemonClient> {
+        const trace = createTraceWriter(options);
+        trace?.(`Resolving local daemon client for workspace ${workspaceRoot}`);
+        const resolved = await ensureProjectRegistered(workspaceRoot, trace);
         const port = await getDaemonPort();
         if (port === undefined) {
             throw new Error(
@@ -167,11 +218,16 @@ export class DaemonClient {
             );
         }
         const token = await readTokenFile();
-        return new DaemonClient({ port, token, projectId: resolved.projectId });
+        trace?.(`Resolved local daemon port ${port} for project ${resolved.projectId}`);
+        return new DaemonClient({ port, token, projectId: resolved.projectId, ...options });
     }
 
     private projectUrl(path: string): string {
         return this.projectPath ? `${this.projectPath}${path}` : `/api/v1${path}`;
+    }
+
+    private emitTrace(message: string): void {
+        this.trace?.(message);
     }
 
     // -------------------------------------------------------------------------
@@ -208,6 +264,12 @@ export class DaemonClient {
             headers['Content-Length'] = String(Buffer.byteLength(bodyStr));
         }
 
+        this.emitTrace(`request ${method} ${url.toString()}`);
+        this.emitTrace(`request headers ${formatTraceValue(redactHeaders(headers))}`);
+        if (body !== undefined) {
+            this.emitTrace(`request body ${formatTraceValue(body)}`);
+        }
+
         const reqOptions: http.RequestOptions = {
             hostname: url.hostname,
             port: url.port,
@@ -225,13 +287,18 @@ export class DaemonClient {
                     const raw = Buffer.concat(chunks).toString('utf-8').trim();
 
                     let parsed: unknown;
+                    let tracedBody: unknown;
                     try {
                         parsed = raw ? JSON.parse(raw) : {};
+                        tracedBody = parsed;
                     } catch {
                         parsed = {};
+                        tracedBody = raw || {};
                     }
 
                     const statusCode = res.statusCode ?? 0;
+                    this.emitTrace(`response ${statusCode} ${method} ${url.toString()}`);
+                    this.emitTrace(`response body ${formatTraceValue(tracedBody)}`);
 
                     if (statusCode >= 200 && statusCode < 300) {
                         resolve(parsed as T);
@@ -259,11 +326,18 @@ export class DaemonClient {
                     }
                     reject(new DaemonHttpError(statusCode, `Server error: ${errorMessage}`));
                 });
-                res.on('error', reject);
+                res.on('error', (err) => {
+                    this.emitTrace(`response stream error ${method} ${url.toString()} ${err.message}`);
+                    reject(err);
+                });
             });
 
-            req.on('error', reject);
+            req.on('error', (err) => {
+                this.emitTrace(`request error ${method} ${url.toString()} ${err.message}`);
+                reject(err);
+            });
             req.on('timeout', () => {
+                this.emitTrace(`request timeout ${method} ${url.toString()} after ${this.timeoutMs}ms`);
                 req.destroy(new Error('Request timed out after 30s'));
             });
 

--- a/src/test/cli/cli-daemon-host-options.test.ts
+++ b/src/test/cli/cli-daemon-host-options.test.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { registerClearCommand } from '../../cli/commands/clear';
 import { registerConfigCommand } from '../../cli/commands/config';
 import { registerCreateCommand } from '../../cli/commands/create';
+import { registerDaemonCommand } from '../../cli/commands/daemon';
 import { registerDeleteCommand } from '../../cli/commands/delete';
 import { registerDiffCommand } from '../../cli/commands/diff';
 import { registerInsightsCommand } from '../../cli/commands/insights';
@@ -31,6 +32,14 @@ function assertCommandHasHostOption(command: Command, label: string): void {
     );
 }
 
+function assertCommandHasVerboseOption(command: Command, label: string): void {
+    const optionNames = command.options.map((option) => option.long);
+    assert.ok(
+        optionNames.includes('--verbose'),
+        `Expected ${label} to expose --verbose, found: ${optionNames.join(', ')}`
+    );
+}
+
 function makeTargetedProgram(): Command {
     const program = makeProgram();
     registerCreateCommand(program);
@@ -55,6 +64,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'create');
         assert.ok(command);
         assertCommandHasHostOption(command, 'create');
+        assertCommandHasVerboseOption(command, 'create');
     });
 
     test('list command exposes --host', () => {
@@ -63,6 +73,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'list');
         assert.ok(command);
         assertCommandHasHostOption(command, 'list');
+        assertCommandHasVerboseOption(command, 'list');
     });
 
     test('status command exposes --host', () => {
@@ -71,6 +82,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'status');
         assert.ok(command);
         assertCommandHasHostOption(command, 'status');
+        assertCommandHasVerboseOption(command, 'status');
     });
 
     test('delete command exposes --host', () => {
@@ -79,6 +91,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'delete');
         assert.ok(command);
         assertCommandHasHostOption(command, 'delete');
+        assertCommandHasVerboseOption(command, 'delete');
     });
 
     test('open command exposes --host', () => {
@@ -87,6 +100,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'open');
         assert.ok(command);
         assertCommandHasHostOption(command, 'open');
+        assertCommandHasVerboseOption(command, 'open');
     });
 
     test('clear command exposes --host', () => {
@@ -95,6 +109,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'clear');
         assert.ok(command);
         assertCommandHasHostOption(command, 'clear');
+        assertCommandHasVerboseOption(command, 'clear');
     });
 
     test('diff command exposes --host', () => {
@@ -103,6 +118,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'diff');
         assert.ok(command);
         assertCommandHasHostOption(command, 'diff');
+        assertCommandHasVerboseOption(command, 'diff');
     });
 
     test('insights command exposes --host', () => {
@@ -111,6 +127,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'insights');
         assert.ok(command);
         assertCommandHasHostOption(command, 'insights');
+        assertCommandHasVerboseOption(command, 'insights');
     });
 
     test('config command exposes --host', () => {
@@ -119,6 +136,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'config');
         assert.ok(command);
         assertCommandHasHostOption(command, 'config');
+        assertCommandHasVerboseOption(command, 'config');
     });
 
     test('repair command exposes --host', () => {
@@ -127,6 +145,7 @@ suite('CLI daemon host options', () => {
         const command = program.commands.find((entry) => entry.name() === 'repair');
         assert.ok(command);
         assertCommandHasHostOption(command, 'repair');
+        assertCommandHasVerboseOption(command, 'repair');
     });
 
     test('workflow list exposes --host', () => {
@@ -137,6 +156,7 @@ suite('CLI daemon host options', () => {
         const command = workflow.commands.find((entry) => entry.name() === 'list');
         assert.ok(command);
         assertCommandHasHostOption(command, 'workflow list');
+        assertCommandHasVerboseOption(command, 'workflow list');
     });
 
     test('workflow create exposes --host', () => {
@@ -147,6 +167,7 @@ suite('CLI daemon host options', () => {
         const command = workflow.commands.find((entry) => entry.name() === 'create');
         assert.ok(command);
         assertCommandHasHostOption(command, 'workflow create');
+        assertCommandHasVerboseOption(command, 'workflow create');
     });
 
     test('workflow validate exposes --host', () => {
@@ -157,5 +178,17 @@ suite('CLI daemon host options', () => {
         const command = workflow.commands.find((entry) => entry.name() === 'validate');
         assert.ok(command);
         assertCommandHasHostOption(command, 'workflow validate');
+        assertCommandHasVerboseOption(command, 'workflow validate');
+    });
+
+    test('daemon register exposes --verbose for remote API tracing', () => {
+        const program = makeProgram();
+        registerDaemonCommand(program);
+
+        const daemon = program.commands.find((entry) => entry.name() === 'daemon');
+        assert.ok(daemon);
+        const command = daemon.commands.find((entry) => entry.name() === 'register');
+        assert.ok(command);
+        assertCommandHasVerboseOption(command, 'daemon register');
     });
 });

--- a/src/test/cli/cli-utils.test.ts
+++ b/src/test/cli/cli-utils.test.ts
@@ -207,6 +207,25 @@ suite('CLI utils', () => {
             sinon.assert.notCalled(listRegisteredRemoteDaemonsStub);
         });
 
+        test('passes verbose tracing into the local daemon client when enabled', async () => {
+            const localClient = {} as daemonClientModule.DaemonClient;
+            const traceMessages: string[] = [];
+            fromWorkspaceStub.resolves(localClient);
+
+            const result = await createCliDaemonClient('/repo', {
+                verbose: true,
+                trace: (message) => traceMessages.push(message),
+            });
+
+            assert.strictEqual(result, localClient);
+            sinon.assert.calledOnce(fromWorkspaceStub);
+            const traceOptions = fromWorkspaceStub.firstCall.args[1];
+            assert.strictEqual(traceOptions.verbose, true);
+            assert.strictEqual(typeof traceOptions.trace, 'function');
+            traceOptions.trace('local trace message');
+            assert.deepStrictEqual(traceMessages, ['Using local daemon target for /repo', 'local trace message']);
+        });
+
         test('resolves the matching remote daemon project when --host is provided', async () => {
             const registration = {
                 registrationId: 'remote-1',
@@ -391,6 +410,105 @@ suite('CLI utils', () => {
             sinon.assert.calledOnce(listRegisteredRemoteDaemonsStub);
             sinon.assert.calledOnce(listProjectsStub);
             sinon.assert.calledOnce(discoveryStub);
+        });
+
+        test('emits verbose internal comments while resolving a remote target', async () => {
+            const registration = {
+                registrationId: 'remote-1',
+                baseUrl: 'https://remote.example.test',
+                token: 'secret',
+                registeredAt: '2026-03-16T00:00:00.000Z',
+            };
+            const traceMessages: string[] = [];
+            listRegisteredRemoteDaemonsStub.resolves([registration]);
+            execGitStub.resolves('git@github.com:org/repo.git\n');
+            listProjectsStub.resolves({
+                projects: [
+                    {
+                        projectId: 'project-123',
+                        workspaceRoot: '/srv/repo',
+                        projectName: 'repo',
+                        registeredAt: '2026-03-16T00:00:00.000Z',
+                    },
+                ],
+            });
+            discoveryStub.resolves({
+                projectId: 'project-123',
+                projectName: 'repo',
+                gitRemote: 'git@github.com:org/repo.git',
+                sessionCount: 0,
+                uptime: 0,
+                workspaceRoot: '/srv/repo',
+                port: 9100,
+                apiVersion: '1',
+            });
+
+            const result = await withCliDaemonTarget(
+                '/repo',
+                {
+                    host: 'https://remote.example.test/',
+                    verbose: true,
+                    trace: (message) => traceMessages.push(message),
+                },
+                {
+                    local: async () => 'local',
+                    daemon: async () => 'remote',
+                }
+            );
+
+            assert.strictEqual(result, 'remote');
+            assert.ok(
+                traceMessages.some((message) => message.includes('Resolving remote daemon project'))
+            );
+        });
+
+        test('redacts scp-style credentials from verbose remote resolution traces', async () => {
+            const registration = {
+                registrationId: 'remote-1',
+                baseUrl: 'https://remote.example.test',
+                token: 'secret',
+                registeredAt: '2026-03-16T00:00:00.000Z',
+            };
+            const traceMessages: string[] = [];
+            listRegisteredRemoteDaemonsStub.resolves([registration]);
+            execGitStub.resolves('token@github.com:org/repo.git\n');
+            listProjectsStub.resolves({
+                projects: [
+                    {
+                        projectId: 'project-123',
+                        workspaceRoot: '/srv/repo',
+                        projectName: 'repo',
+                        registeredAt: '2026-03-16T00:00:00.000Z',
+                    },
+                ],
+            });
+            discoveryStub.resolves({
+                projectId: 'project-123',
+                projectName: 'repo',
+                gitRemote: 'git@github.com:org/repo.git',
+                sessionCount: 0,
+                uptime: 0,
+                workspaceRoot: '/srv/repo',
+                port: 9100,
+                apiVersion: '1',
+            });
+
+            const result = await withCliDaemonTarget(
+                '/repo',
+                {
+                    host: 'https://remote.example.test/',
+                    verbose: true,
+                    trace: (message) => traceMessages.push(message),
+                },
+                {
+                    local: async () => 'local',
+                    daemon: async () => 'remote',
+                }
+            );
+
+            assert.strictEqual(result, 'remote');
+            assert.ok(traceMessages.some((message) => message.includes('github.com:org/repo.git')));
+            assert.ok(traceMessages.every((message) => !message.includes('token@github.com')));
         });
     });
 });

--- a/src/test/daemon/client.test.ts
+++ b/src/test/daemon/client.test.ts
@@ -436,6 +436,55 @@ suite('DaemonClient', () => {
         });
     });
 
+    suite('verbose tracing', () => {
+        test('Given verbose tracing is enabled, when a request succeeds, then request and response details are emitted without leaking the token', async () => {
+            const helper = await startTestServer(() => ({ status: 200, body: { sessions: [] } }));
+            const traceMessages: string[] = [];
+            try {
+                const client = new DaemonClient({
+                    port: helper.port(),
+                    token: TEST_TOKEN,
+                    projectId: TEST_PROJECT_ID,
+                    verbose: true,
+                    trace: (message) => traceMessages.push(message),
+                });
+
+                await client.listSessions();
+
+                assert.ok(traceMessages.some((message) => message.includes('request GET')));
+                assert.ok(traceMessages.some((message) => message.includes('response 200 GET')));
+                assert.ok(traceMessages.some((message) => message.includes('Bearer [redacted]')));
+                assert.ok(traceMessages.every((message) => !message.includes(TEST_TOKEN)));
+            } finally {
+                await helper.close();
+            }
+        });
+
+        test('Given verbose tracing is enabled, when a request fails, then the error response is emitted', async () => {
+            const helper = await startTestServer(() => ({
+                status: 404,
+                body: { error: 'missing session' },
+            }));
+            const traceMessages: string[] = [];
+            try {
+                const client = new DaemonClient({
+                    port: helper.port(),
+                    token: TEST_TOKEN,
+                    projectId: TEST_PROJECT_ID,
+                    verbose: true,
+                    trace: (message) => traceMessages.push(message),
+                });
+
+                await assert.rejects(() => client.getSessionStatus('missing'), DaemonHttpError);
+
+                assert.ok(traceMessages.some((message) => message.includes('response 404 GET')));
+                assert.ok(traceMessages.some((message) => message.includes('missing session')));
+            } finally {
+                await helper.close();
+            }
+        });
+    });
+
     // -------------------------------------------------------------------------
     // daemon-client-list-sessions
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a shared `--verbose` flag for daemon-backed CLI flows, including remote daemon registration
- trace daemon API requests and responses in verbose mode with internal CLI resolution comments
- redact authorization headers and sanitize SCP-style remote user segments while preserving remote matching

## Testing
- npm test